### PR TITLE
Implement master controller

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -488,7 +488,7 @@ func startMachineSetController(ctx ControllerContext) (bool, error) {
 }
 
 func startMachineController(ctx ControllerContext) (bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "nodes"}] {
+	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machines"}] {
 		return false, nil
 	}
 	go machine.NewMachineController(
@@ -500,13 +500,17 @@ func startMachineController(ctx ControllerContext) (bool, error) {
 }
 
 func startMasterController(ctx ControllerContext) (bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "nodes"}] {
+	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machinesets"}] {
 		return false, nil
 	}
 	go master.NewMasterController(
-		ctx.InformerFactory.Clusteroperator().V1alpha1().Machines(),
-		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-master-node-controller"),
-		ctx.ClientBuilder.ClientOrDie("clusteroperator-master-node-controller"),
+		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
+		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
+		ctx.KubeInformerFactory.Batch().V1().Jobs(),
+		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-master-controller"),
+		ctx.ClientBuilder.ClientOrDie("clusteroperator-master-controller"),
+		ctx.Options.AnsibleImage,
+		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentMasterSyncs), ctx.Stop)
 	return true, nil
 }

--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -18,6 +18,7 @@ package ansible
 
 import (
 	"path"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -208,7 +209,8 @@ func (r *jobGenerator) GeneratePlaybookJob(name string, hardware *clusteroperato
 	}
 
 	completions := int32(1)
-	deadline := int64(60 * 60) // one hour for now
+	deadline := int64((24 * time.Hour).Seconds())
+	backoffLimit := int32(123456) // effectively limitless
 
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -217,6 +219,7 @@ func (r *jobGenerator) GeneratePlaybookJob(name string, hardware *clusteroperato
 		Spec: kbatch.JobSpec{
 			Completions:           &completions,
 			ActiveDeadlineSeconds: &deadline,
+			BackoffLimit:          &backoffLimit,
 			Template: kapi.PodTemplateSpec{
 				Spec: podSpec,
 			},

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -448,6 +448,18 @@ const (
 	// this machine set have been provisioned (ie. AWS autoscaling group)
 	MachineSetHardwareProvisioned MachineSetConditionType = "HardwareProvisioned"
 
+	// MachineSetHardwareInstalling is true if OpenShift is being installed on
+	// this machine set.
+	MachineSetInstalling MachineSetConditionType = "Installing"
+
+	// MachineSetHardwareInstallationFailed is true if the installation of
+	// OpenShift on this machine set failed.
+	MachineSetInstallationFailed MachineSetConditionType = "InstallationFailed"
+
+	// MachineSetHardwareInstalled is true if OpenShift has been installed
+	// on this machine set.
+	MachineSetInstalled MachineSetConditionType = "Installed"
+
 	// MachineSetHardwareReady is true if the hardware for the nodegroup is in ready
 	// state (is started and healthy)
 	MachineSetHardwareReady MachineSetConditionType = "HardwareReady"

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -253,6 +253,11 @@ type ClusterStatus struct {
 	// regardless of the job having succeeded or failed.
 	ProvisionedJobGeneration int64
 
+	// ProvisionJob is the job that is actively performing provisioning
+	// on the cluster.
+	// +optional
+	ProvisionJob *corev1.LocalObjectReference
+
 	// Running is true if the master of the cluster is running and can be accessed using
 	// the KubeconfigSecret
 	Running bool
@@ -401,6 +406,11 @@ type MachineSetStatus struct {
 	// regardless of the job having succeeded or failed.
 	InstalledJobGeneration int64
 
+	// InstallationJob is the job that is actively performing installation
+	// on the machine set.
+	// +optional
+	InstallationJob *corev1.LocalObjectReference
+
 	// Provisioned is true if the hardware that corresponds to this MachineSet has
 	// been provisioned
 	Provisioned bool
@@ -409,6 +419,11 @@ type MachineSetStatus struct {
 	// to generate the latest completed hardware provisioning job. The value will be set
 	// regardless of the job having succeeded or failed.
 	ProvisionedJobGeneration int64
+
+	// ProvisionJob is the job that is actively performing provisioning
+	// on the machine set.
+	// +optional
+	ProvisionJob *corev1.LocalObjectReference
 }
 
 // MachineSetCondition contains details for the current condition of a MachineSet

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -448,15 +448,15 @@ const (
 	// this machine set have been provisioned (ie. AWS autoscaling group)
 	MachineSetHardwareProvisioned MachineSetConditionType = "HardwareProvisioned"
 
-	// MachineSetHardwareInstalling is true if OpenShift is being installed on
+	// MachineSetInstalling is true if OpenShift is being installed on
 	// this machine set.
 	MachineSetInstalling MachineSetConditionType = "Installing"
 
-	// MachineSetHardwareInstallationFailed is true if the installation of
+	// MachineSetInstallationFailed is true if the installation of
 	// OpenShift on this machine set failed.
 	MachineSetInstallationFailed MachineSetConditionType = "InstallationFailed"
 
-	// MachineSetHardwareInstalled is true if OpenShift has been installed
+	// MachineSetInstalled is true if OpenShift has been installed
 	// on this machine set.
 	MachineSetInstalled MachineSetConditionType = "Installed"
 

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -450,15 +450,15 @@ const (
 	// this machine set have been provisioned (ie. AWS autoscaling group)
 	MachineSetHardwareProvisioned MachineSetConditionType = "HardwareProvisioned"
 
-	// MachineSetHardwareInstalling is true if OpenShift is being installed on
+	// MachineSetInstalling is true if OpenShift is being installed on
 	// this machine set.
 	MachineSetInstalling MachineSetConditionType = "Installing"
 
-	// MachineSetHardwareInstallationFailed is true if the installation of
+	// MachineSetInstallationFailed is true if the installation of
 	// OpenShift on this machine set failed.
 	MachineSetInstallationFailed MachineSetConditionType = "InstallationFailed"
 
-	// MachineSetHardwareInstalled is true if OpenShift has been installed
+	// MachineSetInstalled is true if OpenShift has been installed
 	// on this machine set.
 	MachineSetInstalled MachineSetConditionType = "Installed"
 

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -450,6 +450,18 @@ const (
 	// this machine set have been provisioned (ie. AWS autoscaling group)
 	MachineSetHardwareProvisioned MachineSetConditionType = "HardwareProvisioned"
 
+	// MachineSetHardwareInstalling is true if OpenShift is being installed on
+	// this machine set.
+	MachineSetInstalling MachineSetConditionType = "Installing"
+
+	// MachineSetHardwareInstallationFailed is true if the installation of
+	// OpenShift on this machine set failed.
+	MachineSetInstallationFailed MachineSetConditionType = "InstallationFailed"
+
+	// MachineSetHardwareInstalled is true if OpenShift has been installed
+	// on this machine set.
+	MachineSetInstalled MachineSetConditionType = "Installed"
+
 	// MachineSetHardwareReady is true if the hardware for the nodegroup is in ready
 	// state (is started and healthy)
 	MachineSetHardwareReady MachineSetConditionType = "HardwareReady"

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -255,6 +255,11 @@ type ClusterStatus struct {
 	// regardless of the job having succeeded or failed.
 	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
 
+	// ProvisionJob is the job that is actively performing provisioning
+	// on the cluster.
+	// +optional
+	ProvisionJob *corev1.LocalObjectReference `json:"provisionJob,omitempty"`
+
 	// Running is true if the master of the cluster is running and can be accessed using
 	// the KubeconfigSecret
 	Running bool `json:"running"`
@@ -403,6 +408,11 @@ type MachineSetStatus struct {
 	// regardless of the job having succeeded or failed.
 	InstalledJobGeneration int64 `json:"installedJobGeneration"`
 
+	// InstallationJob is the job that is actively performing installation
+	// on the machine set.
+	// +optional
+	InstallationJob *corev1.LocalObjectReference `json:"installationJob,omitempty"`
+
 	// Provisioned is true if the hardware that corresponds to this MachineSet has
 	// been provisioned
 	Provisioned bool `json:"provisioned"`
@@ -411,6 +421,11 @@ type MachineSetStatus struct {
 	// to generate the latest completed hardware provisioning job. The value will be set
 	// regardless of the job having succeeded or failed.
 	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
+
+	// ProvisionJob is the job that is actively performing provisioning
+	// on the machine set.
+	// +optional
+	ProvisionJob *corev1.LocalObjectReference `json:"provisionJob,omitempty"`
 }
 
 // MachineSetCondition contains details for the current condition of a MachineSet

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -346,6 +346,7 @@ func autoConvert_v1alpha1_ClusterStatus_To_clusteroperator_ClusterStatus(in *Clu
 	out.AdminKubeconfig = (*v1.LocalObjectReference)(unsafe.Pointer(in.AdminKubeconfig))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
+	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	out.Running = in.Running
 	out.Conditions = *(*[]clusteroperator.ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
@@ -363,6 +364,7 @@ func autoConvert_clusteroperator_ClusterStatus_To_v1alpha1_ClusterStatus(in *clu
 	out.AdminKubeconfig = (*v1.LocalObjectReference)(unsafe.Pointer(in.AdminKubeconfig))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
+	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	out.Running = in.Running
 	out.Conditions = *(*[]ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
@@ -711,8 +713,10 @@ func autoConvert_v1alpha1_MachineSetStatus_To_clusteroperator_MachineSetStatus(i
 	out.Conditions = *(*[]clusteroperator.MachineSetCondition)(unsafe.Pointer(&in.Conditions))
 	out.Installed = in.Installed
 	out.InstalledJobGeneration = in.InstalledJobGeneration
+	out.InstallationJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.InstallationJob))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
+	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	return nil
 }
 
@@ -727,8 +731,10 @@ func autoConvert_clusteroperator_MachineSetStatus_To_v1alpha1_MachineSetStatus(i
 	out.Conditions = *(*[]MachineSetCondition)(unsafe.Pointer(&in.Conditions))
 	out.Installed = in.Installed
 	out.InstalledJobGeneration = in.InstalledJobGeneration
+	out.InstallationJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.InstallationJob))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
+	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	return nil
 }
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -252,6 +252,15 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			**out = **in
 		}
 	}
+	if in.ProvisionJob != nil {
+		in, out := &in.ProvisionJob, &out.ProvisionJob
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.LocalObjectReference)
+			**out = **in
+		}
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]ClusterCondition, len(*in))
@@ -615,6 +624,24 @@ func (in *MachineSetStatus) DeepCopyInto(out *MachineSetStatus) {
 		*out = make([]MachineSetCondition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.InstallationJob != nil {
+		in, out := &in.InstallationJob, &out.InstallationJob
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.LocalObjectReference)
+			**out = **in
+		}
+	}
+	if in.ProvisionJob != nil {
+		in, out := &in.ProvisionJob, &out.ProvisionJob
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.LocalObjectReference)
+			**out = **in
 		}
 	}
 	return

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -252,6 +252,15 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			**out = **in
 		}
 	}
+	if in.ProvisionJob != nil {
+		in, out := &in.ProvisionJob, &out.ProvisionJob
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.LocalObjectReference)
+			**out = **in
+		}
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]ClusterCondition, len(*in))
@@ -615,6 +624,24 @@ func (in *MachineSetStatus) DeepCopyInto(out *MachineSetStatus) {
 		*out = make([]MachineSetCondition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.InstallationJob != nil {
+		in, out := &in.InstallationJob, &out.InstallationJob
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.LocalObjectReference)
+			**out = **in
+		}
+	}
+	if in.ProvisionJob != nil {
+		in, out := &in.ProvisionJob, &out.ProvisionJob
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.LocalObjectReference)
+			**out = **in
 		}
 	}
 	return

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -52,60 +52,88 @@ func WaitForCacheSync(controllerName string, stopCh <-chan struct{}, cacheSyncs 
 	return true
 }
 
