### PR TITLE
Add validation for the API resources.

### DIFF
--- a/cmd/cluster-operator-apiserver/app/server.go
+++ b/cmd/cluster-operator-apiserver/app/server.go
@@ -53,6 +53,7 @@ func Run(opts *options.ClusterOperatorServerRunOptions, stopCh <-chan struct{}) 
 	return server.PrepareRun().Run(stopCh)
 }
 
+// CreateServer create an API server according to opts.
 func CreateServer(opts *options.ClusterOperatorServerRunOptions, stopCh <-chan struct{}) (*apiserver.ServiceCatalogAPIServer, error) {
 	etcdOpts := opts.Etcd
 	glog.V(4).Infoln("Preparing to run API server")

--- a/cmd/cluster-operator-apiserver/app/testing/server_test.go
+++ b/cmd/cluster-operator-apiserver/app/testing/server_test.go
@@ -37,13 +37,13 @@ func TestRun(t *testing.T) {
 	// test whether the server is really healthy after /healthz told us so
 	t.Logf("Creating Cluster directly after being healthy")
 	_, err = client.Clusters("default").Create(&clusteroperator.Cluster{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Cluster",
-			APIVersion: "clusteroperator.openshift.io/v1alpha1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "cluster1",
+			Name: "cluster1",
+		},
+		Spec: clusteroperator.ClusterSpec{
+			MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+				Size: 1,
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -145,8 +145,6 @@ type NodeList struct {
 }
 
 type NodeSpec struct {
-	NodeGroupName string `json:"nodeGroupName"`
-
 	// NodeType is the type of the node
 	NodeType NodeType
 }

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -145,8 +145,6 @@ type NodeList struct {
 }
 
 type NodeSpec struct {
-	NodeGroupName string `json:"nodeGroupName"`
-
 	// NodeType is the type of the node
 	NodeType NodeType `json:"nodeType"`
 }

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -363,7 +363,6 @@ func Convert_clusteroperator_NodeList_To_v1alpha1_NodeList(in *clusteroperator.N
 }
 
 func autoConvert_v1alpha1_NodeSpec_To_clusteroperator_NodeSpec(in *NodeSpec, out *clusteroperator.NodeSpec, s conversion.Scope) error {
-	out.NodeGroupName = in.NodeGroupName
 	out.NodeType = clusteroperator.NodeType(in.NodeType)
 	return nil
 }
@@ -374,7 +373,6 @@ func Convert_v1alpha1_NodeSpec_To_clusteroperator_NodeSpec(in *NodeSpec, out *cl
 }
 
 func autoConvert_clusteroperator_NodeSpec_To_v1alpha1_NodeSpec(in *clusteroperator.NodeSpec, out *NodeSpec, s conversion.Scope) error {
-	out.NodeGroupName = in.NodeGroupName
 	out.NodeType = NodeType(in.NodeType)
 	return nil
 }

--- a/pkg/apis/clusteroperator/validation/cluster.go
+++ b/pkg/apis/clusteroperator/validation/cluster.go
@@ -20,38 +20,96 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
-// ValidateClusterName is the validation function for Cluster names.
-var ValidateClusterName = apivalidation.NameIsDNSSubdomain
+// ValidateClusterName validates the name of a cluster.
+var ValidateClusterName = apivalidation.ValidateClusterName
 
-// ValidateCluster implements the validation rules for a Cluster.
+// ValidateCluster validates a cluster being created.
 func ValidateCluster(cluster *clusteroperator.Cluster) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs,
-		apivalidation.ValidateObjectMeta(&cluster.ObjectMeta,
-			true, /* namespace required */
-			ValidateClusterName,
-			field.NewPath("metadata"))...)
+	for _, msg := range ValidateClusterName(cluster.Name, false) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("name"), cluster.Name, msg))
+	}
 
 	allErrs = append(allErrs, validateClusterSpec(&cluster.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, validateClusterStatus(&cluster.Status, field.NewPath("status"))...)
+
 	return allErrs
 }
 
