### PR TITLE
Create type for handling jobs for controllers

### DIFF
--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ansible
 
 import (
@@ -16,7 +32,18 @@ const (
 	openshiftAnsibleContainerDir = "/usr/share/ansible/openshift-ansible/"
 )
 
+// JobGenerator is used to generate jobs that run ansible playbooks.
 type JobGenerator interface {
+	// GeneratePlaybookJob generates a job to run the specified playbook.
+	// Note that neither the job nor the configmap will be created in the API
+	// server. It is the responsibility of the caller to create the objects
+	// in the API server.
+	//
+	// name - name to give the job and the configmap
+	// hardware - details of the hardware of the target cluster
+	// playbook - name of the playbook to run
+	// inventory - inventory to pass to the playbook
+	// vars - Ansible variables to the pass to the playbook
 	GeneratePlaybookJob(name string, hardware *clusteroperator.ClusterHardwareSpec, playbook, inventory, vars string) (*kbatch.Job, *kapi.ConfigMap)
 }
 
@@ -25,6 +52,13 @@ type jobGenerator struct {
 	imagePullPolicy kapi.PullPolicy
 }
 
+// NewJobGenerator creates a new JobGenerator that can be used to create
+// Ansible jobs.
+//
+// openshiftAnsibleImage - name of the openshift-ansible image that the
+//   jobs created by the job generator will use
+// openshiftAnsibleImagePullPolicy - policy to use to pull the
+//   openshift-ansible image
 func NewJobGenerator(openshiftAnsibleImage string, openshiftAnsibleImagePullPolicy kapi.PullPolicy) JobGenerator {
 	return &jobGenerator{
 		image:           openshiftAnsibleImage,

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -236,10 +236,10 @@ type ClusterStatus struct {
 	// For machine set hardware, see the status of each machine set resource.
 	Provisioned bool
 
-	// ProvisioningJobGeneration is the generation of the cluster resource used to
+	// ProvisionedJobGeneration is the generation of the cluster resource used to
 	// to generate the latest completed infra provisioning job. The value will be set
 	// regardless of the job having succeeded or failed.
-	ProvisioningJobGeneration int64
+	ProvisionedJobGeneration int64
 
 	// Running is true if the master of the cluster is running and can be accessed using
 	// the KubeconfigSecret

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -23,9 +23,9 @@ import (
 
 // Annotation constants
 const (
-	// ClusterGenerationAnnotation contains the generation of a cluster spec used to create
-	// a provisioning job
-	ClusterGenerationAnnotation = GroupName + "/cluster.generation"
+	// OwnerGenerationAnnotation contains the generation of the spec of the
+	// owner of a job
+	OwnerGenerationAnnotation = GroupName + "/owner.generation"
 )
 
 // +genclient
@@ -238,10 +238,10 @@ type ClusterStatus struct {
 	// For machine set hardware, see the status of each machine set resource.
 	Provisioned bool `json:"provisioned"`
 
-	// ProvisioningJobGeneration is the generation of the cluster resource used to
+	// ProvisionedJobGeneration is the generation of the cluster resource used to
 	// to generate the latest completed infra provisioning job. The value will be set
 	// regardless of the job having succeeded or failed.
-	ProvisioningJobGeneration int64 `json:"provisioningJobGeneration"`
+	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
 
 	// Running is true if the master of the cluster is running and can be accessed using
 	// the KubeconfigSecret

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -343,7 +343,7 @@ func autoConvert_v1alpha1_ClusterStatus_To_clusteroperator_ClusterStatus(in *Clu
 	out.InfraMachineSetName = in.InfraMachineSetName
 	out.AdminKubeconfig = (*v1.LocalObjectReference)(unsafe.Pointer(in.AdminKubeconfig))
 	out.Provisioned = in.Provisioned
-	out.ProvisioningJobGeneration = in.ProvisioningJobGeneration
+	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
 	out.Running = in.Running
 	out.Conditions = *(*[]clusteroperator.ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
@@ -360,7 +360,7 @@ func autoConvert_clusteroperator_ClusterStatus_To_v1alpha1_ClusterStatus(in *clu
 	out.InfraMachineSetName = in.InfraMachineSetName
 	out.AdminKubeconfig = (*v1.LocalObjectReference)(unsafe.Pointer(in.AdminKubeconfig))
 	out.Provisioned = in.Provisioned
-	out.ProvisioningJobGeneration = in.ProvisioningJobGeneration
+	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
 	out.Running = in.Running
 	out.Conditions = *(*[]ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	return nil

--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -496,9 +496,9 @@ func (c *InfraController) syncCluster(key string) error {
 
 	specChanged := cluster.Status.ProvisionedJobGeneration != cluster.Generation
 
-	jobFactory := c.getJobFactory(cluster, specChanged)
+	jobFactory := c.getJobFactory(cluster)
 
-	job, isJobNew, err := c.jobControl.ControlJobs(key, cluster, jobFactory, cLog)
+	job, isJobNew, err := c.jobControl.ControlJobs(key, cluster, specChanged, jobFactory, cLog)
 	if err != nil {
 		return err
 	}
@@ -604,10 +604,7 @@ func (f jobFactory) BuildJob(name string) (*v1batch.Job, *kapi.ConfigMap, error)
 	return f(name)
 }
 
-func (c *InfraController) getJobFactory(cluster *clusteroperator.Cluster, specChanged bool) controller.JobFactory {
-	if !specChanged {
-		return nil
-	}
+func (c *InfraController) getJobFactory(cluster *clusteroperator.Cluster) controller.JobFactory {
 	return jobFactory(func(name string) (*v1batch.Job, *kapi.ConfigMap, error) {
 		varsGenerator := ansible.NewVarsGenerator(cluster)
 		vars, err := varsGenerator.GenerateVars()

--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -530,7 +530,7 @@ func (c *InfraController) setClusterToNotProvisioning(original *clusteroperator.
 	cluster := original.DeepCopy()
 	now := metav1.Now()
 
-	clusterProvisioning := clusterCondition(cluster, clusteroperator.ClusterHardwareProvisioning)
+	clusterProvisioning := clusterCondition(cluster, clusteroperator.ClusterInfraProvisioning)
 	if clusterProvisioning != nil &&
 		clusterProvisioning.Status == kapi.ConditionTrue {
 		clusterProvisioning.Status = kapi.ConditionFalse

--- a/pkg/controller/jobcontrol.go
+++ b/pkg/controller/jobcontrol.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	kbatch "k8s.io/api/batch/v1"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage/names"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
+
+	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+)
+
+type JobControl interface {
+	// ControlJobs handles running/deleting jobs for the owner.
+	//
+	// ownerKey: key to identify the owner (namespace/name)
+	// owner: owner owning the jobs
+	// jobFactory: function to call to build a new job if one does not already
+	//   exist. if nil, then a new job is not needed.
+	// logger: logger to which to log
+	//
+	// Return:
+	//  (*kbatch.Job) current job
+	//  (bool) true if the current job was newly created
+	//  (error) error that preventing handling the jobs
+	ControlJobs(ownerKey string, owner metav1.Object, jobFactory JobFactory, logger log.FieldLogger) (*kbatch.Job, bool, error)
+
+	// ObserveOwnerDeletion observes that the owner with the specified key was
+	// deleted.
+	ObserveOwnerDeletion(ownerKey string)
+
+	// ObserveJobCreation observes that a job was created for the owner with
+	// the specified key.
+	ObserveJobCreation(ownerKey string, job *kbatch.Job)
+
+	// ObserveJobDeletion observes that a job created was deleted for the
+	// owner with the specified key.
+	ObserveJobDeletion(ownerKey string, job *kbatch.Job)
+
+	// IsControlledJob tests that the job is controlled by this control.
+	IsControlledJob(job *kbatch.Job) bool
+}
+
+type JobFactory interface {
+	BuildJob(name string) (*kbatch.Job, *kapi.ConfigMap, error)
+}
+
+type jobControl struct {
+	jobPrefix  string
+	ownerKind  schema.GroupVersionKind
+	kubeClient kubeclientset.Interface
+	jobsLister batchlisters.JobLister
+	// A TTLCache of job creations/deletions we're expecting to see
+	expectations *UIDTrackingControllerExpectations
+}
+
+// NewJobControl creates a new JobControl.
+func NewJobControl(jobPrefix string, ownerKind schema.GroupVersionKind, kubeClient kubeclientset.Interface, jobsLister batchlisters.JobLister) JobControl {
+	return &jobControl{
+		jobPrefix:    jobPrefix,
+		ownerKind:    ownerKind,
+		kubeClient:   kubeClient,
+		jobsLister:   jobsLister,
+		expectations: NewUIDTrackingControllerExpectations(NewControllerExpectations()),
+	}
+}
+
+func (c *jobControl) ControlJobs(ownerKey string, owner metav1.Object, jobFactory JobFactory, logger log.FieldLogger) (*kbatch.Job, bool, error) {
+	if !c.expectations.SatisfiedExpectations(ownerKey) {
+		// expectations have not been met, come back later
+		logger.Debugln("expectations have not been satisfied yet")
+		return nil, false, nil
+	}
+
+	// Look through jobs that belong to the owner and that match the type
+	// of job created by this control.
+	// If the job's generation corresponds to the owner's current
+	// generation, sync the owner status with the job's latest status.
+	// If the job does not correspond to the owner's current generation,
+	// delete the job.
+	oldJobs := []*kbatch.Job{}
+	var currentJob *kbatch.Job
+	jobs, err := c.jobsLister.Jobs(owner.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		return nil, false, err
+	}
+	for _, job := range jobs {
+		if !metav1.IsControlledBy(job, owner) {
+			continue
+		}
+		if !c.IsControlledJob(job) {
+			continue
+		}
+		if jobOwnerGeneration(job) == owner.GetGeneration() {
+			currentJob = job
+		} else {
+			logger.WithField("job", jobKey(job)).
+				Debugln("found job that does not correspond to owner's current generation")
+			oldJobs = append(oldJobs, job)
+		}
+	}
+
+	if len(oldJobs) > 0 {
+		return nil, false, c.deleteOldJobs(ownerKey, oldJobs, logger)
+	}
+
+	if currentJob != nil {
+		return currentJob, false, nil
+	}
+
+	if jobFactory != nil {
+		job, err := c.createJob(ownerKey, owner, jobFactory, logger)
+		return job, job != nil, err
+	}
+
+	return nil, false, nil
+}
+
+func (c *jobControl) ObserveOwnerDeletion(ownerKey string) {
+	c.expectations.DeleteExpectations(ownerKey)
+}
+
+func (c *jobControl) ObserveJobCreation(ownerKey string, job *kbatch.Job) {
+	c.expectations.CreationObserved(ownerKey)
+}
+
+func (c *jobControl) ObserveJobDeletion(ownerKey string, job *kbatch.Job) {
+	c.expectations.DeletionObserved(ownerKey, jobKey(job))
+}
+
+func (c *jobControl) IsControlledJob(job *kbatch.Job) bool {
+	return strings.HasPrefix(job.Name, c.jobPrefix)
+}
+
+func (c *jobControl) createJob(ownerKey string, owner metav1.Object, jobFactory JobFactory, logger log.FieldLogger) (*kbatch.Job, error) {
+	logger.Infof("Creating new %q job", c.jobPrefix)
+
+	name := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s%s-", c.jobPrefix, owner.GetName()))
+
+	job, configMap, err := jobFactory.BuildJob(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if job == nil {
+		return nil, nil
+	}
+
+	ownerRef := metav1.NewControllerRef(owner, c.ownerKind)
+
+	job.OwnerReferences = append(job.OwnerReferences, *ownerRef)
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations[clusteroperator.OwnerGenerationAnnotation] = fmt.Sprintf("%d", owner.GetGeneration())
+
+	cleanUpConfigMap := true
+	if configMap != nil {
+		configMap.OwnerReferences = append(configMap.OwnerReferences, *ownerRef)
+
+		configMap, err = c.kubeClient.CoreV1().ConfigMaps(owner.GetNamespace()).Create(configMap)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if configMap != nil && cleanUpConfigMap {
+				if err := c.kubeClient.CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{}); err != nil {
+					logger.Warnf("Could not delete config map %v/%v", configMap.Namespace, configMap.Name)
+				}
+			}
+		}()
+	}
+
+	if err := c.expectations.ExpectCreations(ownerKey, 1); err != nil {
+		return nil, err
+	}
+
+	newJob, err := c.kubeClient.BatchV1().Jobs(owner.GetNamespace()).Create(job)
+	if err != nil {
+		// If an error occurred creating the job, remove expectation
+		c.expectations.CreationObserved(ownerKey)
+		return nil, err
+	}
+
+	cleanUpConfigMap = false
+
+	return newJob, nil
+}
+
+func (c *jobControl) deleteOldJobs(ownerKey string, oldJobs []*kbatch.Job, logger log.FieldLogger) error {
+	keysToDelete := []string{}
+	for _, job := range oldJobs {
+		keysToDelete = append(keysToDelete, jobKey(job))
+	}
+	c.expectations.ExpectDeletions(ownerKey, keysToDelete)
+
+	logger.Infof("Deleting old jobs: %v", keysToDelete)
+
+	var errCh chan error
+
+	var wg sync.WaitGroup
+	wg.Add(len(oldJobs))
+	for i, ng := range oldJobs {
+		go func(ix int, job *kbatch.Job) {
+			defer wg.Done()
+			if err := c.kubeClient.BatchV1().Jobs(job.Namespace).Delete(job.Name, &metav1.DeleteOptions{}); err != nil {
+				// Decrement the expected number of deletes because the informer won't observe this deletion
+				jobKey := keysToDelete[ix]
+				logger.Infof("Failed to delete %v, decrementing expectations", jobKey)
+				c.expectations.DeletionObserved(ownerKey, jobKey)
+				errCh <- err
+			}
+		}(i, ng)
+	}
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		// all errors have been reported before and they're likely to be the same, so we'll only return the first one we hit.
+		if err != nil {
+			return err
+		}
+	default:
+	}
+	return nil
+}
+
+func jobOwnerGeneration(job *kbatch.Job) int64 {
+	if job.Annotations == nil {
+		return 0
+	}
+	generationStr, ok := job.Annotations[clusteroperator.OwnerGenerationAnnotation]
+	if !ok {
+		return 0
+	}
+	generation, err := strconv.ParseInt(generationStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return generation
+}
+
+func jobKey(job *kbatch.Job) string {
+	return fmt.Sprintf("%s/%s", job.Namespace, job.Name)
+}

--- a/pkg/controller/jobcontrol_test.go
+++ b/pkg/controller/jobcontrol_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	testlog "github.com/sirupsen/logrus/hooks/test"
+
+	kbatch "k8s.io/api/batch/v1"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeinformers "k8s.io/client-go/informers"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+)
+
+const (
+	testJobPrefix = "test-job-"
+	testOwnerKey  = "test-owner-key"
+)
+
+var (
+	testOwnerKind = schema.FromAPIVersionAndKind("test-api", "test-kind")
+)
+
+type testJobFactory struct {
+	responseJob       *kbatch.Job
+	responseConfigMap *kapi.ConfigMap
+	responseError     error
+	calls             []string
+}
+
+func newTestJobFactory(job *kbatch.Job, configMap *kapi.ConfigMap, err error) *testJobFactory {
+	factory := &testJobFactory{
+		responseError: err,
+	}
+	if job != nil {
+		factory.responseJob = job.DeepCopy()
+	}
+	if configMap != nil {
+		factory.responseConfigMap = configMap.DeepCopy()
+	}
+	return factory
+}
+
+func (f *testJobFactory) BuildJob(name string) (*kbatch.Job, *kapi.ConfigMap, error) {
+	f.calls = append(f.calls, name)
+	return f.responseJob, f.responseConfigMap, f.responseError
+}
+
+func newTestJobControl(jobPrefix string, ownerKind schema.GroupVersionKind) (
+	*jobControl,
+	cache.Store, // job store
+	*clientgofake.Clientset,
+) {
+	kubeClient := &clientgofake.Clientset{}
+	kubeInformers := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+
+	// Ensure that the return from creating a job is the job created, since
+	// jobControl.createJob uses the returned job.
+	kubeClient.AddReactor("create", "jobs", func(action clientgotesting.Action) (bool, kruntime.Object, error) {
+		return true, action.(clientgotesting.CreateAction).GetObject(), nil
+	})
+
+	c := NewJobControl(
+		jobPrefix,
+		ownerKind,
+		kubeClient,
+		kubeInformers.Batch().V1().Jobs().Lister(),
+	)
+
+	return c.(*jobControl),
+		kubeInformers.Batch().V1().Jobs().Informer().GetStore(),
+		kubeClient
+}
+
+func newTestOwner(generation int64) metav1.Object {
+	return &metav1.ObjectMeta{
+		Name:       "test-owner",
+		Generation: generation,
+	}
+}
+
+func newTestJob(name string) *kbatch.Job {
+	return &kbatch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func newTestControlledJob(namePrefix, nameEnding string, owner metav1.Object, ownerKind schema.GroupVersionKind, generation int64) *kbatch.Job {
+	return &kbatch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            namePrefix + nameEnding,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(owner, ownerKind)},
+			Annotations:     map[string]string{clusteroperator.OwnerGenerationAnnotation: strconv.FormatInt(generation, 10)},
+		},
+	}
+}
+
+func newTestConfigMap(name string) *kapi.ConfigMap {
+	return &kapi.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// TestJobControlWithoutNeedForNewJob tests controlling jobs when a new job
+// is not needed.
+func TestJobControlWithoutNeedForNewJob(t *testing.T) {
+	logger, hook := getTestLogger()
+	jobControl, _, _ := newTestJobControl(testJobPrefix, testOwnerKind)
+	testOwner := newTestOwner(1)
+	job, isNew, err := jobControl.ControlJobs(testOwnerKey, testOwner, nil, logger)
+	if err != nil {
+		t.Fatalf("no error expected: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("no job expected: %v", job)
+	}
+	if isNew {
+		t.Fatalf("job should not be created")
+	}
+	assertNoDireLogEntries(t, hook)
+}
+
+// TestJobControlWithPendingExpectations tests controlling jobs when there
+// are pending expectations that have not yet been met.
+func TestJobControlWithPendingExpectations(t *testing.T) {
+	logger, hook := getTestLogger()
+	jobControl, _, _ := newTestJobControl(testJobPrefix, testOwnerKind)
+	testOwner := newTestOwner(1)
+	jobControl.expectations.ExpectCreations(testOwnerKey, 1)
+	jobFactory := newTestJobFactory(nil, nil, nil)
+	job, isNew, err := jobControl.ControlJobs(testOwnerKey, testOwner, jobFactory, logger)
+	if err != nil {
+		t.Fatalf("no error expected: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("no job expected: %v", job)
+	}
+	if isNew {
+		t.Fatalf("job should not be created")
+	}
+	if len(jobFactory.calls) > 0 {
+		t.Fatalf("should not build new jobs while expectations pending")
+	}
+	assertNoDireLogEntries(t, hook)
+}
+
+// TestJobControlForNewJob tests controlling jobs when there are no existing
+// jobs and a new job is needed.
+func TestJobControlForNewJob(t *testing.T) {
+	logger, hook := getTestLogger()
+	jobControl, _, kubeClient := newTestJobControl(testJobPrefix, testOwnerKind)
+	testOwner := newTestOwner(1)
+	newJob := newTestJob("new-job")
+	newConfigMap := newTestConfigMap("new-configmap")
+	jobFactory := newTestJobFactory(newJob, newConfigMap, nil)
+	job, isNew, err := jobControl.ControlJobs(testOwnerKey, testOwner, jobFactory, logger)
+	if err != nil {
+		t.Fatalf("no error expected: %v", err)
+	}
+	if job == nil {
+		t.Fatalf("job expected")
+	}
+	if !isNew {
+		t.Fatalf("job should be created")
+	}
+	if e, a := 1, len(jobFactory.calls); e != a {
+		t.Fatalf("unexpected number of calls to build jobs: expected %v, got %v", e, a)
+	}
+	if e, a := newJob.Name, job.Name; e != a {
+		t.Fatalf("unexpected job created: expected %v, got %v", e, a)
+	}
+	actions := kubeClient.Actions()
+	if e, a := 2, len(actions); e != a {
+		t.Fatalf("unexpected number of kube client actions: expected %v, got %v", e, a)
+	}
+	{
+		createAction, ok := actions[0].(clientgotesting.CreateAction)
+		if !ok {
+			t.Fatalf("first action was not a create: %v", actions[0])
+		}
+		createdObject := createAction.GetObject()
+		configMap, ok := createdObject.(*kapi.ConfigMap)
+		if !ok {
+			t.Fatalf("first action created object is not a configmap")
+		}
+		if e, a := newConfigMap.Name, configMap.Name; e != a {
+			t.Fatalf("created configmap does not match expected: expected %v, got %v", e, a)
+		}
+	}
+	{
+		createAction, ok := actions[1].(clientgotesting.CreateAction)
+		if !ok {
+			t.Fatalf("second action was not a create: %v", actions[0])
+		}
+		createdObject := createAction.GetObject()
+		createdJob, ok := createdObject.(*kbatch.Job)
+		if !ok {
+			t.Fatalf("second action created object is not a job")
+		}
+		if e, a := newJob.Name, createdJob.Name; e != a {
+			t.Fatalf("created job does not match expected: expected %v, got %v", e, a)
+		}
+	}
+	assertNoDireLogEntries(t, hook)
+}
+
+// TestJobControlForExistingJob tests controlling jobs when there is an
+// existing job for the current generation of the owner.
+func TestJobControlForExistingJob(t *testing.T) {
+	logger, hook := getTestLogger()
+	jobControl, jobStore, kubeClient := newTestJobControl(testJobPrefix, testOwnerKind)
+	testOwner := newTestOwner(1)
+	existingJob := newTestControlledJob(testJobPrefix, "existing-job", testOwner, testOwnerKind, 1)
+	jobStore.Add(existingJob)
+	newJob := newTestJob("new-job")
+	newConfigMap := newTestConfigMap("new-configmap")
+	jobFactory := newTestJobFactory(newJob, newConfigMap, nil)
+	job, isNew, err := jobControl.ControlJobs(testOwnerKey, testOwner, jobFactory, logger)
+	if err != nil {
+		t.Fatalf("no error expected: %v", err)
+	}
+	if job == nil {
+		t.Fatalf("job expected")
+	}
+	if isNew {
+		t.Fatalf("job should not be created")
+	}
+	if e, a := 0, len(jobFactory.calls); e != a {
+		t.Fatalf("unexpected number of calls to build jobs: expected %v, got %v", e, a)
+	}
+	if e, a := existingJob.Name, job.Name; e != a {
+		t.Fatalf("unexpected job returned: expected %v, got %v", e, a)
+	}
+	actions := kubeClient.Actions()
+	if e, a := 0, len(actions); e != a {
+		t.Fatalf("unexpected number of kube client actions: expected %v, got %v", e, a)
+	}
+	assertNoDireLogEntries(t, hook)
+}
+
+// TestJobControlForExistingOldJob tests controlling jobs whene there is an
+// existing job for an older generation of the owner.
+func TestJobControlForExistingOldJob(t *testing.T) {
+	logger, hook := getTestLogger()
+	jobControl, jobStore, kubeClient := newTestJobControl(testJobPrefix, testOwnerKind)
+	testOwner := newTestOwner(2)
+	existingJob := newTestControlledJob(testJobPrefix, "existing-job", testOwner, testOwnerKind, 1)
+	jobStore.Add(existingJob)
+	newJob := newTestJob("new-job")
+	newConfigMap := newTestConfigMap("new-configmap")
+	jobFactory := newTestJobFactory(newJob, newConfigMap, nil)
+	job, _, err := jobControl.ControlJobs(testOwnerKey, testOwner, jobFactory, logger)
+	if err != nil {
+		t.Fatalf("no error expected: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("unexpected job: %v", job)
+	}
+	if e, a := 0, len(jobFactory.calls); e != a {
+		t.Fatalf("unexpected number of calls to build jobs: expected %v, got %v", e, a)
+	}
+	actions := kubeClient.Actions()
+	if e, a := 1, len(actions); e != a {
+		t.Fatalf("unexpected number of kube client actions: expected %v, got %v", e, a)
+	}
+	{
+		deleteAction, ok := actions[0].(clientgotesting.DeleteAction)
+		if !ok {
+			t.Fatalf("first action was not a delete: %v", actions[0])
+		}
+		deletedObjectName := deleteAction.GetName()
+		if e, a := existingJob.Name, deletedObjectName; e != a {
+			t.Fatalf("deleted job does not match expected: expected %v, got %v", e, a)
+		}
+	}
+	assertNoDireLogEntries(t, hook)
+}
+
+func getTestLogger() (log.FieldLogger, *testlog.Hook) {
+	logger := log.StandardLogger()
+	hook := testlog.NewLocal(logger)
+	function, _, _, _ := runtime.Caller(1)
+	fieldLogger := logger.WithField("test", runtime.FuncForPC(function).Name())
+	return fieldLogger, hook
+}
+
+func assertNoDireLogEntries(t *testing.T, hook *testlog.Hook) {
+	for _, entry := range hook.Entries {
+		if entry.Level < log.InfoLevel {
+			t.Fatalf("Encountered dire log entry: %v", entry)
+		}
+	}
+}

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -47,10 +47,35 @@ const (
 	//
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
+
+	controllerLogName = "master"
+
+	infraPlaybook = "playbooks/aws/openshift-cluster/install.yml"
+	// jobPrefix is used when generating a name for the configmap and job used for each
+	// Ansible execution.
+	jobPrefix = "job-master-"
 )
 
+const provisionInventoryTemplate = `
+[OSEv3:children]
+masters
+
+[OSEv3:vars]
+
+[masters]
+`
+
+var machineSetKind = clusteroperator.SchemeGroupVersion.WithKind("MachineSet")
+
 // NewMasterController returns a new *MasterController.
-func NewMasterController(machineInformer informers.MachineInformer, kubeClient kubeclientset.Interface, clusteroperatorClient clusteroperatorclientset.Interface) *MasterController {
+func NewMasterController(
+	machineSetInformer informers.MachineSetInformer,
+	jobInformer batchinformers.JobInformer,
+	kubeClient kubeclientset.Interface,
+	clusteroperatorClient clusteroperatorclientset.Interface,
+	ansibleImage string,
+	ansibleImagePullPolicy kapi.PullPolicy,
+) *MasterController {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
@@ -60,12 +85,15 @@ func NewMasterController(machineInformer informers.MachineInformer, kubeClient k
 		metrics.RegisterMetricAndTrackRateLimiterUsage("clusteroperator_master_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
 	}
 
+	logger := log.WithField("controller", controllerLogName)
 	c := &MasterController{
-		client: clusteroperatorClient,
-		queue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "master"),
+		coClient:   clusteroperatorClient,
+		kubeClient: kubeClient,
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "master"),
+		logger:     logger,
 	}
 
-	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	machineSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addMachine,
 		UpdateFunc: c.updateMachine,
 		DeleteFunc: c.deleteMachine,

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -444,9 +444,9 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
-						"provisioningJobGeneration": {
+						"provisionedJobGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ProvisioningJobGeneration is the generation of the cluster resource used to to generate the latest completed infra provisioning job. The value will be set regardless of the job having succeeded or failed.",
+								Description: "ProvisionedJobGeneration is the generation of the cluster resource used to to generate the latest completed infra provisioning job. The value will be set regardless of the job having succeeded or failed.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},
@@ -472,7 +472,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"machineSetCount", "provisioned", "provisioningJobGeneration", "running", "conditions"},
+					Required: []string{"machineSetCount", "provisioned", "provisionedJobGeneration", "running", "conditions"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
`JobControl` can be re-used by other controllers (master, machineset) that need to start jobs to do work.