-type UpdateConditionCheck func(oldReason, oldMessage, newReason, newMessage string) bool
+type Condition struct {
+	Status  corev1.ConditionStatus
+	Reason  string
+	Message string
+}
 
-func verifyUpdateConditionChecks(
-	oldReason, oldMessage, newReason, newMessage string,
-	updateConditionChecks ...UpdateConditionCheck,
-) bool {
-	for _, check := range updateConditionChecks {
-		if check(oldReason, oldMessage, newReason, newMessage) {
-			return true
-		}
-	}
+type UpdateConditionCheck func(old, new Condition) bool
+
+func UpdateConditionAlways(old, new Condition) bool {
+	return true
+}
+
+func UpdateConditionNever(old, new Condition) bool {
 	return false
 }
 
-// SetClusterCondition ensures that the specified cluster has a condition
-// with the specified condition type and status. If there is not a condition
-// with the condition type, then one is added. Otherwise, the
-// existing condition is modified if any of the following are true.
-// 1) Requested status is True.
-// 2) Requested status is different than existing status.
-// 3) Any of the updateConditionChecks checks return true.
+func UpdateConditionIfReasonOrMessageChange(old, new Condition) bool {
+	return old.Reason != new.Reason ||
+		old.Message != new.Message
+}
+
+func shouldUpdateCondition(
+	oldStatus corev1.ConditionStatus, oldReason, oldMessage string,
+	newStatus corev1.ConditionStatus, newReason, newMessage string,
+	updateConditionCheck UpdateConditionCheck,
+) bool {
+	if oldStatus != newStatus {
+		return true
+	}
+	return updateConditionCheck(
+		Condition{
+			Status:  oldStatus,
+			Reason:  oldReason,
+			Message: oldMessage,
+		},
+		Condition{
+			Status:  oldStatus,
+			Reason:  oldReason,
+			Message: oldMessage,
+		},
+	)
+}
+
+// SetClusterCondition sets the condition for the cluster.
+// If the cluster does not already have a condition with the specified type,
+// a condition will be added to the cluster if and only if the specified
+// status is True.
+// If the cluster does already have a condition with the specified type,
+// the condition will be updated if either of the following are true.
+// 1) Requested status is different than existing status.
+// 2) The updateConditionCheck function returns true.
 func SetClusterCondition(
 	cluster *clusteroperator.Cluster,
 	conditionType clusteroperator.ClusterConditionType,
 	status corev1.ConditionStatus,
 	reason string,
 	message string,
-	updateConditionChecks ...UpdateConditionCheck,
+	updateConditionCheck UpdateConditionCheck,
 ) {
 	now := metav1.Now()
-	condition := clusteroperator.ClusterCondition{
-		Type:               conditionType,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: now,
-		LastProbeTime:      now,
-	}
 	existingCondition := FindClusterCondition(cluster, conditionType)
 	if existingCondition == nil {
 		if status == corev1.ConditionTrue {
-			cluster.Status.Conditions = append(cluster.Status.Conditions, condition)
+			cluster.Status.Conditions = append(
+				cluster.Status.Conditions,
+				clusteroperator.ClusterCondition{
+					Type:               conditionType,
+					Status:             status,
+					Reason:             reason,
+					Message:            message,
+					LastTransitionTime: now,
+					LastProbeTime:      now,
+				},
+			)
 		}
 	} else {
-		if status != existingCondition.Status ||
-			status == corev1.ConditionTrue ||
-			verifyUpdateConditionChecks(
-				existingCondition.Reason,
-				existingCondition.Message,
-				condition.Reason,
-				condition.Message,
-				updateConditionChecks...,
-			) {
-			if existingCondition.Status != condition.Status {
+		if shouldUpdateCondition(
+			existingCondition.Status, existingCondition.Reason, existingCondition.Message,
+			status, reason, message,
+			updateConditionCheck,
+		) {
+			if existingCondition.Status != status {
 				existingCondition.LastTransitionTime = now
 			}
 			existingCondition.Status = status
@@ -127,46 +155,45 @@ func FindClusterCondition(cluster *clusteroperator.Cluster, conditionType cluste
 	return nil
 }
 
-// SetMachineSetCondition ensures that the specified machine set has a
-// condition with the specified condition type and status. If there is not a
-// condition with the condition type, then one is added. Otherwise, the
-// existing condition is modified if any of the following are true.
-// 1) Requested status is True.
-// 2) Requested status is different than existing status.
-// 3) Any of the updateConditionChecks checks return true.
+// SetClusterCondition sets the condition for the cluster.
+// If the cluster does not already have a condition with the specified type,
+// a condition will be added to the cluster if and only if the specified
+// status is True.
+// If the cluster does already have a condition with the specified type,
+// the condition will be updated if either of the following are true.
+// 1) Requested status is different than existing status.
+// 2) The updateConditionCheck function returns true.
 func SetMachineSetCondition(
 	machineSet *clusteroperator.MachineSet,
 	conditionType clusteroperator.MachineSetConditionType,
 	status corev1.ConditionStatus,
 	reason string,
 	message string,
-	updateConditionChecks ...UpdateConditionCheck,
+	updateConditionCheck UpdateConditionCheck,
 ) {
 	now := metav1.Now()
-	condition := clusteroperator.MachineSetCondition{
-		Type:               conditionType,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: now,
-		LastProbeTime:      now,
-	}
 	existingCondition := FindMachineSetCondition(machineSet, conditionType)
 	if existingCondition == nil {
 		if status == corev1.ConditionTrue {
-			machineSet.Status.Conditions = append(machineSet.Status.Conditions, condition)
+			machineSet.Status.Conditions = append(
+				machineSet.Status.Conditions,
+				clusteroperator.MachineSetCondition{
+					Type:               conditionType,
+					Status:             status,
+					Reason:             reason,
+					Message:            message,
+					LastTransitionTime: now,
+					LastProbeTime:      now,
+				},
+			)
 		}
 	} else {
-		if status != existingCondition.Status ||
-			status == corev1.ConditionTrue ||
-			verifyUpdateConditionChecks(
-				existingCondition.Reason,
-				existingCondition.Message,
-				condition.Reason,
-				condition.Message,
-				updateConditionChecks...,
-			) {
-			if existingCondition.Status != condition.Status {
+		if shouldUpdateCondition(
+			existingCondition.Status, existingCondition.Reason, existingCondition.Message,
+			status, reason, message,
+			updateConditionCheck,
+		) {
+			if existingCondition.Status != status {
 				existingCondition.LastTransitionTime = now
 			}
 			existingCondition.Status = status

--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -420,6 +420,9 @@ func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
 		s.controller.logger.Warn("could not convert owner from JobSync into a cluster: %#v", owner)
 		return
 	}
+	// ProvisionedJobGeneration is set even when the job failed because we
+	// do not want to run the provision job again until there have been
+	// changes in the spec of the cluster.
 	cluster.Status.ProvisionedJobGeneration = cluster.Generation
 }
 

--- a/pkg/controller/infra/infra_controller_test.go
+++ b/pkg/controller/infra/infra_controller_test.go
@@ -132,7 +132,7 @@ func TestInfraController(t *testing.T) {
 			cluster := newCluster()
 			clusterStore.Add(cluster)
 
-			err := controller.syncCluster(getKey(cluster, t))
+			err := controller.syncHandler(getKey(cluster, t))
 			if tc.expectedErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/controller/jobsync.go
+++ b/pkg/controller/jobsync.go
@@ -69,9 +69,6 @@ const (
 // JobSyncStrategy provides a strategy to the job sync for details on how
 // to sync for the controller.
 type JobSyncStrategy interface {
-	// EnqueueOwner enqueues the specified owner in the controller.
-	EnqueueOwner(owner metav1.Object)
-
 	// GetOwner gets the owner object with the specified key.
 	GetOwner(key string) (metav1.Object, error)
 
@@ -82,25 +79,25 @@ type JobSyncStrategy interface {
 	// GetJobFactory gets a factory for building a job to do the processing.
 	GetJobFactory(owner metav1.Object) (JobFactory, error)
 
-	// GetOwnerJobSyncConditionStatus gets the status of the specified
-	// condition for the specified owner.
-	GetOwnerJobSyncConditionStatus(owner metav1.Object, conditionType JobSyncConditionType) bool
+	// GetOwnerCurrentJob gets the name of the current job for the owner. If
+	// there is not a current job, then returns an empty string.
+	GetOwnerCurrentJob(owner metav1.Object) string
+
+	// SetOwnerCurrentJob sets the name of the current job for the owner.
+	SetOwnerCurrentJob(owner metav1.Object, jobName string)
 
 	// DeepCopyOwner returns a deep copy of the owner object.
 	DeepCopyOwner(owner metav1.Object) metav1.Object
 
 	// SetOwnerJobSyncCondition sets the specified condition for the specified
 	// owner.
-	// The updateConditionCheck functions are used to determine whether
-	// the condition should be updated if there are changes to the reason or
-	// the message of the condition.
 	SetOwnerJobSyncCondition(
 		owner metav1.Object,
 		conditionType JobSyncConditionType,
 		status kapi.ConditionStatus,
 		reason string,
 		message string,
-		updateConditionCheck ...UpdateConditionCheck,
+		updateConditionCheck UpdateConditionCheck,
 	)
 
 	// OnJobCompletion is called when the processing job for the owner
@@ -158,6 +155,8 @@ func (s *jobSync) Sync(key string) error {
 		return s.strategy.ProcessDeletedOwner(owner)
 	}
 
+	currentJobName := s.strategy.GetOwnerCurrentJob(owner)
+
 	needsProcessing := s.strategy.DoesOwnerNeedProcessing(owner)
 
 	jobFactory, err := s.strategy.GetJobFactory(owner)
@@ -165,36 +164,33 @@ func (s *jobSync) Sync(key string) error {
 		return err
 	}
 
-	job, isJobNew, err := s.jobControl.ControlJobs(key, owner, needsProcessing, jobFactory)
+	jobControlResult, job, err := s.jobControl.ControlJobs(key, owner, currentJobName, needsProcessing, jobFactory)
 	if err != nil {
 		return err
 	}
 
-	switch {
-	// Owner is update to date
-	case !needsProcessing:
-		return nil
-	// New job has not been created, so an old job must exist. Set the owner
-	// to not processing as the old job is deleted.
-	case job == nil:
-		return s.setOwnerToNotProcessing(owner)
-	// Job was not newly created, so sync owner status with job.
-	case !isJobNew:
-		logger.Debugln("job exists, will sync with job")
+	switch jobControlResult {
+	case JobControlJobWorking:
 		return s.syncOwnerStatusWithJob(owner, job)
-	// Owner should have a job but it was not found.
-	case s.strategy.GetOwnerJobSyncConditionStatus(owner, JobSyncProcessing):
-		return s.setJobNotFoundStatus(owner)
-	// New job created
+	case JobControlDeletingJobs:
+		if currentJobName == "" {
+			return nil
+		}
+		return s.setOwnerStatusForOutdatedJob(owner)
+	case JobControlLostCurrentJob:
+		return s.setOwnerStatusForLostJob(owner)
+	case JobControlCreatingJob, JobControlPendingExpectations, JobControlNoWork:
+		return nil
 	default:
+		logger.Warnf("unknown job control result: %v", jobControlResult)
 		return nil
 	}
 }
 
-// setOwnerToNotProcessing updates the processing condition
+// setOwnerStatusForOutdatedJob updates the processing condition
 // for the owner to reflect that an in-progress job is no longer processing
 // due to a change in the spec of the owner.
-func (s *jobSync) setOwnerToNotProcessing(original metav1.Object) error {
+func (s *jobSync) setOwnerStatusForOutdatedJob(original metav1.Object) error {
 	owner := s.strategy.DeepCopyOwner(original)
 	s.strategy.SetOwnerJobSyncCondition(
 		owner,
@@ -202,7 +198,9 @@ func (s *jobSync) setOwnerToNotProcessing(original metav1.Object) error {
 		kapi.ConditionFalse,
 		ReasonSpecChanged,
 		"Spec changed. New job needed",
+		UpdateConditionNever,
 	)
+	s.strategy.SetOwnerCurrentJob(owner, "")
 	return s.strategy.UpdateOwnerStatus(original, owner)
 }
 
@@ -214,51 +212,67 @@ func (s *jobSync) setOwnerToNotProcessing(original metav1.Object) error {
 // not processed.
 // If the job is still in progress, the owner will be marked as
 // processing.
-func (s *jobSync) syncOwnerStatusWithJob(original metav1.Object, job *v1batch.Job) error {
-	owner := s.strategy.DeepCopyOwner(original)
-
+func (s *jobSync) syncOwnerStatusWithJob(owner metav1.Object, job *v1batch.Job) error {
 	jobCompleted := findJobCondition(job, v1batch.JobComplete)
-	jobFailed := findJobCondition(job, v1batch.JobFailed)
-
-	switch {
-	// Job completed successfully
-	case jobCompleted != nil && jobCompleted.Status == kapi.ConditionTrue:
-		reason := ReasonJobCompleted
-		message := fmt.Sprintf("Job %s/%s completed at %v", job.Namespace, job.Name, jobCompleted.LastTransitionTime)
-		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message)
-		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessed, kapi.ConditionTrue, reason, message)
-		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionFalse, reason, message)
-		s.strategy.OnJobCompletion(owner)
-	// Job failed
-	case jobFailed != nil && jobFailed.Status == kapi.ConditionTrue:
-		reason := ReasonJobFailed
-		message := fmt.Sprintf("Job %s/%s failed at %v, reason: %s", job.Namespace, job.Name, jobFailed.LastTransitionTime, jobFailed.Reason)
-		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message)
-		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionTrue, reason, message)
-		s.strategy.OnJobFailure(owner)
-	// Job in progress
-	default:
-		s.strategy.SetOwnerJobSyncCondition(
+	if jobCompleted != nil && jobCompleted.Status == kapi.ConditionTrue {
+		return s.setOwnerStatusForCompletedJob(
 			owner,
-			JobSyncProcessing,
-			kapi.ConditionTrue,
-			ReasonJobRunning,
-			fmt.Sprintf("Job %s/%s is running since %v. Pod completions: %d, failures: %d", job.Namespace, job.Name, job.Status.StartTime, job.Status.Succeeded, job.Status.Failed),
-			func(oldReason, oldMessage, newReason, newMessage string) bool {
-				return oldReason != newReason || newMessage != oldMessage
-			},
+			ReasonJobCompleted,
+			fmt.Sprintf("Job %s/%s completed at %v", job.Namespace, job.Name, jobCompleted.LastTransitionTime),
 		)
 	}
 
+	jobFailed := findJobCondition(job, v1batch.JobFailed)
+	if jobFailed != nil && jobFailed.Status == kapi.ConditionTrue {
+		return s.setOwnerStatusForFailedJob(
+			owner,
+			ReasonJobFailed,
+			fmt.Sprintf("Job %s/%s failed at %v, reason: %s", job.Namespace, job.Name, jobFailed.LastTransitionTime, jobFailed.Reason),
+		)
+	}
+
+	return s.setOwnerStatusForInProgressJob(
+		owner,
+		job,
+		ReasonJobRunning,
+		fmt.Sprintf("Job %s/%s is running since %v. Pod completions: %d, failures: %d", job.Namespace, job.Name, job.Status.StartTime, job.Status.Succeeded, job.Status.Failed),
+	)
+}
+
+func (s *jobSync) setOwnerStatusForLostJob(owner metav1.Object) error {
+	return s.setOwnerStatusForFailedJob(owner, ReasonJobMissing, "Job not found.")
+}
+
+func (s *jobSync) setOwnerStatusForCompletedJob(original metav1.Object, reason, message string) error {
+	owner := s.strategy.DeepCopyOwner(original)
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message, UpdateConditionNever)
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessed, kapi.ConditionTrue, reason, message, UpdateConditionAlways)
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionFalse, reason, message, UpdateConditionNever)
+	s.strategy.SetOwnerCurrentJob(owner, "")
+	s.strategy.OnJobCompletion(owner)
 	return s.strategy.UpdateOwnerStatus(original, owner)
 }
 
-func (s *jobSync) setJobNotFoundStatus(original metav1.Object) error {
+func (s *jobSync) setOwnerStatusForFailedJob(original metav1.Object, reason, message string) error {
 	owner := s.strategy.DeepCopyOwner(original)
-	reason := ReasonJobMissing
-	message := "Job not found."
-	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message)
-	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionTrue, reason, message)
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message, UpdateConditionNever)
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionTrue, reason, message, UpdateConditionAlways)
+	s.strategy.SetOwnerCurrentJob(owner, "")
+	s.strategy.OnJobFailure(owner)
+	return s.strategy.UpdateOwnerStatus(original, owner)
+}
+
+func (s *jobSync) setOwnerStatusForInProgressJob(original metav1.Object, job *v1batch.Job, reason, message string) error {
+	owner := s.strategy.DeepCopyOwner(original)
+	s.strategy.SetOwnerJobSyncCondition(
+		owner,
+		JobSyncProcessing,
+		kapi.ConditionTrue,
+		reason,
+		message,
+		UpdateConditionIfReasonOrMessageChange,
+	)
+	s.strategy.SetOwnerCurrentJob(owner, job.Name)
 	return s.strategy.UpdateOwnerStatus(original, owner)
 }
 

--- a/pkg/controller/jobsync.go
+++ b/pkg/controller/jobsync.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	v1batch "k8s.io/api/batch/v1"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// JobSync is used by a controller to sync an object that uses a job to do
+// its processing.
+type JobSync interface {
+	// Sync syncs the object with the specified key.
+	Sync(key string) error
+}
+
+// JobSyncConditionType is the type of condition that the job sync is
+// adjusting on the owner object.
+type JobSyncConditionType string
+
+const (
+	// JobSyncProcessing indicates that the processing job is in progress.
+	JobSyncProcessing JobSyncConditionType = "Processing"
+	// JobSyncProcessed indicates that the processing job has completed
+	// successfully.
+	JobSyncProcessed JobSyncConditionType = "Processed"
+	// JobSyncProcessingFailed indicates that the processing job has failed.
+	JobSyncProcessingFailed JobSyncConditionType = "ProcessingFailed"
+)
+
+const (
+	// ReasonJobRunning is a condition reason used when a job is still
+	// running.
+	ReasonJobRunning = "JobRunning"
+	// ReasonJobCompleted is a condition reason used when a job has been
+	// completed successfully.
+	ReasonJobCompleted = "JobCompleted"
+	// ReasonJobFailed is a condition reason used when a job has failed.
+	ReasonJobFailed = "JobFailed"
+	// ReasonJobMissing is a condition reason used when a job that was
+	// expected to exist does not exist.
+	ReasonJobMissing = "JobMissing"
+	// ReasonSpecChanged is a condition reason used when the spec of an
+	// object changes, invalidating existing jobs.
+	ReasonSpecChanged = "SpecChanged"
+)
+
+// JobSyncStrategy provides a strategy to the job sync for details on how
+// to sync for the controller.
+type JobSyncStrategy interface {
+	// EnqueueOwner enqueues the specified owner in the controller.
+	EnqueueOwner(owner metav1.Object)
+
+	// GetOwner gets the owner object with the specified key.
+	GetOwner(key string) (metav1.Object, error)
+
+	// DoesOwnerNeedProcessing returns true if the owner is not up to date
+	// and needs a processing job to bring the owner up to date.
+	DoesOwnerNeedProcessing(owner metav1.Object) bool
+
+	// GetJobFactory gets a factory for building a job to do the processing.
+	GetJobFactory(owner metav1.Object) (JobFactory, error)
+
+	// GetOwnerJobSyncConditionStatus gets the status of the specified
+	// condition for the specified owner.
+	GetOwnerJobSyncConditionStatus(owner metav1.Object, conditionType JobSyncConditionType) bool
+
+	// DeepCopyOwner returns a deep copy of the owner object.
+	DeepCopyOwner(owner metav1.Object) metav1.Object
+
+	// SetOwnerJobSyncCondition sets the specified condition for the specified
+	// owner.
+	// The updateConditionCheck functions are used to determine whether
+	// the condition should be updated if there are changes to the reason or
+	// the message of the condition.
+	SetOwnerJobSyncCondition(
+		owner metav1.Object,
+		conditionType JobSyncConditionType,
+		status kapi.ConditionStatus,
+		reason string,
+		message string,
+		updateConditionCheck ...UpdateConditionCheck,
+	)
+
+	// OnJobCompletion is called when the processing job for the owner
+	// completes successfully.
+	OnJobCompletion(owner metav1.Object)
+
+	// OnJobFailure is called when the processing job for the owner fails.
+	OnJobFailure(owner metav1.Object)
+
+	// UpdateOwnerStatus updates the status of the owner from the original
+	// copy to the owner copy.
+	UpdateOwnerStatus(original, owner metav1.Object) error
+
+	// ProcessDeletedOwner processes an owner that has been marked for
+	// deletion.
+	ProcessDeletedOwner(owner metav1.Object) error
+}
+
+type jobSync struct {
+	jobControl JobControl
+	strategy   JobSyncStrategy
+	logger     log.FieldLogger
+}
+
+// NewJobSync creates a new JobSync.
+func NewJobSync(jobControl JobControl, strategy JobSyncStrategy, logger log.FieldLogger) JobSync {
+	return &jobSync{
+		jobControl: jobControl,
+		strategy:   strategy,
+		logger:     logger,
+	}
+}
+
+func (s *jobSync) Sync(key string) error {
+	logger := log.FieldLogger(s.logger.WithField("key", key))
+	startTime := time.Now()
+	logger.Debugln("Started syncing")
+	defer logger.WithField("duration", time.Since(startTime)).Debugln("Finished syncing")
+
+	owner, err := s.strategy.GetOwner(key)
+	if errors.IsNotFound(err) {
+		logger.Debugln("owner has been deleted")
+		s.jobControl.ObserveOwnerDeletion(key)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	logger = loggerForOwner(s.logger, owner)
+
+	// Are we dealing with an owner marked for deletion
+	if owner.GetDeletionTimestamp() != nil {
+		logger.Debugf("DeletionTimestamp set")
+		return s.strategy.ProcessDeletedOwner(owner)
+	}
+
+	needsProcessing := s.strategy.DoesOwnerNeedProcessing(owner)
+
+	jobFactory, err := s.strategy.GetJobFactory(owner)
+	if err != nil {
+		return err
+	}
+
+	job, isJobNew, err := s.jobControl.ControlJobs(key, owner, needsProcessing, jobFactory)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	// Owner is update to date
+	case !needsProcessing:
+		return nil
+	// New job has not been created, so an old job must exist. Set the owner
+	// to not processing as the old job is deleted.
+	case job == nil:
+		return s.setOwnerToNotProcessing(owner)
+	// Job was not newly created, so sync owner status with job.
+	case !isJobNew:
+		logger.Debugln("job exists, will sync with job")
+		return s.syncOwnerStatusWithJob(owner, job)
+	// Owner should have a job but it was not found.
+	case s.strategy.GetOwnerJobSyncConditionStatus(owner, JobSyncProcessing):
+		return s.setJobNotFoundStatus(owner)
+	// New job created
+	default:
+		return nil
+	}
+}
+
+// setOwnerToNotProcessing updates the processing condition
+// for the owner to reflect that an in-progress job is no longer processing
+// due to a change in the spec of the owner.
+func (s *jobSync) setOwnerToNotProcessing(original metav1.Object) error {
+	owner := s.strategy.DeepCopyOwner(original)
+	s.strategy.SetOwnerJobSyncCondition(
+		owner,
+		JobSyncProcessing,
+		kapi.ConditionFalse,
+		ReasonSpecChanged,
+		"Spec changed. New job needed",
+	)
+	return s.strategy.UpdateOwnerStatus(original, owner)
+}
+
+// syncOwnerStatusWithJob update the status of the owner to
+// reflect the current status of the job that is processing the owner.
+// If the job completed successfully, the owner will be marked as
+// processed.
+// If the job completed with a failure, the owner will be marked as
+// not processed.
+// If the job is still in progress, the owner will be marked as
+// processing.
+func (s *jobSync) syncOwnerStatusWithJob(original metav1.Object, job *v1batch.Job) error {
+	owner := s.strategy.DeepCopyOwner(original)
+
+	jobCompleted := findJobCondition(job, v1batch.JobComplete)
+	jobFailed := findJobCondition(job, v1batch.JobFailed)
+
+	switch {
+	// Job completed successfully
+	case jobCompleted != nil && jobCompleted.Status == kapi.ConditionTrue:
+		reason := ReasonJobCompleted
+		message := fmt.Sprintf("Job %s/%s completed at %v", job.Namespace, job.Name, jobCompleted.LastTransitionTime)
+		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message)
+		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessed, kapi.ConditionTrue, reason, message)
+		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionFalse, reason, message)
+		s.strategy.OnJobCompletion(owner)
+	// Job failed
+	case jobFailed != nil && jobFailed.Status == kapi.ConditionTrue:
+		reason := ReasonJobFailed
+		message := fmt.Sprintf("Job %s/%s failed at %v, reason: %s", job.Namespace, job.Name, jobFailed.LastTransitionTime, jobFailed.Reason)
+		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message)
+		s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionTrue, reason, message)
+		s.strategy.OnJobFailure(owner)
+	// Job in progress
+	default:
+		s.strategy.SetOwnerJobSyncCondition(
+			owner,
+			JobSyncProcessing,
+			kapi.ConditionTrue,
+			ReasonJobRunning,
+			fmt.Sprintf("Job %s/%s is running since %v. Pod completions: %d, failures: %d", job.Namespace, job.Name, job.Status.StartTime, job.Status.Succeeded, job.Status.Failed),
+			func(oldReason, oldMessage, newReason, newMessage string) bool {
+				return oldReason != newReason || newMessage != oldMessage
+			},
+		)
+	}
+
+	return s.strategy.UpdateOwnerStatus(original, owner)
+}
+
+func (s *jobSync) setJobNotFoundStatus(original metav1.Object) error {
+	owner := s.strategy.DeepCopyOwner(original)
+	reason := ReasonJobMissing
+	message := "Job not found."
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessing, kapi.ConditionFalse, reason, message)
+	s.strategy.SetOwnerJobSyncCondition(owner, JobSyncProcessingFailed, kapi.ConditionTrue, reason, message)
+	return s.strategy.UpdateOwnerStatus(original, owner)
+}
+
+// findJobCondition finds in the job the condition that has the
+// specified condition type. If none exists, then returns nil.
+func findJobCondition(job *v1batch.Job, conditionType v1batch.JobConditionType) *v1batch.JobCondition {
+	for i, condition := range job.Status.Conditions {
+		if condition.Type == conditionType {
+			return &job.Status.Conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -160,27 +160,6 @@ func (c *MachineController) enqueue(machine *clusteroperator.Machine) {
 	c.queue.Add(key)
 }
 
-func (c *MachineController) enqueueRateLimited(machine *clusteroperator.Machine) {
-	key, err := controller.KeyFunc(machine)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", machine, err))
-		return
-	}
-
-	c.queue.AddRateLimited(key)
-}
-
-// enqueueAfter will enqueue a machine after the provided amount of time.
-func (c *MachineController) enqueueAfter(machine *clusteroperator.Machine, after time.Duration) {
-	key, err := controller.KeyFunc(machine)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", machine, err))
-		return
-	}
-
-	c.queue.AddAfter(key, after)
-}
-
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
 func (c *MachineController) worker() {

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -501,6 +501,9 @@ func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
 		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
 		return
 	}
+	// ProvisionedJobGeneration is set even when the job failed because we
+	// do not want to run the provision job again until there have been
+	// changes in the spec of the machine set.
 	machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
 }
 

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -22,7 +22,6 @@ import (
 
 	v1batch "k8s.io/api/batch/v1"
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -39,13 +38,12 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/cluster-operator/pkg/ansible"
-	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
-
 	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	clusteroperatorclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
 	informers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions/clusteroperator/v1alpha1"
 	lister "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
 	"github.com/openshift/cluster-operator/pkg/controller"
+	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
 )
 
 const (
@@ -120,7 +118,9 @@ func NewMachineSetController(
 	jobInformer.Informer().AddEventHandler(c.jobControl)
 	c.jobsSynced = jobInformer.Informer().HasSynced
 
-	c.syncHandler = c.syncMachineSet
+	c.jobSync = controller.NewJobSync(c.jobControl, &jobSyncStrategy{controller: c}, logger)
+
+	c.syncHandler = c.jobSync.Sync
 	c.enqueueMachineSet = c.enqueue
 	c.ansibleGenerator = ansible.NewJobGenerator(ansibleImage, ansibleImagePullPolicy)
 
@@ -140,6 +140,8 @@ type MachineSetController struct {
 
 	jobControl controller.JobControl
 
+	jobSync controller.JobSync
+
 	// used for unit testing
 	enqueueMachineSet func(machineSet *clusteroperator.MachineSet)
 
@@ -151,7 +153,7 @@ type MachineSetController struct {
 	machineSetsSynced cache.InformerSynced
 
 	// clustersLister is able to list/get clusters and is populated by the shared informer passed to
-	// NewClusterController.
+	// NewMachineSetController.
 	clustersLister lister.ClusterLister
 	// clustersSynced returns true if the cluster shared informer has been synced at least once.
 	// Added as a member to the struct to allow injection for testing.
@@ -163,7 +165,7 @@ type MachineSetController struct {
 	// MachineSets that need to be synced
 	queue workqueue.RateLimitingInterface
 
-	logger *log.Entry
+	logger log.FieldLogger
 }
 
 func (c *MachineSetController) addMachineSet(obj interface{}) {
@@ -312,122 +314,6 @@ func (c *MachineSetController) handleErr(err error, key interface{}) {
 	c.queue.Forget(key)
 }
 
-// syncMachineSet will sync the machine set with the given key.
-// This function is not meant to be invoked concurrently with the same key.
-func (c *MachineSetController) syncMachineSet(key string) error {
-	startTime := time.Now()
-	logger := c.logger.WithField("machineset", key)
-	logger.Debugln("Started syncing machine set")
-	defer logger.WithField("duration", time.Since(startTime)).Debugln("Finished syncing machine set")
-
-	ns, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot parse machine set key %q: %v", key, err))
-		return nil
-	}
-	if len(ns) == 0 || len(name) == 0 {
-		utilruntime.HandleError(fmt.Errorf("invalid machineset key %q: either namespace or name is missing", key))
-		return nil
-	}
-
-	machineSet, err := c.machineSetsLister.MachineSets(ns).Get(name)
-	if errors.IsNotFound(err) {
-		logger.Debugln("machine set has been deleted")
-		c.jobControl.ObserveOwnerDeletion(key)
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-
-	shouldProvisionMachineSet, err := c.shouldProvision(machineSet)
-	if err != nil {
-		return err
-	}
-
-	jobFactory, err := c.getJobFactory(machineSet)
-	if err != nil {
-		return err
-	}
-
-	job, isJobNew, err := c.jobControl.ControlJobs(key, machineSet, shouldProvisionMachineSet, jobFactory)
-	if err != nil {
-		return err
-	}
-
-	if !shouldProvisionMachineSet {
-		return nil
-	}
-
-	switch {
-	// New job has not been created, so an old job must exist. Set the machine
-	// set to not provisioning as the old job is deleted.
-	case job == nil:
-		return c.setMachineSetToNotProvisioning(machineSet)
-	// Job was not newly created, so sync machine set status with job.
-	case !isJobNew:
-		logger.Debugln("provisioning job exists, will sync with job")
-		return c.syncMachineSetStatusWithJob(machineSet, job)
-	// MachineSet should have a job to provision the current spec but it was not
-	// found.
-	case isMachineSetProvisioning(machineSet):
-		return c.setJobNotFoundStatus(machineSet)
-	// New job created for new provisioning
-	default:
-		return nil
-	}
-}
-
-func (c *MachineSetController) clusterForMachineSet(machineSet *clusteroperator.MachineSet) (*clusteroperator.Cluster, error) {
-	controllerRef := metav1.GetControllerOf(machineSet)
-	if controllerRef.Kind != clusterKind.Kind {
-		return nil, nil
-	}
-	cluster, err := c.clustersLister.Clusters(machineSet.Namespace).Get(controllerRef.Name)
-	if err != nil {
-		return nil, err
-	}
-	if cluster.UID != controllerRef.UID {
-		// The controller we found with this Name is not the same one that the
-		// ControllerRef points to.
-		return nil, nil
-	}
-	return cluster, nil
-}
-
-func (c *MachineSetController) shouldProvision(machineSet *clusteroperator.MachineSet) (bool, error) {
-	if machineSet.Status.ProvisionedJobGeneration == machineSet.Generation {
-		return false, nil
-	}
-	cluster, err := c.clusterForMachineSet(machineSet)
-	if err != nil {
-		return false, err
-	}
-	if !cluster.Status.Provisioned || cluster.Status.ProvisionedJobGeneration != cluster.Generation {
-		return false, nil
-	}
-	switch machineSet.Spec.NodeType {
-	case clusteroperator.NodeTypeMaster:
-		return true, nil
-	case clusteroperator.NodeTypeCompute:
-		masterMachineSet, err := c.machineSetsLister.MachineSets(machineSet.Namespace).Get(cluster.Status.MasterMachineSetName)
-		if err != nil {
-			return false, err
-		}
-		// Only provision compute nodes if openshift has been installed on
-		// master nodes.
-		// We need to verify that the generation of the master machine set
-		// has not been changed since the installation. If the generation
-		// has changed, then the installation is no longer valid. The master
-		// controller needs to re-work the installation first.
-		masterInstalled := masterMachineSet.Status.Installed &&
-			masterMachineSet.Status.InstalledJobGeneration == masterMachineSet.Generation
-		return masterInstalled, nil
-	default:
-		return false, fmt.Errorf("unknown node type")
-	}
-}
-
 type jobOwnerControl struct {
 	controller *MachineSetController
 }
@@ -456,8 +342,81 @@ func (f jobFactory) BuildJob(name string) (*v1batch.Job, *kapi.ConfigMap, error)
 	return f(name)
 }
 
-func (c *MachineSetController) getJobFactory(machineSet *clusteroperator.MachineSet) (controller.JobFactory, error) {
-	cluster, err := c.clusterForMachineSet(machineSet)
+type jobSyncStrategy struct {
+	controller *MachineSetController
+}
+
+func (s *jobSyncStrategy) EnqueueOwner(owner metav1.Object) {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return
+	}
+	s.controller.enqueue(machineSet)
+}
+
+func (s *jobSyncStrategy) GetOwner(key string) (metav1.Object, error) {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(namespace) == 0 || len(name) == 0 {
+		return nil, fmt.Errorf("invalid key %q: either namespace or name is missing", key)
+	}
+	return s.controller.machineSetsLister.MachineSets(namespace).Get(name)
+}
+
+func (s *jobSyncStrategy) DoesOwnerNeedProcessing(owner metav1.Object) bool {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return false
+	}
+	if machineSet.Status.ProvisionedJobGeneration == machineSet.Generation {
+		return false
+	}
+	cluster, err := controller.ClusterForMachineSet(machineSet, s.controller.clustersLister)
+	if err != nil {
+		loggerForMachineSet(s.controller.logger, machineSet).
+			Warn("could not get cluster for machine set")
+		return false
+	}
+	if !cluster.Status.Provisioned || cluster.Status.ProvisionedJobGeneration != cluster.Generation {
+		return false
+	}
+	switch machineSet.Spec.NodeType {
+	case clusteroperator.NodeTypeMaster:
+		return true
+	case clusteroperator.NodeTypeCompute:
+		masterMachineSet, err := s.controller.machineSetsLister.MachineSets(machineSet.Namespace).Get(cluster.Status.MasterMachineSetName)
+		if err != nil {
+			loggerForCluster(loggerForMachineSet(s.controller.logger, machineSet), cluster).
+				WithField("master", cluster.Status.MasterMachineSetName).
+				Warn("could not get master machine set")
+			return false
+		}
+		// Only provision compute nodes if openshift has been installed on
+		// master nodes.
+		// We need to verify that the generation of the master machine set
+		// has not been changed since the installation. If the generation
+		// has changed, then the installation is no longer valid. The master
+		// controller needs to re-work the installation first.
+		masterInstalled := masterMachineSet.Status.Installed &&
+			masterMachineSet.Status.InstalledJobGeneration == masterMachineSet.Generation
+		return masterInstalled
+	default:
+		loggerForMachineSet(s.controller.logger, machineSet).
+			Warnf("unknown node type %q", machineSet.Spec.NodeType)
+		return false
+	}
+}
+
+func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object) (controller.JobFactory, error) {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		return nil, fmt.Errorf("could not convert owner from JobSync into a machineset")
+	}
+	cluster, err := controller.ClusterForMachineSet(machineSet, s.controller.clustersLister)
 	if err != nil {
 		return nil, err
 	}
@@ -472,108 +431,112 @@ func (c *MachineSetController) getJobFactory(machineSet *clusteroperator.Machine
 		} else {
 			playbook = computeProvisioningPlaybook
 		}
-		job, configMap := c.ansibleGenerator.GeneratePlaybookJob(name, &cluster.Spec.Hardware, playbook, ansible.DefaultInventory, vars)
+		job, configMap := s.controller.ansibleGenerator.GeneratePlaybookJob(
+			name,
+			&cluster.Spec.Hardware,
+			playbook,
+			ansible.DefaultInventory,
+			vars,
+		)
 		return job, configMap, nil
 	}), nil
 }
 
-// setMachineSetToNotProvisioning updates the HardwareProvisioning condition
-// for the machine set to reflect that a machine set that had an in-progress
-// provision is no longer provisioning due to a change in the spec of the
-// machine set.
-func (c *MachineSetController) setMachineSetToNotProvisioning(original *clusteroperator.MachineSet) error {
-	machineSet := original.DeepCopy()
+func (s *jobSyncStrategy) GetOwnerJobSyncConditionStatus(owner metav1.Object, conditionType controller.JobSyncConditionType) bool {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return false
+	}
+	machineSetConditionType := convertJobSyncConditionType(conditionType)
+	condition := controller.FindMachineSetCondition(machineSet, machineSetConditionType)
+	return condition != nil && condition.Status == kapi.ConditionTrue
+}
 
+func (s *jobSyncStrategy) DeepCopyOwner(owner metav1.Object) metav1.Object {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return machineSet
+	}
+	return machineSet.DeepCopy()
+}
+
+func (s *jobSyncStrategy) SetOwnerJobSyncCondition(
+	owner metav1.Object,
+	conditionType controller.JobSyncConditionType,
+	status kapi.ConditionStatus,
+	reason string,
+	message string,
+	updateConditionCheck ...controller.UpdateConditionCheck,
+) {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return
+	}
 	controller.SetMachineSetCondition(
 		machineSet,
-		clusteroperator.MachineSetHardwareProvisioning,
-		kapi.ConditionFalse,
-		controller.ReasonSpecChanged,
-		"Spec changed. New provisioning needed",
+		convertJobSyncConditionType(conditionType),
+		status,
+		reason,
+		message,
+		updateConditionCheck...,
 	)
