### PR TITLE
Tweaks to make ec2 provisioning work

### DIFF
--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -21,8 +21,8 @@ objects:
         keyPairName: "libra"
     defaultHardwareSpec:
       aws:
-        instanceType: "t2.medium"
-        amiName: "ami-10aed306"
+        amiName: "ami-2ed6f454"
+        instanceType: "m4.xlarge"
     machineSets:
     - name: master
       nodeType: Master

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -341,7 +341,7 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object) (controller.JobFact
 		return nil, err
 	}
 	return jobFactory(func(name string) (*v1batch.Job, *kapi.ConfigMap, error) {
-		vars, err := ansible.GenerateMachineSetVars(cluster, machineSet)
+		vars, err := ansible.GenerateClusterVars(cluster)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
When we get more parameterization on the openshift-ansible side we'll be able to get rid of the complex structs that we're passing in vars. But for now, these changes make provisioning work, up to the point where we have a master and nodes running. The last remaining step is to approve the nodes.