### PR TITLE
cluster infra delete/deprovision

### DIFF
--- a/build/fake-openshift-ansible/Dockerfile
+++ b/build/fake-openshift-ansible/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openshift/origin-ansible:v3.8
+FROM openshift/origin-ansible:latest
 
 ADD fake-openshift-ansible /usr/local/bin
 

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -44,6 +44,11 @@ type Cluster struct {
 	Status ClusterStatus
 }
 
+// finalizer values unique to cluster-operator
+const (
+	FinalizerClusterOperator string = "openshift/cluster-operator"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterList is a list of Clusters.

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -44,6 +44,11 @@ type Cluster struct {
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
+// finalizer values unique to cluster-operator
+const (
+	FinalizerClusterOperator string = "openshift/cluster-operator"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterList is a list of Clusters.

--- a/pkg/registry/clusteroperator/cluster/strategy.go
+++ b/pkg/registry/clusteroperator/cluster/strategy.go
@@ -91,6 +91,7 @@ func (clusterRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
+	cluster.Finalizers = []string{clusteroperator.FinalizerClusterOperator}
 	cluster.Generation = 1
 	cluster.Status = clusteroperator.ClusterStatus{}
 }

--- a/pkg/registry/clusteroperator/cluster/strategy.go
+++ b/pkg/registry/clusteroperator/cluster/strategy.go
@@ -91,7 +91,6 @@ func (clusterRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
-	cluster.Finalizers = []string{clusteroperator.FinalizerClusterOperator}
 	cluster.Generation = 1
 	cluster.Status = clusteroperator.ClusterStatus{}
 }


### PR DESCRIPTION
Add some handling in syncCluster() for when a cluster object has been marked for deletion

Fire off a non-JobControl(ed) job to run the 'uninstall_prerequisites.yml' playbook to remove the infra pieces

Update from the origin-ansible:v3.8 to 'latest' since that's where the uninstall/deprovision playbooks exist.