-
-	return c.updateMachineSetStatus(original, machineSet)
 }
 
-// syncMachineSetStatusWithJob update the status of the machine set to
-// reflect the current status of the job that is provisioning the machine set.
-// If the job completed successfully, the machine set will be marked as
-// provisioned.
-// If the job completed with a failure, the machine set will be marked as
-// not provisioned.
-// If the job is still in progress, the machine set will be marked as
-// provisioning.
-func (c *MachineSetController) syncMachineSetStatusWithJob(original *clusteroperator.MachineSet, job *v1batch.Job) error {
-	machineSet := original.DeepCopy()
-
-	jobCompleted := jobCondition(job, v1batch.JobComplete)
-	jobFailed := jobCondition(job, v1batch.JobFailed)
-	switch {
-	// Provision job completed successfully
-	case jobCompleted != nil && jobCompleted.Status == kapi.ConditionTrue:
-		reason := controller.ReasonJobCompleted
-		message := fmt.Sprintf("Job %s/%s completed at %v", job.Namespace, job.Name, jobCompleted.LastTransitionTime)
-		controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioning, kapi.ConditionFalse, reason, message)
-		controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioned, kapi.ConditionTrue, reason, message)
-		controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioningFailed, kapi.ConditionFalse, reason, message)
-		machineSet.Status.Provisioned = true
-		machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
-	// Provision job failed
-	case jobFailed != nil && jobFailed.Status == kapi.ConditionTrue:
-		reason := controller.ReasonJobFailed
-		message := fmt.Sprintf("Job %s/%s failed at %v, reason: %s", job.Namespace, job.Name, jobFailed.LastTransitionTime, jobFailed.Reason)
-		controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioning, kapi.ConditionFalse, reason, message)
-		controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioningFailed, kapi.ConditionTrue, reason, message)
-		// ProvisionedJobGeneration is set even when the job failed because we
-		// do not want to run the provision job again until there have been
-		// changes in the spec of the machine set.
-		machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
-	default:
-		reason := controller.ReasonJobRunning
-		message := fmt.Sprintf("Job %s/%s is running since %v. Pod completions: %d, failures: %d", job.Namespace, job.Name, job.Status.StartTime, job.Status.Succeeded, job.Status.Failed)
-		controller.SetMachineSetCondition(
-			machineSet,
-			clusteroperator.MachineSetHardwareProvisioning,
-			kapi.ConditionTrue,
-			reason,
-			message,
-			func(old, new clusteroperator.MachineSetCondition) bool {
-				return new.Message != old.Message
-			},
-		)
+func (s *jobSyncStrategy) OnJobCompletion(owner metav1.Object) {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return
 	}
