### PR TITLE
Remove API and console port overrides.

### DIFF
--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -38,9 +38,6 @@ openshift_master_bootstrap_enabled: True
 openshift_hosted_router_wait: False
 openshift_hosted_registry_wait: False
 
-openshift_master_api_port: 443
-openshift_master_console_port: 443
-
 ################################################################################
 # cluster specific settings
 ################################################################################


### PR DESCRIPTION
Remove API and console port overrides. https://github.com/openshift/openshift-ansible/pull/6889 breaks overriding and removes the need to override the ports for the time being.