### PR TITLE
Fix registry strategy tests that were incorrectly testing that resources were not namespace-scoped

### DIFF
--- a/pkg/registry/clusteroperator/cluster/strategy_test.go
+++ b/pkg/registry/clusteroperator/cluster/strategy_test.go
@@ -39,11 +39,8 @@ func clusterWithNewSpec() *clusteroperator.Cluster {
 // TestClusterStrategyTrivial is the testing of the trivial hardcoded
 // boolean flags.
 func TestClusterStrategyTrivial(t *testing.T) {
-	if clusterRESTStrategies.NamespaceScoped() {
-		t.Errorf("cluster create must not be namespace scoped")
-	}
-	if clusterRESTStrategies.NamespaceScoped() {
-		t.Errorf("cluster update must not be namespace scoped")
+	if !clusterRESTStrategies.NamespaceScoped() {
+		t.Errorf("cluster create must be namespace scoped")
 	}
 	if clusterRESTStrategies.AllowCreateOnUpdate() {
 		t.Errorf("cluster should not allow create on update")

--- a/pkg/registry/clusteroperator/node/strategy_test.go
+++ b/pkg/registry/clusteroperator/node/strategy_test.go
@@ -39,11 +39,8 @@ func nodeWithNewSpec() *clusteroperator.Node {
 // TestNodeStrategyTrivial is the testing of the trivial hardcoded
 // boolean flags.
 func TestNodeStrategyTrivial(t *testing.T) {
-	if nodeRESTStrategies.NamespaceScoped() {
-		t.Errorf("node create must not be namespace scoped")
-	}
-	if nodeRESTStrategies.NamespaceScoped() {
-		t.Errorf("node update must not be namespace scoped")
+	if !nodeRESTStrategies.NamespaceScoped() {
+		t.Errorf("node update must be namespace scoped")
 	}
 	if nodeRESTStrategies.AllowCreateOnUpdate() {
 		t.Errorf("node should not allow create on update")

--- a/pkg/registry/clusteroperator/nodegroup/strategy_test.go
+++ b/pkg/registry/clusteroperator/nodegroup/strategy_test.go
@@ -39,11 +39,8 @@ func nodegroupWithNewSpec() *clusteroperator.NodeGroup {
 // TestNodeGroupStrategyTrivial is the testing of the trivial hardcoded
 // boolean flags.
 func TestNodeGroupStrategyTrivial(t *testing.T) {
-	if nodegroupRESTStrategies.NamespaceScoped() {
-		t.Errorf("nodegroup create must not be namespace scoped")
-	}
-	if nodegroupRESTStrategies.NamespaceScoped() {
-		t.Errorf("nodegroup update must not be namespace scoped")
+	if !nodegroupRESTStrategies.NamespaceScoped() {
+		t.Errorf("nodegroup create must be namespace scoped")
 	}
 	if nodegroupRESTStrategies.AllowCreateOnUpdate() {
 		t.Errorf("nodegroup should not allow create on update")


### PR DESCRIPTION
Cluster, NodeGroup, and Node should all be namespace-scoped.