### PR TITLE
don't continue on errors

### DIFF
--- a/contrib/apiserver-aggregation-tls-setup.sh
+++ b/contrib/apiserver-aggregation-tls-setup.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 export CLUSTER_OPERATOR_NAMESPACE=${CLUSTER_OPERATOR_NAMESPACE:-cluster-operator}
 CLUSTER_OPERATOR_SERVICE_NAME=cluster-operator-apiserver
 

--- a/contrib/examples/deploy.sh
+++ b/contrib/examples/deploy.sh
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 # Create namespace for cluster-operator resources
-oc create namespace cluster-operator
+oc create namespace cluster-operator || :
 
 # Create ssl certs for api server
 ./contrib/apiserver-aggregation-tls-setup.sh


### PR DESCRIPTION
tell bash to not continue if any commands return non-zero

update 'oc create namespace' since that errors when the namespace already exists