### PR TITLE
Use the correct name for the nodegroups resource so that the nodegroup controller isn't skipped

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -436,7 +436,7 @@ func startInfraController(ctx ControllerContext) (bool, error) {
 }
 
 func startNodeGroupController(ctx ControllerContext) (bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "nodeGroups"}] {
+	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "nodegroups"}] {
 		return false, nil
 	}
 	go nodegroup.NewNodeGroupController(


### PR DESCRIPTION
Node group controller was using "nodeGroups" instead of "nodegroups" for the name of the resource that *needed* to exist.