### PR TITLE
Add scripts for running test coverage analysis

### DIFF
--- a/contrib/hack/coverage.sh
+++ b/contrib/hack/coverage.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o nounset
+set -o errexit
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+. "${ROOT}/contrib/hack/utilities.sh" || { echo 'Cannot load utilities.'; exit 1; }
+
+function usage() {
+  [[ -n "${1:-}" ]] && { echo "${1}"; echo ; }
+
+  cat <<__EOF__
+Usage: coverage.sh [options] packages ...
+
+Runs test code coverage on specified packages and aggregates results.
+
+Supported options:
+
+  --out:  aggregated coverage profile output file name
+  --html: aggregated coverage html output file name
+
+__EOF__
+
+  exit 1
+}
+
+while [[ $# -ne 0 ]]; do
+  case "$1" in
+    --out)     OUT="$2";  shift ;;
+    --html)    HTML="$2"; shift ;;
+    -*)        usage "Unrecognized command line argument $1" ;;
+    *)         break;
+  esac
+  shift
+done
+
+[[ -z "${OUT:-}" && -z "${HTML:-}" ]] \
+  && usage "Either --out or --html must be specified"
+
+PACKAGES=( ${@+"${@}"} )
+OUT=${OUT:-${TMP:=$(mktemp)}}
+
+function cleanup() {
+  local tmp="${TMP:-}"
+  [[ -n "${tmp}" ]] && rm -f "${tmp}"
+}
+trap cleanup EXIT
+
+function run-coverage() {
+  local packages=(${!1+"${!1}"})
+  local package subpackage
+  local result=0
+
+  echo 'mode: set' > "${OUT}"
+
+  for package in ${packages[@]+"${packages[@]}"}; do
+      local out="$(mktemp)"
+      go test -cover "${package}" -coverprofile "${out}" \
+        || result=1
+      grep -h -v '^mode: ' "${out}" >> "${OUT}"
+      rm "${out}"
+  done
+
+  [[ ${result} -eq 0 && -n "${HTML:-}" ]] \
+    && go tool cover -html "${OUT}" -o "${HTML}"
+
+  return ${result}
+}
+
+run-coverage PACKAGES[@]

--- a/contrib/hack/utilities.sh
+++ b/contrib/hack/utilities.sh
@@ -1,0 +1,146 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Library of useful utilities.
+
+# Exit with a message and an exit code.
+# Arguments:
+#   $1 - string with an error message
+#   $2 - exit code, defaults to 1
+function error_exit() {
+  # ${BASH_SOURCE[1]} is the file name of the caller.
+  echo "${BASH_SOURCE[1]}: line ${BASH_LINENO[0]}: ${1:-Unknown Error.} (exit ${2:-1})" 1>&2
+  exit ${2:-1}
+}
+
+# Retries a command with an exponential back-off.
+# The back-off base is a constant 3/2
+# Options:
+#   -n Maximum total attempts (0 for infinite, default 10)
+#   -t Maximum time to sleep between retries (default 60)
+#   -s Initial time to sleep between retries. Subsequent retries
+#      subject to exponential back-off up-to the maximum time.
+#      (default 5)
+function retry() {
+  local OPTIND OPTARG ARG
+  local COUNT=10
+  local SLEEP=5 MAX_SLEEP=60
+  local MUL=3 DIV=2 # Exponent base multiplier and divisor
+                    # (Bash doesn't do floats)
+
+  while getopts ":n:s:t:" ARG; do
+    case ${ARG} in
+      n) COUNT=${OPTARG};;
+      s) SLEEP=${OPTARG};;
+      t) MAX_SLEEP=${OPTARG};;
+      *) echo "Unrecognized argument: -${OPTARG}";;
+    esac
+  done
+
+  shift $((OPTIND-1))
+
+  # If there is no command, abort early.
+  [[ ${#} -le 0 ]] && { echo "No command specified, aborting."; return 1; }
+
+  local N=1 S=${SLEEP}  # S is the current length of sleep.
+  while : ; do
+    echo "${N}. Executing ${@}"
+    "${@}" && { echo "Command succeeded."; return 0; }
+
+    [[ (( COUNT -le 0 || N -lt COUNT )) ]] \
+      || { echo "Command '${@}' failed ${N} times, aborting."; return 1; }
+
+    if [[ (( S -lt MAX_SLEEP )) ]] ; then
+      # Must always count full exponent due to integer rounding.
+      ((S=SLEEP * (MUL ** (N-1)) / (DIV ** (N-1))))
+    fi
+
+    ((S=(S < MAX_SLEEP) ? S : MAX_SLEEP))
+
+    echo "Command failed. Will retry in ${S} seconds."
+    sleep ${S}
+
+    ((N++))
+  done
+}
+
+# Will wait until the output of the passed command contains the
+# expected substring.
+# If the negate flag is passed, waits until output does not contain
+# the expected substring.
+function wait_for_expected_output() {
+  local OPTIND OPTARG ARG
+  local negate=''
+  local count=10
+  local sleep_amount=5
+  local max_sleep=60
+  local expected=''
+
+  while getopts ":xn:s:t:e:" ARG; do
+    case ${ARG} in
+      x) negate='YES';;
+      n) count=${OPTARG};;
+      s) sleep_amount=${OPTARG};;
+      t) max_sleep=${OPTARG};;
+      e) expected=${OPTARG};;
+      *) echo "Unrecognized argument: -${OPTARG}";;
+    esac
+  done
+
+  shift $((OPTIND-1))
+
+  # If there is no command, abort early.
+  [[ ${#} -le 0 ]] && { echo "No command specified, aborting."; return 1; }
+
+  if [[ -n "${negate:-}" ]]; then
+    retry -n ${count} -s ${sleep_amount} -t ${max_sleep} \
+        output_does_not_contain_substring -e "${expected}" "${@}" > /dev/null \
+      && return 0
+
+    echo "Waited unsuccessfully for no occurrence of \"${expected}\" in: \"$("${@}")\""
+  else
+    retry -n ${count} -s ${sleep_amount} -t ${max_sleep} \
+        output_contains_substring -e "${expected}" "${@}" > /dev/null \
+      && return 0
+
+    echo "Waited unsuccessfully for occurrence of \"${expected}\" in: \"$("${@}")\""
+  fi
+
+  return 1
+}
+
+function output_contains_substring() {
+  local OPTIND OPTARG ARG
+  local expected=''
+
+  while getopts ":e:" ARG; do
+    case ${ARG} in
+      e) expected=${OPTARG};;
+      *) echo "Unrecognized argument: -${OPTARG}";;
+    esac
+  done
+
+  shift $((OPTIND-1))
+
+  # If there is no command, abort early.
+  [[ ${#} -le 0 ]] && { echo "No command specified, aborting."; return 1; }
+
+  [[ "$("${@}")" == *"${expected}"* ]]
+}
+
+function output_does_not_contain_substring() {
+  output_contains_substring "$@" && return 1
+  return 0
+}


### PR DESCRIPTION
* Coverage analysis is done by running `make coverage`. This produces an HTML file at cluster-operator/coverage.html where you can see covered and uncovered code in each file.
* Currently, analysis is only run on packages that contain tests. The scripts are written exit out on the first package encountered without a test. There are two things we can do about this in the future. First, once we have at least some tests in all packages, we can adjust the scripts to run the coverage analysis on all packages, and we can treat packages without tests as a failure. Second, we can adjust the scripts so that they handle packages without tests as code with 0% coverage instead of as a failure.