-
-	return c.updateMachineSetStatus(original, machineSet)
-
+	machineSet.Status.Provisioned = true
+	machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
 }
 
-func (c *MachineSetController) setJobNotFoundStatus(original *clusteroperator.MachineSet) error {
-	machineSet := original.DeepCopy()
-	reason := controller.ReasonJobMissing
-	message := "Provisioning job not found."
-	controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioning, kapi.ConditionFalse, reason, message)
-	controller.SetMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioningFailed, kapi.ConditionTrue, reason, message)
-	return c.updateMachineSetStatus(original, machineSet)
+func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
+		return
+	}
+	machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
+}
+
+func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error {
+	originalMachineSet, ok := original.(*clusteroperator.MachineSet)
+	if !ok {
+		return fmt.Errorf("could not convert original from JobSync into a machineset")
+	}
+	machineSet, ok := owner.(*clusteroperator.MachineSet)
+	if !ok {
+		return fmt.Errorf("could not convert owner from JobSync into a machineset")
+	}
+	return s.controller.updateMachineSetStatus(originalMachineSet, machineSet)
+}
+
+func (s *jobSyncStrategy) ProcessDeletedOwner(owner metav1.Object) error {
+	return nil
+}
+
+func convertJobSyncConditionType(conditionType controller.JobSyncConditionType) clusteroperator.MachineSetConditionType {
+	switch conditionType {
+	case controller.JobSyncProcessing:
+		return clusteroperator.MachineSetHardwareProvisioning
+	case controller.JobSyncProcessed:
+		return clusteroperator.MachineSetHardwareProvisioned
+	case controller.JobSyncProcessingFailed:
+		return clusteroperator.MachineSetHardwareProvisioningFailed
+	default:
+		return clusteroperator.MachineSetConditionType("")
+	}
 }
 
 func (c *MachineSetController) updateMachineSetStatus(original, machineSet *clusteroperator.MachineSet) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		return controller.PatchMachineSetStatus(c.client, original, machineSet)
 	})
