### PR TITLE
Provide a fake openshift-ansible image to avoid real AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ ca-key.pem
 ca.csr
 ca.pem
 server-ca-config.json
+*.retry

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ creates.
 
 To enable and test:
 
-  1. Uncomment the correct Command in the pod definition in pkg/ansible/runner.py.
+  1. Enable using real AWS by supplying the use_real_aws parameter to the contrib/ansible/deploy-devel.yaml playbook.
+		* `ansible-playbook contrib/ansible/deploy-devel.yaml -e "use_real_aws=true"`
   1. `cp ./contrib/examples/cluster.yaml ./contrib/examples/mycluster.yaml`
   1. Edit mycluster.yaml and change the name to your username. This will allow you to find objects created in the AWS account to clean up.
-  1. `kubectl create -n cluster-operator -f ./contrib/examples/dgoodwin-cluster.yaml`
-    * Ability to create the cluster in any namespace will be coming shortly but for now, must be cluster-operator.
+  1. `kubectl create -f ./contrib/examples/mycluster.yaml`
   1. You should see some action in the controller manager logs, and a provisioning job and associated pod.
 

--- a/build/fake-openshift-ansible/Dockerfile
+++ b/build/fake-openshift-ansible/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openshift/origin-ansible:v3.8
+
+ADD fake-openshift-ansible /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/fake-openshift-ansible"]

--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -450,6 +450,8 @@ func startInfraController(ctx ControllerContext) (bool, error) {
 		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-infra-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-infra-controller"),
+		ctx.Options.AnsibleImage,
+		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentClusterSyncs), ctx.Stop)
 	return true, nil
 }

--- a/cmd/cluster-operator-controller-manager/app/options/options.go
+++ b/cmd/cluster-operator-controller-manager/app/options/options.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -52,6 +53,8 @@ const (
 	defaultConcurrentSyncs               = 5
 	defaultLeaderElectionNamespace       = "kube-system"
 	defaultLogLevel                      = "info"
+	defaultAnsibleImage                  = "openshift/origin-ansible:v3.8"
+	defaultAnsibleImagePullPolicy        = string(kapi.PullAlways)
 )
 
 // NewCMServer creates a new CMServer with a default config.
@@ -74,6 +77,8 @@ func NewCMServer() *CMServer {
 			ControllerStartInterval:       metav1.Duration{Duration: 0 * time.Second},
 			EnableProfiling:               true,
 			EnableContentionProfiling:     false,
+			AnsibleImage:                  defaultAnsibleImage,
+			AnsibleImagePullPolicy:        defaultAnsibleImagePullPolicy,
 		},
 	}
 	s.LeaderElection.LeaderElect = true
@@ -106,6 +111,8 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", s.LeaderElectionNamespace, "Namespace to use for leader election lock")
 	fs.StringVar(&s.LogLevel, "log-level", defaultLogLevel, "Log level (debug,info,warn,error,fatal)")
 	fs.DurationVar(&s.ControllerStartInterval.Duration, "controller-start-interval", s.ControllerStartInterval.Duration, "Interval between starting controller managers.")
+	fs.StringVar(&s.AnsibleImage, "ansible-image", s.AnsibleImage, "Name of the image to use to run ansible playbooks")
+	fs.StringVar(&s.AnsibleImagePullPolicy, "ansible-image-pull-policy", s.AnsibleImagePullPolicy, fmt.Sprintf("Policy to use to pull the ansible image. This can be %s, %s, or %s", kapi.PullAlways, kapi.PullNever, kapi.PullIfNotPresent))
 
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }
@@ -113,6 +120,15 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 // Validate is used to validate the options and config before launching the controller manager
 func (s *CMServer) Validate(allControllers []string, disabledByDefaultControllers []string) error {
 	var errs []error
+
+	validPullPolicies := map[kapi.PullPolicy]bool{
+		kapi.PullAlways:       true,
+		kapi.PullNever:        true,
+		kapi.PullIfNotPresent: true,
+	}
+	if !validPullPolicies[kapi.PullPolicy(s.AnsibleImagePullPolicy)] {
+		errs = append(errs, fmt.Errorf("%q is not a valid pull policy for the ansible image", s.AnsibleImagePullPolicy))
+	}
 
 	allControllersSet := sets.NewString(allControllers...)
 	for _, controller := range s.Controllers {

--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -5,6 +5,9 @@
   gather_facts: no
   vars:
     aws_section: default
+    use_real_aws: false
+    ansible_image: "fake-openshift-ansible:canary"
+    ansible_image_pull_policy: "Never"
   tasks:
   - name: create cluster-operator namespace
     command: oc create namespace cluster-operator
@@ -25,6 +28,11 @@
     when: cli_aws_section is defined
 
   - set_fact:
+      ansible_image: "openshift/origin-ansible:v3.8"
+      ansible_image_pull_policy: "Always"
+    when: use_real_aws
+
+  - set_fact:
       l_serving_ca: "{{ lookup('file', playbook_dir + '/../../ca.pem') | b64encode }}"
       l_serving_cert: "{{ lookup('file', playbook_dir + '/../../apiserver.pem') | b64encode }}"
       l_serving_key: "{{ lookup('file', playbook_dir + '/../../apiserver-key.pem') | b64encode }}"
@@ -33,7 +41,7 @@
 
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template
-    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p SERVING_CA={{ l_serving_ca }} -p SERVING_CERT={{ l_serving_cert }} -p SERVING_KEY={{ l_serving_key }} AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} | oc apply -f -"
+    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p SERVING_CA={{ l_serving_ca }} -p SERVING_CERT={{ l_serving_cert }} -p SERVING_KEY={{ l_serving_key }} AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} ANSIBLE_IMAGE={{ ansible_image }} ANSIBLE_IMAGE_PULL_POLICY={{ ansible_image_pull_policy }} | oc apply -f -"
 
 
 

