### PR TITLE
allow using non 'default' aws profile names

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -3,6 +3,8 @@
 - hosts: localhost
   connection: local
   gather_facts: no
+  vars:
+    aws_section: default
   tasks:
   - name: create cluster-operator namespace
     command: oc create namespace cluster-operator
@@ -19,11 +21,15 @@
       creates: "{{ playbook_dir }}/../../apiserver.pem"
 
   - set_fact:
+      aws_section: "{{ cli_aws_section }}"
+    when: cli_aws_section is defined
+
+  - set_fact:
       l_serving_ca: "{{ lookup('file', playbook_dir + '/../../ca.pem') | b64encode }}"
       l_serving_cert: "{{ lookup('file', playbook_dir + '/../../apiserver.pem') | b64encode }}"
       l_serving_key: "{{ lookup('file', playbook_dir + '/../../apiserver-key.pem') | b64encode }}"
-      l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=default file=~/.aws/credentials') | b64encode }}"
-      l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=default file=~/.aws/credentials') | b64encode }}"
+      l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
+      l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
 
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template


### PR DESCRIPTION
default the cluster-operator install playbook to continue to use 'default', but allow passing cli_aws_section to pick a different aws profile to run with/against