### PR TITLE
Allow running Ansible without root/elevated SCC.

### DIFF
--- a/contrib/examples/deploy.yaml
+++ b/contrib/examples/deploy.yaml
@@ -85,17 +85,17 @@ objects:
   - apiGroups: [""]
     resources: ["events"]
     verbs:     ["create","patch","update"]
-  # allow operations on required resources in our namespace
+  # allow all operations on all resources in our API group
+  - apiGroups: ["clusteroperator.openshift.io"]
+    resources: ["*"]
+    verbs:     ["create", "get", "list", "watch", "update", "delete"]
+  # allow operations on required resources in any namespace a cluster is created
   - apiGroups:     [""]
     resources:     ["configmaps", "pods", "secrets"]
     verbs: ["*"]
   - apiGroups:     ["batch"]
     resources:     ["jobs"]
     verbs: ["*"]
-  # allow all operations on all resources in our API group
-  - apiGroups: ["clusteroperator.openshift.io"]
-    resources: ["*"]
-    verbs:     ["create", "get", "list", "watch", "update", "delete"]
 
 # Bind the Controller Manager service account to the role created for it
 - apiVersion: rbac.authorization.k8s.io/v1
@@ -111,19 +111,6 @@ objects:
     kind: ServiceAccount
     name: cluster-operator-controller-manager
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
-
-# Allow our service account to run Ansible pods as UID 0:
-- kind: SecurityContextConstraints
-  apiVersion: v1
-  metadata:
-    name: cluster-operator-runasuser
-  allowPrivilegedContainer: true
-  runAsUser:
-    type: RunAsAny
-  seLinuxContext:
-    type: RunAsAny
-  users:
-  - system:serviceaccount:${CLUSTER_OPERATOR_NAMESPACE}:cluster-operator-controller-manager
 
 # Secret to pass the SSL certs to the API Server
 - apiVersion: v1

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -23,8 +23,9 @@ const varsTemplate = `---
 # Common/Cluster Variables #
 # ------------------------ #
 # Variables in this section affect all areas of the cluster
+# TODO:
 ansible_ssh_user: centos
-ansible_become: true
+
 ################################################################################
 # Ensure these variables are set for bootstrap
 ################################################################################

--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -241,7 +241,8 @@ func (c *InfraController) syncCluster(key string) error {
 		return err
 	}
 
-	err = ansibleRunner.RunPlaybook(cluster.Name, jobPrefix, infraPlaybook, provisionInventoryTemplate, vars)
+	err = ansibleRunner.RunPlaybook(cluster.Namespace, cluster.Name, jobPrefix, infraPlaybook,
+		provisionInventoryTemplate, vars)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Also adds support for creating clusters in namespaces other than
"cluster-operator".

For now, secrets we use for AWS and SSH are copied to any namespace where a cluster appears. These will fold into the cluster API and/or provisioning eventually.

Ansible jobs will also run in the namespace where the cluster lands keeping things nicely segmented.