### PR TITLE
Clean up etcd stores on API Server shutdown

### DIFF
--- a/cmd/cluster-operator-apiserver/app/server.go
+++ b/cmd/cluster-operator-apiserver/app/server.go
@@ -101,7 +101,7 @@ func CreateServer(opts *options.ClusterOperatorServerRunOptions, stopCh <-chan s
 
 	// make the server
 	glog.V(4).Infoln("Completing API server configuration")
-	server, err := completed.NewServer()
+	server, err := completed.NewServer(stopCh)
 	if err != nil {
 		return nil, fmt.Errorf("error completing API server configuration: %v", err)
 	}

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -25,5 +25,5 @@ type Config interface {
 // CompletedConfig is the result of a Config being Complete()-ed. Calling code should call Start()
 // to start a server from its completed config
 type CompletedConfig interface {
-	NewServer() (*ClusterOperatorAPIServer, error)
+	NewServer(stopCh <-chan struct{}) (*ClusterOperatorAPIServer, error)
 }


### PR DESCRIPTION
The integration tests will start and stop API Servers. This will keep those tests from leaking go routines.