-}
-
-func isMachineSetProvisioning(machineSet *clusteroperator.MachineSet) bool {
-	provisioning := controller.FindMachineSetCondition(machineSet, clusteroperator.MachineSetHardwareProvisioning)
-	return provisioning != nil && provisioning.Status == kapi.ConditionTrue
-}
-
-func jobCondition(job *v1batch.Job, conditionType v1batch.JobConditionType) *v1batch.JobCondition {
-	for i, condition := range job.Status.Conditions {
-		if condition.Type == conditionType {
-			return &job.Status.Conditions[i]
-		}
-	}
-	return nil
 }
 
 func loggerForMachineSet(logger log.FieldLogger, machineSet *clusteroperator.MachineSet) log.FieldLogger {

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -446,6 +446,9 @@ func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
 		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
 		return
 	}
+	// InstalledJobGeneration is set even when the job failed because we
+	// do not want to run the installation job again until there have been
+	// changes in the spec of the machine set.
 	machineSet.Status.InstalledJobGeneration = machineSet.Generation
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -457,6 +457,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
+						"provisionJob": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ProvisionJob is the job that is actively performing provisioning on the cluster.",
+								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+							},
+						},
 						"running": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Running is true if the master of the cluster is running and can be accessed using the KubeconfigSecret",
@@ -1025,6 +1031,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
+						"installationJob": {
+							SchemaProps: spec.SchemaProps{
+								Description: "InstallationJob is the job that is actively performing installation on the machine set.",
+								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+							},
+						},
 						"provisioned": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Provisioned is true if the hardware that corresponds to this MachineSet has been provisioned",