--- a/contrib/examples/deploy.yaml
+++ b/contrib/examples/deploy.yaml
@@ -7,6 +7,8 @@
 #   SERVING_CERT: base-64-encoded, pem cert to use for ssl communication with the Cluster Operator API Server. Required.
 #   SERVING_KEY: base-64-encoded, pem private key for the cert to use for ssl communication with the Cluster Operator API Server. Required.
 #   SERVING_CA: base-64-encoded, pem CA cert for the ssl certs. Required.
+#   ANSIBLE_IMAGE: ansible image to use to run playbooks. Defaults to "fake-openshift-ansible:canary".
+#   ANSIBLE_IMAGE_PULL_POLICY: policy to use to pull the ansible image. Always, Never, or IfNotPresent. Defaults to "Never".
 #
 ########
 
@@ -304,6 +306,10 @@ objects:
           - "1"
           - --log-level
           - "debug"
+          - --ansible-image
+          - ${ANSIBLE_IMAGE}
+          - --ansible-image-pull-policy
+          - ${ANSIBLE_IMAGE_PULL_POLICY}
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -375,3 +381,9 @@ parameters:
 - name: SERVING_KEY
 - name: AWS_ACCESS_KEY_ID
 - name: AWS_SECRET_ACCESS_KEY
+# Ansible image to use for running playbooks
+- name: ANSIBLE_IMAGE
+  value: fake-openshift-ansible:canary
+# Policy for pulling the ansible image
+- name: ANSIBLE_IMAGE_PULL_POLICY
+  value: Never

--- a/contrib/fake-openshift-ansible/fake-openshift-ansible
+++ b/contrib/fake-openshift-ansible/fake-openshift-ansible
@@ -1,0 +1,19 @@
+#! /usr/bin/bash
+
+# Ensure that the playbook file exists.
+[ -z $PLAYBOOK_FILE ] && { echo "PLAYBOOK_FILE environment variable not set."; exit 1; }
+[ ! -f "${PLAYBOOK_FILE}" ] && { echo "Playbook file ${PLAYBOOK_FILE} not found."; exit 1; }
+
+# Ensure that the inventory file exists.
+[ -z $INVENTORY_FILE ] && { echo "INVENTORY_FILE environment variable not set."; exit 1; }
+[ ! -f "${INVENTORY_FILE}" ] && { echo "Inventory file ${INVENTORY_FILE} not found."; exit 1; }
+
+# Ensure that the AWS access key ID exists.
+[ -z $AWS_ACCESS_KEY_ID ] && { echo "AWS_ACCESS_KEY_ID environment variable not set."; exit 1; }
+
+# Ensure that the AWS secret access key exists.
+[ -z $AWS_SECRET_ACCESS_KEY ] && { echo "AWS_SECRET_ACCESS_KEY environment variable not set."; exit 1; }
+
+echo PLAYBOOK_FILE=${PLAYBOOK_FILE}
+echo INVENTORY_FILE=${INVENTORY_FILE}
+echo OPTS=${OPTS}

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -109,4 +109,10 @@ type ControllerManagerConfiguration struct {
 
 	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
 	EnableContentionProfiling bool
+
+	// ansibleImage is the name of the image to use to run ansible playbooks
+	AnsibleImage string
+
+	// ansibleImagePullPolicy is the pull policy to use for ansibleImage
+	AnsibleImagePullPolicy string
 }


### PR DESCRIPTION
* `make images` will now also build a fake-openshift-ansible image built on top of the openshift/origin-ansible image. This new image will not actually execute the playbook. All it does now is validate that certain environment variables are set and files exist. Eventually, the playbook will do more validation and log playbooks run to a server for further validation.
* The ansible image to use is configurable in controller-manager via command-line arguments.
* contrib/ansible/deploy-devel.yaml has been modified to allow the user to use either the fake image or connect to the real AWS. If the `use_real_aws` variable is set to true when running the playbook, then the real openshift-ansible image will be used, which connects to the real AWS.
* The echo command has been removed from `ansibleRunner` since the playbook execution can be avoided by using the fake image now.
* I have made the fake image the preference at this point because I want to avoid accidental resource allocations on AWS. I expect that once clust op is more mature we will make the default in the controller-manager the real image. I do expect that the development deployment will still prefer the fake image, but that the production deployment will prefer the real image.