+// validateClusterSpec validates the spec of a cluster.
 func validateClusterSpec(spec *clusteroperator.ClusterSpec, fldPath *field.Path) field.ErrorList {
-	return field.ErrorList{}
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateClusterNodeGroup(&spec.MasterNodeGroup, fldPath.Child("masterNodeGroup"))...)
+	computeNodeGroupsFldPath := fldPath.Child("computeNodeGroup")
+	for i, nodeGroup := range spec.ComputeNodeGroups {
+		allErrs = append(allErrs, validateClusterComputeNodeGroup(&nodeGroup, computeNodeGroupsFldPath.Index(i))...)
+	}
+	computeNames := map[string]bool{}
+	for i, nodeGroup := range spec.ComputeNodeGroups {
+		if computeNames[nodeGroup.Name] {
+			allErrs = append(allErrs, field.Duplicate(computeNodeGroupsFldPath.Index(i).Child("name"), nodeGroup.Name))
+		}
+		computeNames[nodeGroup.Name] = true
+	}
+
+	return allErrs
 }
 
-// ValidateClusterUpdate checks that when changing from an older cluster to a newer cluster is okay ?
+// validateClusterNodeGroup validates a ClusterNodeGroup in the spec of a cluster.
+func validateClusterNodeGroup(nodeGroup *clusteroperator.ClusterNodeGroup, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if nodeGroup.Size <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), nodeGroup.Size, "must be positive"))
+	}
+
+	return allErrs
+}
+
+// validateClusterComputeNodeGroup validates a ClusterComputeNodeGroup in the spec of a cluster.
+func validateClusterComputeNodeGroup(nodeGroup *clusteroperator.ClusterComputeNodeGroup, fldPath *field.Path) field.ErrorList {
+	allErrs := validateClusterNodeGroup(&nodeGroup.ClusterNodeGroup, fldPath)
+
+	for _, msg := range apivalidation.NameIsDNSSubdomain(nodeGroup.Name, false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), nodeGroup.Name, msg))
+	}
+
+	return allErrs
+}
+
+// validateClusterStatus validates the status of a cluster.
+func validateClusterStatus(status *clusteroperator.ClusterStatus, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if status.MasterNodeGroups < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("masterNodeGroups"), status.MasterNodeGroups, "must be non-negative"))
+	}
+	if status.ComputeNodeGroups < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("computeNodeGroups"), status.ComputeNodeGroups, "must be non-negative"))
+	}
+
+	return allErrs
+}
+
+// ValidateClusterUpdate validates an update to the spec of a cluster.
 func ValidateClusterUpdate(new *clusteroperator.Cluster, old *clusteroperator.Cluster) field.ErrorList {
-	return field.ErrorList{}
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateClusterSpec(&new.Spec, field.NewPath("spec"))...)
+
+	return allErrs
 }
 
-// ValidateClusterStatusUpdate checks that when changing from an older cluster to a newer cluster is okay.
+// ValidateClusterStatusUpdate validates an update to the status of a cluster.
 func ValidateClusterStatusUpdate(new *clusteroperator.Cluster, old *clusteroperator.Cluster) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, ValidateClusterUpdate(new, old)...)
+
+	allErrs = append(allErrs, validateClusterStatus(&new.Status, field.NewPath("status"))...)
+
 	return allErrs
 }