@@ -1039,12 +1051,18 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
+						"provisionJob": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ProvisionJob is the job that is actively performing provisioning on the machine set.",
+								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+							},
+						},
 					},
 					Required: []string{"machineCount", "machinesReady", "conditions", "installed", "installedJobGeneration", "provisioned", "provisionedJobGeneration"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetCondition"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetCondition", "k8s.io/api/core/v1.LocalObjectReference"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSpec": {
 			Schema: spec.Schema{


### PR DESCRIPTION
**Changes**
* Implement the controller that is responsible for installing openshift on the master nodes.
* Create a JobSync type to pull together more of the duplicated code around syncing for controllers that rely on jobs.
* Increase the duration that ansible jobs can run before failing. This is needed now because the machines created in AWS are not available for a while after the scale groups are created. The machineset job that creates the scale groups completes successfully prior to the machines in the scale groups being accessible. The pods of the master job will fail until the master machines are accessible. We wanted to increase this duration anyway, so now is as good a time as any.

**Notes**
* The latest docker.io/openshift/origin-ansible does not work with cluster-operator. @abutcher has a PR up to fix at least one of the problem. In the meantime, you can build your own openshift-ansible image to use. I tested with commit 3346448363ead62312cb29596dcf3df5ce753ef7.
* The master job is not passing for me. It is failing trying to ssh into the master machine. The logic for controlling the master is working. Given the size of this PR, I wanted to get it in even though the work to install on the master machines is not complete.