### PR TITLE
Swap prerequisites playbook for CO infrastructure playbook

### DIFF
--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -57,7 +57,7 @@ const (
 
 	controllerLogName = "infra"
 
-	infraPlaybook = "playbooks/aws/openshift-cluster/prerequisites.yml"
+	infraPlaybook = "playbooks/cluster-operator/aws/infrastructure.yml"
 	// jobPrefix is used when generating a name for the configmap and job used for each
 	// Ansible execution.
 	jobPrefix = "job-infra-"


### PR DESCRIPTION
Call combined cluster-operator infrastructure playbook in place of openshift-ansible AWS prerequisites playbook.

playbooks/cluster-operator/aws/infrastructure.yml is responsible for creating:
* VPC
* SSH keypair
* security groups
* S3 bucket (added)
* ELB (added)