--- a/pkg/apis/clusteroperator/validation/cluster_test.go
+++ b/pkg/apis/clusteroperator/validation/cluster_test.go
@@ -20,10 +20,37 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
+// getValidCluster gets a cluster that passes all validity checks.
+func getValidCluster() *clusteroperator.Cluster {
+	return &clusteroperator.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+		Spec: clusteroperator.ClusterSpec{
+			MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+				Size: 1,
+			},
+		},
+	}
+}
+
+// getTestClusterComputeNodeGroup gets a ClusterComputeNodeGroup with the
+// specified name and size.
+func getTestClusterComputeNodeGroup(name string, size int) clusteroperator.ClusterComputeNodeGroup {
+	return clusteroperator.ClusterComputeNodeGroup{
+		Name: name,
+		ClusterNodeGroup: clusteroperator.ClusterNodeGroup{
+			Size: size,
+		},
+	}
+}
+
+// TestValidateCluster tests the ValidateCluster function.
 func TestValidateCluster(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -31,10 +58,213 @@ func TestValidateCluster(t *testing.T) {
 		valid   bool
 	}{
 		{
-			name: "invalid cluster - cluster without namespace",
-			cluster: &clusteroperator.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
+			name:    "valid",
+			cluster: getValidCluster(),
+			valid:   true,
+		},
+		{
+			name: "invalid name",
+			cluster: func() *clusteroperator.Cluster {
+				c := getValidCluster()
+				c.Name = "###"
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "invalid spec",
+			cluster: func() *clusteroperator.Cluster {
+				c := getValidCluster()
+				c.Spec.MasterNodeGroup.Size = 0
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "invalid status",
+			cluster: func() *clusteroperator.Cluster {
+				c := getValidCluster()
+				c.Status.MasterNodeGroups = -1
+				return c
+			}(),
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateCluster(tc.cluster)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateClusterUpdate tests the ValidateClusterUpdate function.
+func TestValidateClusterUpdate(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   *clusteroperator.Cluster
+		new   *clusteroperator.Cluster
+		valid bool
+	}{
+		{
+			name:  "valid",
+			old:   getValidCluster(),
+			new:   getValidCluster(),
+			valid: true,
+		},
+		{
+			name: "invalid spec",
+			old:  getValidCluster(),
+			new: func() *clusteroperator.Cluster {
+				c := getValidCluster()
+				c.Spec.MasterNodeGroup.Size = 0
+				return c
+			}(),
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateClusterUpdate(tc.new, tc.old)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateClusterStatusUpdate tests the ValidateClusterStatusUpdate function.
+func TestValidateClusterStatusUpdate(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   *clusteroperator.Cluster
+		new   *clusteroperator.Cluster
+		valid bool
+	}{
+		{
+			name:  "valid",
+			old:   getValidCluster(),
+			new:   getValidCluster(),
+			valid: true,
+		},
+		{
+			name: "invalid status",
+			old:  getValidCluster(),
+			new: func() *clusteroperator.Cluster {
+				c := getValidCluster()
+				c.Status.MasterNodeGroups = -1
+				return c
+			}(),
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateClusterStatusUpdate(tc.new, tc.old)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateClusterSpec tests the validateClusterSpec function.
+func TestValidateClusterSpec(t *testing.T) {
+	cases := []struct {
+		name  string
+		spec  *clusteroperator.ClusterSpec
+		valid bool
+	}{
+		{
+			name: "valid master only",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 1,
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid master size",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 0,
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "valid single compute",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 1,
+				},
+				ComputeNodeGroups: []clusteroperator.ClusterComputeNodeGroup{
+					getTestClusterComputeNodeGroup("first", 1),
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "valid multiple computes",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 1,
+				},
+				ComputeNodeGroups: []clusteroperator.ClusterComputeNodeGroup{
+					getTestClusterComputeNodeGroup("first", 1),
+					getTestClusterComputeNodeGroup("second", 5),
+					getTestClusterComputeNodeGroup("third", 2),
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid compute name",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 1,
+				},
+				ComputeNodeGroups: []clusteroperator.ClusterComputeNodeGroup{
+					getTestClusterComputeNodeGroup("first", 1),
+					getTestClusterComputeNodeGroup("", 5),
+					getTestClusterComputeNodeGroup("third", 2),
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid compute size",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 1,
+				},
+				ComputeNodeGroups: []clusteroperator.ClusterComputeNodeGroup{
+					getTestClusterComputeNodeGroup("first", 1),
+					getTestClusterComputeNodeGroup("second", 0),
+					getTestClusterComputeNodeGroup("third", 2),
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid duplicate compute name",
+			spec: &clusteroperator.ClusterSpec{
+				MasterNodeGroup: clusteroperator.ClusterNodeGroup{
+					Size: 1,
+				},
+				ComputeNodeGroups: []clusteroperator.ClusterComputeNodeGroup{
+					getTestClusterComputeNodeGroup("first", 1),
+					getTestClusterComputeNodeGroup("first", 5),
+					getTestClusterComputeNodeGroup("third", 2),
 				},
 			},
 			valid: false,
@@ -42,7 +272,68 @@ func TestValidateCluster(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		errs := ValidateCluster(tc.cluster)
+		errs := validateClusterSpec(tc.spec, field.NewPath("spec"))
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateClusterStatus tests the validateClusterStatus function.
+func TestValidateClusterStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status *clusteroperator.ClusterStatus
+		valid  bool
+	}{
+		{
+			name:   "empty",
+			status: &clusteroperator.ClusterStatus{},
+			valid:  true,
+		},
+		{
+			name: "positive masters",
+			status: &clusteroperator.ClusterStatus{
+				MasterNodeGroups: 1,
+			},
+			valid: true,
+		},
+		{
+			name: "positive computes",
+			status: &clusteroperator.ClusterStatus{
+				ComputeNodeGroups: 1,
+			},
+			valid: true,
+		},
+		{
+			name: "positive masters and computes",
+			status: &clusteroperator.ClusterStatus{
+				MasterNodeGroups:  1,
+				ComputeNodeGroups: 1,
+			},
+			valid: true,
+		},
+		{
+			name: "negative masters",
+			status: &clusteroperator.ClusterStatus{
+				MasterNodeGroups: -1,
+			},
+			valid: false,
+		},
+		{
+			name: "negative computes",
+			status: &clusteroperator.ClusterStatus{
+				ComputeNodeGroups: -1,
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateClusterStatus(tc.status, field.NewPath("status"))
 		if len(errs) != 0 && tc.valid {
 			t.Errorf("%v: unexpected error: %v", tc.name, errs)
 			continue

--- a/pkg/apis/clusteroperator/validation/node_test.go
+++ b/pkg/apis/clusteroperator/validation/node_test.go
@@ -19,11 +19,21 @@ package validation
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
+// getValidNode gets a node that passes all validity checks.
+func getValidNode() *clusteroperator.Node {
+	return &clusteroperator.Node{
+		Spec: clusteroperator.NodeSpec{
+			NodeType: clusteroperator.NodeTypeMaster,
+		},
+	}
+}
+
+// TestValidateNode tests the ValidateNode function.
 func TestValidateNode(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -31,18 +41,125 @@ func TestValidateNode(t *testing.T) {
 		valid bool
 	}{
 		{
-			name: "invalid node - node without namespace",
-			node: &clusteroperator.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-node",
-				},
-			},
-			valid: false,
+			name:  "valid",
+			node:  getValidNode(),
+			valid: true,
 		},
 	}
 
 	for _, tc := range cases {
 		errs := ValidateNode(tc.node)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeUpdate tests the ValidateNodeUpdate function.
+func TestValidateNodeUpdate(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   *clusteroperator.Node
+		new   *clusteroperator.Node
+		valid bool
+	}{
+		{
+			name:  "valid",
+			old:   getValidNode(),
+			new:   getValidNode(),
+			valid: true,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateNodeUpdate(tc.new, tc.old)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeStatusUpdate tests the ValidateNodeStatus function.
+func TestValidateNodeStatusUpdate(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   *clusteroperator.Node
+		new   *clusteroperator.Node
+		valid bool
+	}{
+		{
+			name:  "valid",
+			old:   getValidNode(),
+			new:   getValidNode(),
+			valid: true,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateNodeStatusUpdate(tc.new, tc.old)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeSpec tests the validateNodeSpec function.
+func TestValidateNodeSpec(t *testing.T) {
+	cases := []struct {
+		name  string
+		spec  *clusteroperator.NodeSpec
+		valid bool
+	}{
+		{
+			name: "valid",
+			spec: &clusteroperator.NodeSpec{
+				NodeType: clusteroperator.NodeTypeMaster,
+			},
+			valid: true,
+		},
+		{
+			name:  "invalid node type",
+			spec:  &clusteroperator.NodeSpec{},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateNodeSpec(tc.spec, field.NewPath("spec"))
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeStatus tests the validateNodeStatus function.
+func TestValidateNodeStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status *clusteroperator.NodeStatus
+		valid  bool
+	}{
+		{
+			name:   "valid",
+			status: &clusteroperator.NodeStatus{},
+			valid:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateNodeStatus(tc.status, field.NewPath("status"))
 		if len(errs) != 0 && tc.valid {
 			t.Errorf("%v: unexpected error: %v", tc.name, errs)
 			continue

--- a/pkg/apis/clusteroperator/validation/nodegroup.go
+++ b/pkg/apis/clusteroperator/validation/nodegroup.go
@@ -18,40 +18,92 @@ package validation
 
 import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	cov1alpha1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
-// ValidateNodeGroupName is the validation function for NodeGroup names.
-var ValidateNodeGroupName = apivalidation.NameIsDNSSubdomain
-
-// ValidateNodeGroup implements the validation rules for a NodeGroup.
+// ValidateNodeGroup validates a node group being created.
 func ValidateNodeGroup(nodeGroup *clusteroperator.NodeGroup) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs,
-		apivalidation.ValidateObjectMeta(&nodeGroup.ObjectMeta,
-			true, /* namespace required */
-			ValidateNodeGroupName,
-			field.NewPath("metadata"))...)
-
+	allErrs = append(allErrs, validateNodeGroupClusterOwner(nodeGroup.GetOwnerReferences(), field.NewPath("metadata").Child("ownerReferences"))...)
 	allErrs = append(allErrs, validateNodeGroupSpec(&nodeGroup.Spec, field.NewPath("spec"))...)
+
 	return allErrs
 }
 
+// validateNodeGroupClusterOwner validates that a node group has an owner and
+// that the first owner is a cluster.
+func validateNodeGroupClusterOwner(ownerRefs []metav1.OwnerReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(ownerRefs) != 0 {
+		ownerRef := ownerRefs[0]
+		if ownerRef.APIVersion != cov1alpha1.SchemeGroupVersion.String() ||
+			ownerRef.Kind != "clusters" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(0), ownerRef, "first owner of nodegroup must be a cluster"))
+		}
+		if ownerRef.Controller == nil || !*ownerRef.Controller {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(0).Child("controller"), ownerRef.Controller, "first owner must be the managing controller"))
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(fldPath, "nodegroup must have an owner"))
+	}
+
+	return allErrs
+}
+
+// validateNodeGroupSpec validates the spec of a node group.
 func validateNodeGroupSpec(spec *clusteroperator.NodeGroupSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateNodeType(spec.NodeType, fldPath.Child("nodeType"))...)
+
+	if spec.Size <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), spec.Size, "size must be positive"))
+	}
+
+	return allErrs
+}
+
+// validateNodeGroupStatus validates the status of a node group.
+func validateNodeGroupStatus(status *clusteroperator.NodeGroupStatus, fldPath *field.Path) field.ErrorList {
 	return field.ErrorList{}
 }
 
-// ValidateNodeGroupUpdate checks that when changing from an older nodegroup to a newer nodegroup is okay ?
+// ValidateNodeGroupUpdate validates an update to the spec of a node group.
 func ValidateNodeGroupUpdate(new *clusteroperator.NodeGroup, old *clusteroperator.NodeGroup) field.ErrorList {
-	return field.ErrorList{}
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateNodeGroupSpec(&new.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, validateNodeGroupImmutableClusterOwner(new.GetOwnerReferences(), old.GetOwnerReferences(), field.NewPath("metadata").Child("ownerReferences"))...)
+
+	return allErrs
 }
 
-// ValidateNodeGroupStatusUpdate checks that when changing from an older nodegroup to a newer nodegroup is okay.
+// validateNodeGroupImmutableClusterOwner validates that the cluster owner of
+// a node group is immutable.
+func validateNodeGroupImmutableClusterOwner(newOwnerRefs, oldOwnerRefs []metav1.OwnerReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(newOwnerRefs) != 0 {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newOwnerRefs[0], oldOwnerRefs[0], fldPath.Index(0))...)
+	} else {
+		allErrs = append(allErrs, field.Required(fldPath, "nodegroup must have an owner"))
+	}
+
+	return allErrs
+}
+
+// ValidateNodeGroupStatusUpdate validates an update to the status of a node
+// group.
 func ValidateNodeGroupStatusUpdate(new *clusteroperator.NodeGroup, old *clusteroperator.NodeGroup) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, ValidateNodeGroupUpdate(new, old)...)
+
+	allErrs = append(allErrs, validateNodeGroupStatus(&new.Status, field.NewPath("status"))...)
+
 	return allErrs
 }

--- a/pkg/apis/clusteroperator/validation/nodegroup_test.go
+++ b/pkg/apis/clusteroperator/validation/nodegroup_test.go
@@ -20,10 +20,37 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
+// getValidClusterOwnerRef returns an owner reference that can be used as a
+// valid cluster owner reference for a node group.
+func getValidClusterOwnerRef() metav1.OwnerReference {
+	truePtr := func() *bool { b := true; return &b }
+	return metav1.OwnerReference{
+		APIVersion: "clusteroperator.openshift.io/v1alpha1",
+		Kind:       "clusters",
+		UID:        "cluster-owner",
+		Controller: truePtr(),
+	}
+}
+
+// getValidNodeGroup gets a node group that passes all validity checks.
+func getValidNodeGroup() *clusteroperator.NodeGroup {
+	return &clusteroperator.NodeGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{getValidClusterOwnerRef()},
+		},
+		Spec: clusteroperator.NodeGroupSpec{
+			NodeType: clusteroperator.NodeTypeMaster,
+			Size:     1,
+		},
+	}
+}
+
+// TestValidateNodeGroup tests the ValidateNodeGroup function.
 func TestValidateNodeGroup(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -31,18 +58,371 @@ func TestValidateNodeGroup(t *testing.T) {
 		valid     bool
 	}{
 		{
-			name: "invalid node group - node group without namespace",
-			nodeGroup: &clusteroperator.NodeGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-nodegroup",
-				},
-			},
+			name:      "valid",
+			nodeGroup: getValidNodeGroup(),
+			valid:     true,
+		},
+		{
+			name: "invalid cluster owner",
+			nodeGroup: func() *clusteroperator.NodeGroup {
+				ng := getValidNodeGroup()
+				ng.OwnerReferences = []metav1.OwnerReference{}
+				return ng
+			}(),
+			valid: false,
+		},
+		{
+			name: "invalid spec",
+			nodeGroup: func() *clusteroperator.NodeGroup {
+				ng := getValidNodeGroup()
+				ng.Spec.Size = 0
+				return ng
+			}(),
 			valid: false,
 		},
 	}
 
 	for _, tc := range cases {
 		errs := ValidateNodeGroup(tc.nodeGroup)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeGroupUpdate tests the ValidateNodeGroupUpdate function.
+func TestValidateNodeGroupUpdate(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   *clusteroperator.NodeGroup
+		new   *clusteroperator.NodeGroup
+		valid bool
+	}{
+		{
+			name:  "valid",
+			old:   getValidNodeGroup(),
+			new:   getValidNodeGroup(),
+			valid: true,
+		},
+		{
+			name: "invalid cluster owner mutation",
+			old: func() *clusteroperator.NodeGroup {
+				ng := getValidNodeGroup()
+				ng.OwnerReferences[0].UID = "old-owner-uid"
+				return ng
+			}(),
+			new: func() *clusteroperator.NodeGroup {
+				ng := getValidNodeGroup()
+				ng.OwnerReferences[0].UID = "new-owner-uid"
+				return ng
+			}(),
+			valid: false,
+		},
+		{
+			name: "invalid spec",
+			old:  getValidNodeGroup(),
+			new: func() *clusteroperator.NodeGroup {
+				ng := getValidNodeGroup()
+				ng.Spec.Size = 0
+				return ng
+			}(),
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateNodeGroupUpdate(tc.new, tc.old)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeGroupStatusUpdate tests the ValidateNodeGroupStatusUpdate
+// function.
+func TestValidateNodeGroupStatusUpdate(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   *clusteroperator.NodeGroup
+		new   *clusteroperator.NodeGroup
+		valid bool
+	}{
+		{
+			name:  "valid",
+			old:   getValidNodeGroup(),
+			new:   getValidNodeGroup(),
+			valid: true,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := ValidateNodeGroupStatusUpdate(tc.new, tc.old)
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeGroupClusterOwner tests the validateNodeGroupClusterOwner
+// function.
+func TestValidateNodeGroupClusterOwner(t *testing.T) {
+	cases := []struct {
+		name      string
+		ownerRefs []metav1.OwnerReference
+		valid     bool
+	}{
+		{
+			name: "valid single owner",
+			ownerRefs: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+			},
+			valid: true,
+		},
+		{
+			name: "valid multiple owners",
+			ownerRefs: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+				{},
+			},
+			valid: true,
+		},
+		{
+			name:      "no owners",
+			ownerRefs: []metav1.OwnerReference{},
+			valid:     false,
+		},
+		{
+			name: "first owner not cluster owner",
+			ownerRefs: []metav1.OwnerReference{
+				func() metav1.OwnerReference {
+					r := getValidClusterOwnerRef()
+					r.Kind = "other-kind"
+					return r
+				}(),
+				getValidClusterOwnerRef(),
+			},
+			valid: false,
+		},
+		{
+			name: "invalid api version",
+			ownerRefs: []metav1.OwnerReference{
+				func() metav1.OwnerReference {
+					r := getValidClusterOwnerRef()
+					r.APIVersion = "other-api-version"
+					return r
+				}(),
+			},
+			valid: false,
+		},
+		{
+			name: "invalid kind",
+			ownerRefs: []metav1.OwnerReference{
+				func() metav1.OwnerReference {
+					r := getValidClusterOwnerRef()
+					r.Kind = "other-kind"
+					return r
+				}(),
+			},
+			valid: false,
+		},
+		{
+			name: "cluster owner not controller",
+			ownerRefs: []metav1.OwnerReference{
+				func() metav1.OwnerReference {
+					r := getValidClusterOwnerRef()
+					r.Controller = nil
+					return r
+				}(),
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateNodeGroupClusterOwner(tc.ownerRefs, field.NewPath("metadata").Child("ownerReferences"))
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeGroupSpec tests the validateNodeGroupSpec function.
+func TestValidateNodeGroupSpec(t *testing.T) {
+	cases := []struct {
+		name  string
+		spec  *clusteroperator.NodeGroupSpec
+		valid bool
+	}{
+		{
+			name: "valid",
+			spec: &clusteroperator.NodeGroupSpec{
+				NodeType: clusteroperator.NodeTypeMaster,
+				Size:     1,
+			},
+			valid: true,
+		},
+		{
+			name: "invalid node type",
+			spec: &clusteroperator.NodeGroupSpec{
+				NodeType: clusteroperator.NodeType(""),
+				Size:     1,
+			},
+		},
+		{
+			name: "invalid size",
+			spec: &clusteroperator.NodeGroupSpec{
+				NodeType: clusteroperator.NodeTypeMaster,
+				Size:     0,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateNodeGroupSpec(tc.spec, field.NewPath("spec"))
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeGroupImmutableClusterOwner tests the
+// validateNodeGroupImmutableClusterOwner function.
+func TestValidateNodeGroupImmutableClusterOwner(t *testing.T) {
+	cases := []struct {
+		name  string
+		old   []metav1.OwnerReference
+		new   []metav1.OwnerReference
+		valid bool
+	}{
+		{
+			name: "valid single owner",
+			old: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+			},
+			new: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+			},
+			valid: true,
+		},
+		{
+			name: "valid multiple owners",
+			old: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+				{},
+			},
+			new: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+				{},
+			},
+			valid: true,
+		},
+		{
+			name: "single owner removed",
+			old: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+			},
+			new:   []metav1.OwnerReference{},
+			valid: false,
+		},
+		{
+			name: "cluster owner removed",
+			old: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+				{},
+			},
+			new: []metav1.OwnerReference{
+				{},
+				{},
+			},
+			valid: false,
+		},
+		{
+			name: "cluster owner moved",
+			old: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+				{},
+			},
+			new: []metav1.OwnerReference{
+				{},
+				getValidClusterOwnerRef(),
+				{},
+			},
+			valid: false,
+		},
+		{
+			name: "other owner removed",
+			old: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+				{},
+			},
+			new: []metav1.OwnerReference{
+				getValidClusterOwnerRef(),
+				{},
+			},
+			valid: true,
+		},
+		{
+			name: "cluster owner mutated",
+			old: []metav1.OwnerReference{
+				func() metav1.OwnerReference {
+					r := getValidClusterOwnerRef()
+					r.UID = "old-owner-uid"
+					return r
+				}(),
+			},
+			new: []metav1.OwnerReference{
+				func() metav1.OwnerReference {
+					r := getValidClusterOwnerRef()
+					r.UID = "new-owner-uid"
+					return r
+				}(),
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateNodeGroupImmutableClusterOwner(tc.new, tc.old, field.NewPath("metadata").Child("ownerReferences"))
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.name, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+// TestValidateNodeGroupStatus tests the validateNodeGroupStatus function.
+func TestValidateNodeGroupStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status *clusteroperator.NodeGroupStatus
+		valid  bool
+	}{}
+
+	for _, tc := range cases {
+		errs := validateNodeGroupStatus(tc.status, field.NewPath("status"))
 		if len(errs) != 0 && tc.valid {
 			t.Errorf("%v: unexpected error: %v", tc.name, errs)
 			continue

--- a/pkg/apis/clusteroperator/validation/validation.go
+++ b/pkg/apis/clusteroperator/validation/validation.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+)
+
+// validNodeTypes is a map containing an entry for every valid NodeType value.
+var validNodeTypes = map[clusteroperator.NodeType]bool{
+	clusteroperator.NodeTypeMaster:  true,
+	clusteroperator.NodeTypeCompute: true,
+}
+
+// validNodeTypeValues is an array of every valid NodeType value.
+var validNodeTypeValues = func() []string {
+	validValues := make([]string, len(validNodeTypes))
+	i := 0
+	for nodeType := range validNodeTypes {
+		validValues[i] = string(nodeType)
+		i++
+	}
+	return validValues
+}()
+
+// validateNodeType validates that the specified node type has a valid
+// NodeType value.
+func validateNodeType(nodeType clusteroperator.NodeType, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if !validNodeTypes[nodeType] {
+		allErrs = append(allErrs, field.NotSupported(fldPath, nodeType, validNodeTypeValues))
+	}
+
+	return allErrs
+}

--- a/pkg/apis/clusteroperator/validation/validation_test.go
+++ b/pkg/apis/clusteroperator/validation/validation_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+)
+
+// TestValidateNodeType validates the validateNodeType function.
+func TestValidateNodeType(t *testing.T) {
+	cases := []struct {
+		nodeType string
+		valid    bool
+	}{
+		{
+			nodeType: "Master",
+			valid:    true,
+		},
+		{
+			nodeType: "Compute",
+			valid:    true,
+		},
+		{
+			nodeType: "",
+			valid:    false,
+		},
+		{
+			nodeType: "Other",
+			valid:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		errs := validateNodeType(clusteroperator.NodeType(tc.nodeType), field.NewPath("nodeType"))
+		if len(errs) != 0 && tc.valid {
+			t.Errorf("%v: unexpected error: %v", tc.nodeType, errs)
+			continue
+		} else if len(errs) == 0 && !tc.valid {
+			t.Errorf("%v: unexpected success", tc.nodeType)
+		}
+	}
+}

--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -467,7 +467,7 @@ func (c *ClusterController) manageNodeGroups(nodeGroups []*clusteroperator.NodeG
 		nodeGroupsToDelete = append(nodeGroupsToDelete, masterNodeGroup)
 	}
 	// Sync compute node groups
-	for i, _ := range cluster.Spec.ComputeNodeGroups {
+	for i := range cluster.Spec.ComputeNodeGroups {
 		nodeGroupToCreate, deleteNodeGroup, err := c.manageNodeGroup(cluster, computeNodeGroups[i], cluster.Spec.ComputeNodeGroups[i].ClusterNodeGroup, clusteroperator.NodeTypeCompute, computeNodeGroupsPrefixes[i])
 		if err != nil {
 			errCh <- err

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -26,6 +26,7 @@ import (
 )
 
 var (
+	// KeyFunc returns the key identifying a cluster-operator resource.
 	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 )
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -407,12 +407,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
 					Properties: map[string]spec.Schema{
-						"nodeGroupName": {
-							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
-							},
-						},
 						"nodeType": {
 							SchemaProps: spec.SchemaProps{
 								Description: "NodeType is the type of the node",
@@ -421,7 +415,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"nodeGroupName", "nodeType"},
+					Required: []string{"nodeType"},
 				},
 			},
 			Dependencies: []string{},


### PR DESCRIPTION
* Add validation for the API resources.
* Remove NodeGroupName from Node as it is not currently used. It may not be needed at all depending upon how we implement nodes. So, let's get rid of it for now.
* Fix some fmt and lint warnings.