### PR TITLE
Use username in cluster creation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@
   * If your image changed, but the kubernetes config did not, it is often required to delete all pods:
     * `oc delete pod --all -n cluster-operator`
 
+## Creating a Sample Cluster
+  * `contrib/examples/create-cluster.sh`
+
 ## Testing Provisioning
 
 Provisioning code is currently disabled to avoid doing anything unintentional
@@ -49,8 +52,6 @@ To enable and test:
 
   1. Enable using real AWS by supplying the use_real_aws parameter to the contrib/ansible/deploy-devel.yaml playbook.
 		* `ansible-playbook contrib/ansible/deploy-devel.yaml -e "use_real_aws=true"`
-  1. `cp ./contrib/examples/cluster.yaml ./contrib/examples/mycluster.yaml`
-  1. Edit mycluster.yaml and change the name to your username. This will allow you to find objects created in the AWS account to clean up.
-  1. `kubectl create -f ./contrib/examples/mycluster.yaml`
+  1. Create a Cluster. Prefer a name for the Cluster that is prefaced with your username. This makes it easier to associate to you resources created in the AWS, making them easier to find and clean up. By default, if you are using the contrib/examples/create-cluster.sh script, the cluster will be prefaced with your username.
   1. You should see some action in the controller manager logs, and a provisioning job and associated pod.
 

--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -1,12 +1,25 @@
-apiVersion: clusteroperator.openshift.io/v1alpha1
-kind: Cluster
+apiVersion: v1
+kind: Template
 metadata:
-  name: cluster1
-spec:
-  masterNodeGroup:
-    size: 1
-  computeNodeGroups:
-    - name: alpha
+  name: cluster-create-template
+objects:
+
+- apiVersion: clusteroperator.openshift.io/v1alpha1
+  kind: Cluster
+  metadata:
+    name: ${CLUSTER_NAME}
+  spec:
+    masterNodeGroup:
       size: 1
-    - name: beta
-      size: 2
+    computeNodeGroups:
+      - name: alpha
+        size: 1
+      - name: beta
+        size: 2
+
+parameters:
+- name: CLUSTER_NAME
+  displayName: Cluster Name
+  description: The name to give to the Cluster created. If using real AWS, then this name should include your username so that resources created in AWS can be identified as yours.
+  value: cluster1
+  required: true

--- a/contrib/examples/create-cluster.sh
+++ b/contrib/examples/create-cluster.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/bash
+
+oc process -f contrib/examples/cluster.yaml -p CLUSTER_NAME=$(whoami)-cluster | oc apply -f -


### PR DESCRIPTION
To avoid having to copy over the cluster.yaml file when using the real AWS, I created a template for creating clusters where the cluster name can be specified as a template parameter. I also created a script to use for creating a cluster that will default to creating a cluster whose name is prefaced with the user name. So, by default, if a cluster is created with the creation script, then the cluster will be named appropriately for use in AWS.