### PR TITLE
Clean up code to pass make verify

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -447,7 +447,7 @@ func startClusterController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "clusters"}] {
 		return false, nil
 	}
-	go cluster.NewClusterController(
+	go cluster.NewController(
 		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-cluster-controller"),
@@ -460,7 +460,7 @@ func startInfraController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "clusters"}] {
 		return false, nil
 	}
-	go infra.NewInfraController(
+	go infra.NewController(
 		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-infra-controller"),
@@ -475,7 +475,7 @@ func startMachineSetController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machinesets"}] {
 		return false, nil
 	}
-	go machineset.NewMachineSetController(
+	go machineset.NewController(
 		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
@@ -491,7 +491,7 @@ func startMachineController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machines"}] {
 		return false, nil
 	}
-	go machine.NewMachineController(
+	go machine.NewController(
 		ctx.InformerFactory.Clusteroperator().V1alpha1().Machines(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-machine-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-machine-controller"),
@@ -503,7 +503,7 @@ func startMasterController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machinesets"}] {
 		return false, nil
 	}
-	go master.NewMasterController(
+	go master.NewController(
 		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),

--- a/cmd/cluster-operator/apiserver.go
+++ b/cmd/cluster-operator/apiserver.go
@@ -39,6 +39,4 @@ func NewAPIServer() *hyperkube.Server {
 	}
 	s.AddFlags(hks.Flags())
 	return &hks
-
-	return nil
 }

--- a/cmd/cluster-operator/controller-manager.go
+++ b/cmd/cluster-operator/controller-manager.go
@@ -39,6 +39,4 @@ func NewControllerManager() *hyperkube.Server {
 	}
 	s.AddFlags(hks.Flags(), app.KnownControllers(), app.ControllersDisabledByDefault.List())
 	return &hks
-
-	return nil
 }

--- a/contrib/examples/create-cluster.sh
+++ b/contrib/examples/create-cluster.sh
@@ -1,5 +1,19 @@
 #! /bin/bash
 
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 oc get secret aws-credentials -n cluster-operator -o yaml | sed -E '/(namespace:|annotations|last-applied-configuration:|selfLink|uid:|resourceVersion:)/d' | oc apply -f -

--- a/contrib/examples/get-playbook-mock-runs.sh
+++ b/contrib/examples/get-playbook-mock-runs.sh
@@ -1,7 +1,22 @@
-#! /usr/bin/bash
+#! /bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # get-playbook-mock-runs queries the playbook-mock server for the playbook runs that
 # it has logged.
-#
+
+set -o errexit
 
 curl --silent http://$(oc get service -n cluster-operator playbook-mock -o json | jq -r .spec.clusterIP) | jq '.'

--- a/contrib/fake-openshift-ansible/fake-openshift-ansible
+++ b/contrib/fake-openshift-ansible/fake-openshift-ansible
@@ -1,10 +1,11 @@
-#! /usr/bin/bash
+#! /bin/bash
 #
 # fake-openshift-ansible is used for testing cluster-operator without creating resources
 # on AWS. Instead of running the real ansible playbooks, fake-openshift-ansible verifies
 # that the playbook exists and logs the action with the playbook-mock server.
 #
 
+set -o errexit
 
 # Ensure that the playbook file exists.
 [ -z $PLAYBOOK_FILE ] && { echo "PLAYBOOK_FILE environment variable not set."; exit 1; }

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ansible
 
 import (
@@ -292,6 +308,8 @@ type machineSetParams struct {
 	InstanceType string
 }
 
+// GenerateClusterVars generates the vars to pass to the ansible playbook
+// for the cluster.
 func GenerateClusterVars(cluster *coapi.Cluster) (string, error) {
 
 	// Currently only AWS is supported. If we don't have an AWS cluster spec, return an error
@@ -323,6 +341,8 @@ func GenerateClusterVars(cluster *coapi.Cluster) (string, error) {
 	return buf.String(), nil
 }
 
+// GenerateMachineSetVars generates the vars to pass to the ansible playbook
+// for the machine set. The machine set must belong to the cluster.
 func GenerateMachineSetVars(cluster *coapi.Cluster, machineSet *coapi.MachineSet) (string, error) {
 	commonVars, err := GenerateClusterVars(cluster)
 	if err != nil {

--- a/pkg/ansible/generate_test.go
+++ b/pkg/ansible/generate_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ansible
 
 import (

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -97,6 +97,7 @@ type ClusterVersionStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// ClusterVersionList is a list of ClusterVersions.
 type ClusterVersionList struct {
 	metav1.TypeMeta
 	// +optional
@@ -511,11 +512,13 @@ type MachineList struct {
 	Items []Machine
 }
 
+// MachineSpec is the specificiation of a Machine.
 type MachineSpec struct {
 	// NodeType is the type of the node in this machine
 	NodeType NodeType
 }
 
+// MachineStatus is the status of a Machine.
 type MachineStatus struct {
 }
 

--- a/pkg/apis/clusteroperator/v1alpha1/conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/conversion.go
@@ -32,7 +32,7 @@ func ClusterFieldLabelConversionFunc(label, value string) (string, string, error
 	}
 }
 
-// NodeGroupFieldLabelConversionFunc does not convert anything, just returns
+// MachineSetFieldLabelConversionFunc does not convert anything, just returns
 // what it's given for the supported fields, and errors for unsupported.
 func MachineSetFieldLabelConversionFunc(label, value string) (string, string, error) {
 	switch label {

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -99,6 +99,7 @@ type ClusterVersionStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// ClusterVersionList is a list of ClusterVersions.
 type ClusterVersionList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -513,11 +514,13 @@ type MachineList struct {
 	Items []Machine `json:"items"`
 }
 
+// MachineSpec is the specificiation of a Machine.
 type MachineSpec struct {
 	// NodeType is the type of the node
 	NodeType NodeType `json:"nodeType"`
 }
 
+// MachineStatus is the status of a Machine.
 type MachineStatus struct {
 }
 

--- a/pkg/apis/clusteroperator/validation/clusterversion.go
+++ b/pkg/apis/clusteroperator/validation/clusterversion.go
@@ -40,6 +40,7 @@ func ValidateClusterVersionStatusUpdate(new *clusteroperator.ClusterVersion, old
 	return allErrs
 }
 
+// ValidateClusterVersionSpec validates the spec of a ClusterVersion.
 func ValidateClusterVersionSpec(spec *clusteroperator.ClusterVersionSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if spec.ImageFormat == "" {
@@ -59,6 +60,7 @@ func ValidateClusterVersionSpec(spec *clusteroperator.ClusterVersionSpec, fldPat
 	return allErrs
 }
 
+// ValidateYumRepository validates a yum repository.
 func ValidateYumRepository(repo *clusteroperator.YumRepository, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/apis/clusteroperator/validation/machineset_test.go
+++ b/pkg/apis/clusteroperator/validation/machineset_test.go
@@ -44,7 +44,7 @@ func getValidMachineSet() *clusteroperator.MachineSet {
 			OwnerReferences: []metav1.OwnerReference{getValidClusterOwnerRef()},
 		},
 		Spec: clusteroperator.MachineSetSpec{
-			clusteroperator.MachineSetConfig{
+			MachineSetConfig: clusteroperator.MachineSetConfig{
 				NodeType: clusteroperator.NodeTypeMaster,
 				Size:     1,
 			},
@@ -409,7 +409,7 @@ func TestValidateMachineSetSpec(t *testing.T) {
 		{
 			name: "valid",
 			spec: &clusteroperator.MachineSetSpec{
-				clusteroperator.MachineSetConfig{
+				MachineSetConfig: clusteroperator.MachineSetConfig{
 					NodeType: clusteroperator.NodeTypeMaster,
 					Size:     1,
 				},
@@ -419,7 +419,7 @@ func TestValidateMachineSetSpec(t *testing.T) {
 		{
 			name: "invalid node type",
 			spec: &clusteroperator.MachineSetSpec{
-				clusteroperator.MachineSetConfig{
+				MachineSetConfig: clusteroperator.MachineSetConfig{
 					NodeType: clusteroperator.NodeType(""),
 					Size:     1,
 				},
@@ -428,7 +428,7 @@ func TestValidateMachineSetSpec(t *testing.T) {
 		{
 			name: "invalid size",
 			spec: &clusteroperator.MachineSetSpec{
-				clusteroperator.MachineSetConfig{
+				MachineSetConfig: clusteroperator.MachineSetConfig{
 					NodeType: clusteroperator.NodeTypeMaster,
 					Size:     0,
 				},

--- a/pkg/controller/client_utils.go
+++ b/pkg/controller/client_utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -147,11 +147,11 @@ func FindClusterCondition(cluster *clusteroperator.Cluster, conditionType cluste
 	return nil
 }
 
-// SetClusterCondition sets the condition for the cluster.
-// If the cluster does not already have a condition with the specified type,
-// a condition will be added to the cluster if and only if the specified
-// status is True.
-// If the cluster does already have a condition with the specified type,
+// SetMachineSetCondition sets the condition for the machine set.
+// If the machine set does not already have a condition with the specified
+// type, a condition will be added to the machine set if and only if the
+// specified status is True.
+// If the machine set does already have a condition with the specified type,
 // the condition will be updated if either of the following are true.
 // 1) Requested status is different than existing status.
 // 2) The updateConditionCheck function returns true.

--- a/pkg/controller/expectations_test.go
+++ b/pkg/controller/expectations_test.go
@@ -25,19 +25,19 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// NewFakeControllerExpectationsLookup creates a fake store for PodExpectations.
-func NewFakeControllerExpectationsLookup(ttl time.Duration) (*ControllerExpectations, *clock.FakeClock) {
+// NewFakeExpectationsLookup creates a fake store for PodExpectations.
+func NewFakeExpectationsLookup(ttl time.Duration) (*Expectations, *clock.FakeClock) {
 	fakeTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	fakeClock := clock.NewFakeClock(fakeTime)
 	ttlPolicy := &cache.TTLPolicy{Ttl: ttl, Clock: fakeClock}
 	ttlStore := cache.NewFakeExpirationStore(
 		ExpKeyFunc, nil, ttlPolicy, fakeClock)
-	return &ControllerExpectations{ttlStore}, fakeClock
+	return &Expectations{ttlStore}, fakeClock
 }
 
-func TestControllerExpectations(t *testing.T) {
+func TestExpectations(t *testing.T) {
 	ttl := 30 * time.Second
-	e, fakeClock := NewFakeControllerExpectationsLookup(ttl)
+	e, fakeClock := NewFakeExpectationsLookup(ttl)
 
 	adds, dels := 10, 30
 	ownerKey := "owner-key"

--- a/pkg/controller/jobcontrol.go
+++ b/pkg/controller/jobcontrol.go
@@ -40,15 +40,28 @@ import (
 
 //go:generate mockgen -source=./jobcontrol.go -destination=./mockjobcontrol_generated_test.go -package=controller
 
+// JobControlResult describes what was done by a call to
+// JobControl.ControlJobs.
 type JobControlResult string
 
 const (
+	// JobControlPendingExpectations indicates that no work was done because
+	// there are pending expectations that need to be met first.
 	JobControlPendingExpectations JobControlResult = "PendingExpectations"
-	JobControlNoWork              JobControlResult = "NoWork"
-	JobControlJobWorking          JobControlResult = "JobWorking"
-	JobControlCreatingJob         JobControlResult = "CreatingJob"
-	JobControlDeletingJobs        JobControlResult = "DeletingJobs"
-	JobControlLostCurrentJob      JobControlResult = "LostCurrentJob"
+	// JobControlNoWork indicates that no work was done because the owner
+	// is already up to date and there are no outstanding jobs.
+	JobControlNoWork JobControlResult = "NoWork"
+	// JobControlJobWorking indicates that there is an outstanding job
+	// processing the current generation of the owner.
+	JobControlJobWorking JobControlResult = "JobWorking"
+	// JobControlCreatingJob indicates that a job is being created to process
+	// the current generation of the owner.
+	JobControlCreatingJob JobControlResult = "CreatingJob"
+	// JobControlDeletingJobs indicates that outdated jobs are being deleted.
+	JobControlDeletingJobs JobControlResult = "DeletingJobs"
+	// JobControlLostCurrentJob indicates that there was an outstanding job
+	// that can no longer be found.
+	JobControlLostCurrentJob JobControlResult = "LostCurrentJob"
 )
 
 // JobControl is used to control jobs that are needed by a controller.
@@ -120,7 +133,7 @@ type jobControl struct {
 	ownerControl JobOwnerControl
 	logger       log.FieldLogger
 	// A TTLCache of job creations/deletions we're expecting to see
-	expectations *UIDTrackingControllerExpectations
+	expectations *UIDTrackingExpectations
 }
 
 // NewJobControl creates a new JobControl.
@@ -140,7 +153,7 @@ func NewJobControl(
 		jobsLister:   jobsLister,
 		ownerControl: ownerControl,
 		logger:       logger,
-		expectations: NewUIDTrackingControllerExpectations(NewControllerExpectations()),
+		expectations: NewUIDTrackingExpectations(NewExpectations()),
 	}
 }
 

--- a/pkg/controller/uidtrackingexpectations_test.go
+++ b/pkg/controller/uidtrackingexpectations_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestUIDExpectations(t *testing.T) {
-	uidExp := NewUIDTrackingControllerExpectations(NewControllerExpectations())
+	uidExp := NewUIDTrackingExpectations(NewExpectations())
 	ownersList := []struct {
 		name  string
 		count int
@@ -47,7 +47,7 @@ func TestUIDExpectations(t *testing.T) {
 		ownerKeys[i] = owner.name
 		childNames := make([]string, owner.count)
 		for j := 0; j < owner.count; j++ {
-			childNames[j] = fmt.Sprint("%v-%v", owner.name, j)
+			childNames[j] = fmt.Sprintf("%v-%v", owner.name, j)
 		}
 		ownerToChild[owner.name] = childNames
 		uidExp.ExpectDeletions(owner.name, childNames)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -533,6 +533,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterVersionList": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
+					Description: "ClusterVersionList is a list of ClusterVersions.",
 					Properties: map[string]spec.Schema{
 						"kind": {
 							SchemaProps: spec.SchemaProps{
@@ -1067,6 +1068,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSpec": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
+					Description: "MachineSpec is the specificiation of a Machine.",
 					Properties: map[string]spec.Schema{
 						"nodeType": {
 							SchemaProps: spec.SchemaProps{
@@ -1084,7 +1086,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineStatus": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Properties: map[string]spec.Schema{},
+					Description: "MachineStatus is the status of a Machine.",
+					Properties:  map[string]spec.Schema{},
 				},
 			},
 			Dependencies: []string{},

--- a/pkg/registry/clusteroperator/cluster/storage_test.go
+++ b/pkg/registry/clusteroperator/cluster/storage_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, clusteroperatorapi.GroupName)
+	etcdStorage, server := registrytest.NewEtcdStorage(t)
 	restOptions := generic.RESTOptions{
 		StorageConfig:           etcdStorage,
 		Decorator:               generic.UndecoratedStorage,

--- a/pkg/registry/clusteroperator/clusterversion/storage_test.go
+++ b/pkg/registry/clusteroperator/clusterversion/storage_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, clusteroperatorapi.GroupName)
+	etcdStorage, server := registrytest.NewEtcdStorage(t)
 	restOptions := generic.RESTOptions{
 		StorageConfig:           etcdStorage,
 		Decorator:               generic.UndecoratedStorage,

--- a/pkg/registry/clusteroperator/machine/storage_test.go
+++ b/pkg/registry/clusteroperator/machine/storage_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, clusteroperatorapi.GroupName)
+	etcdStorage, server := registrytest.NewEtcdStorage(t)
 	restOptions := generic.RESTOptions{
 		StorageConfig:           etcdStorage,
 		Decorator:               generic.UndecoratedStorage,

--- a/pkg/registry/clusteroperator/machineset/storage_test.go
+++ b/pkg/registry/clusteroperator/machineset/storage_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServer) {
-	etcdStorage, server := registrytest.NewEtcdStorage(t, clusteroperatorapi.GroupName)
+	etcdStorage, server := registrytest.NewEtcdStorage(t)
 	restOptions := generic.RESTOptions{
 		StorageConfig:           etcdStorage,
 		Decorator:               generic.UndecoratedStorage,
@@ -57,7 +57,7 @@ func validNewMachineSet(name string) *clusteroperatorapi.MachineSet {
 			},
 		},
 		Spec: clusteroperatorapi.MachineSetSpec{
-			clusteroperatorapi.MachineSetConfig{
+			MachineSetConfig: clusteroperatorapi.MachineSetConfig{
 				NodeType: clusteroperatorapi.NodeTypeMaster,
 				Size:     1,
 			},

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -30,7 +30,8 @@ import (
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
-func NewEtcdStorage(t *testing.T, group string) (*storagebackend.Config, *etcdtesting.EtcdTestServer) {
+// NewEtcdStorage creates a new etcd storage for the clusteroperator schema.
+func NewEtcdStorage(t *testing.T) (*storagebackend.Config, *etcdtesting.EtcdTestServer) {
 	server, config := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 	mediaType, _, err := mime.ParseMediaType(runtime.ContentTypeJSON)
 	if err != nil {

--- a/test/integration/clustercontroller_test.go
+++ b/test/integration/clustercontroller_test.go
@@ -206,7 +206,7 @@ func startServerAndClusterController(t *testing.T) (
 	clusterOperatorSharedInformers := informerFactory.Clusteroperator().V1alpha1()
 
 	// create a test controller
-	testController := clustercontroller.NewClusterController(
+	testController := clustercontroller.NewController(
 		clusterOperatorSharedInformers.Clusters(),
 		clusterOperatorSharedInformers.MachineSets(),
 		fakeKubeClient,


### PR DESCRIPTION
With these changes `make verify` runs with no errors.

Most of the changes are one of two varieties.
* Adding or adjusting comments.
* Renaming types to eliminate stutter. For example, `cluster.ClusterController` is replaced by `cluster.Controller`.