### PR TITLE
Use latest tag for origin-ansible which now contains boto deps.

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -28,7 +28,7 @@
     when: cli_aws_section is defined
 
   - set_fact:
-      ansible_image: "openshift/origin-ansible:v3.8"
+      ansible_image: "openshift/origin-ansible:latest"
       ansible_image_pull_policy: "Always"
     when: use_real_aws
 


### PR DESCRIPTION
This change hasn't yet appeared in the v3.9 tag so latest will have to
do for now.