### PR TITLE
Move deployment type and version from cluster config to version.

### DIFF
--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -7,6 +7,19 @@ objects:
 - apiVersion: clusteroperator.openshift.io/v1alpha1
   kind: ClusterVersion
   metadata:
+    name: origin-v3-7
+    namespace: ${CLUSTER_VERSION_NS}
+  spec:
+    imageFormat: "openshift/origin-${component}:v3.7.0"
+    vmImages:
+      awsVMImages:
+        amiByRegion:
+          us-east-1: ami-10aed306 # TODO: not correct, need to find out how to lookup latest golden image.
+    deploymentType: origin
+    version: "v3.7.0"
+- apiVersion: clusteroperator.openshift.io/v1alpha1
+  kind: ClusterVersion
+  metadata:
     name: ocp-v3-9
     namespace: ${CLUSTER_VERSION_NS}
   spec:
@@ -15,14 +28,8 @@ objects:
       awsVMImages:
         amiByRegion:
           us-east-1: ami-10aed306 # TODO: not correct, need to find out how to lookup latest golden image.
-    yumRepositories:
-    # TODO: replace with a usable OpenShift repo
-    - id: dgoodwin-tito-copr
-      name: Tito Development Copr
-      baseurl: https://copr-be.cloud.fedoraproject.org/results/dgoodwin/tito/fedora-$releasever-$basearch/
-      gpgkey: https://copr-be.cloud.fedoraproject.org/results/dgoodwin/tito/pubkey.gpg
-      gpgcheck: 1
-      enabled: 0
+    deploymentType: openshift-enterprise
+    version: "v3.9.0"
 - apiVersion: clusteroperator.openshift.io/v1alpha1
   kind: ClusterVersion
   metadata:
@@ -34,6 +41,8 @@ objects:
       awsVMImages:
         amiByRegion:
           us-east-1: ami-10aed306 # TODO: not correct, need to find out how to lookup latest golden image.
+    deploymentType: openshift-enterprise
+    version: "v3.10.0"
 - apiVersion: clusteroperator.openshift.io/v1alpha1
   kind: Cluster
   metadata:
@@ -41,7 +50,7 @@ objects:
   spec:
     clusterVersionRef:
       namespace: cluster-operator
-      name: ocp-v3-9
+      name: origin-v3-7
     hardware:
       aws:
         accountSecret:

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -88,6 +88,12 @@ type ClusterVersionSpec struct {
 	ImageFormat string
 
 	VMImages VMImages
+
+	// DeploymentType indicates the type of OpenShift deployment to create.
+	DeploymentType ClusterDeploymentType
+
+	// Version is the version of OpenShift to install.
+	Version string
 }
 
 // ClusterVersionStatus is the status of a ClusterVersion. It may be used to indicate if the
@@ -211,12 +217,6 @@ type AWSClusterSpec struct {
 
 // ClusterConfigSpec contains OpenShift configuration for a cluster
 type ClusterConfigSpec struct {
-	// DeploymentType indicates the type of OpenShift deployment to create
-	DeploymentType ClusterDeploymentType
-
-	// OpenShiftVersion is the version of OpenShift to install
-	OpenshiftVersion string
-
 	// SDNPluginName is the name of the SDN plugin to use for this install
 	SDNPluginName string
 

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -90,6 +90,12 @@ type ClusterVersionSpec struct {
 	ImageFormat string `json:"imageFormat"`
 
 	VMImages VMImages `json:"vmImages"`
+
+	// DeploymentType indicates the type of OpenShift deployment to create.
+	DeploymentType ClusterDeploymentType `json:"deploymentType"`
+
+	// Version is the version of OpenShift to install.
+	Version string `json:"version"`
 }
 
 // ClusterVersionStatus is the status of a ClusterVersion. It may be used to indicate if the
@@ -180,7 +186,7 @@ type AWSClusterSpec struct {
 	AccountSecret corev1.LocalObjectReference `json:"accountSecret"`
 
 	// SSHSecret refers to a secret that contains the ssh private key to access
-	// EC2 instances in this cluster
+	// EC2 instances in this cluster.
 	SSHSecret corev1.LocalObjectReference `json:"sshSecret"`
 
 	// SSLSecret refers to a secret that contains the SSL certificate to use
@@ -214,12 +220,6 @@ type AWSClusterSpec struct {
 
 // ClusterConfigSpec contains OpenShift configuration for a cluster
 type ClusterConfigSpec struct {
-	// DeploymentType indicates the type of OpenShift deployment to create
-	DeploymentType ClusterDeploymentType `json:"deploymentType"`
-
-	// OpenShiftVersion is the version of OpenShift to install
-	OpenshiftVersion string `json:"openshiftVersion"`
-
 	// SDNPluginName is the name of the SDN plugin to use for this install
 	SDNPluginName string `json:"sdnPluginName"`
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -212,8 +212,6 @@ func Convert_clusteroperator_ClusterCondition_To_v1alpha1_ClusterCondition(in *c
 }
 
 func autoConvert_v1alpha1_ClusterConfigSpec_To_clusteroperator_ClusterConfigSpec(in *ClusterConfigSpec, out *clusteroperator.ClusterConfigSpec, s conversion.Scope) error {
-	out.DeploymentType = clusteroperator.ClusterDeploymentType(in.DeploymentType)
-	out.OpenshiftVersion = in.OpenshiftVersion
 	out.SDNPluginName = in.SDNPluginName
 	out.ServiceNetworkSubnet = in.ServiceNetworkSubnet
 	out.PodNetworkSubnet = in.PodNetworkSubnet
@@ -226,8 +224,6 @@ func Convert_v1alpha1_ClusterConfigSpec_To_clusteroperator_ClusterConfigSpec(in 
 }
 
 func autoConvert_clusteroperator_ClusterConfigSpec_To_v1alpha1_ClusterConfigSpec(in *clusteroperator.ClusterConfigSpec, out *ClusterConfigSpec, s conversion.Scope) error {
-	out.DeploymentType = ClusterDeploymentType(in.DeploymentType)
-	out.OpenshiftVersion = in.OpenshiftVersion
 	out.SDNPluginName = in.SDNPluginName
 	out.ServiceNetworkSubnet = in.ServiceNetworkSubnet
 	out.PodNetworkSubnet = in.PodNetworkSubnet
@@ -467,6 +463,8 @@ func autoConvert_v1alpha1_ClusterVersionSpec_To_clusteroperator_ClusterVersionSp
 	if err := Convert_v1alpha1_VMImages_To_clusteroperator_VMImages(&in.VMImages, &out.VMImages, s); err != nil {
 		return err
 	}
+	out.DeploymentType = clusteroperator.ClusterDeploymentType(in.DeploymentType)
+	out.Version = in.Version
 	return nil
 }
 
@@ -481,6 +479,8 @@ func autoConvert_clusteroperator_ClusterVersionSpec_To_v1alpha1_ClusterVersionSp
 	if err := Convert_clusteroperator_VMImages_To_v1alpha1_VMImages(&in.VMImages, &out.VMImages, s); err != nil {
 		return err
 	}
+	out.DeploymentType = ClusterDeploymentType(in.DeploymentType)
+	out.Version = in.Version
 	return nil
 }
 

--- a/pkg/apis/clusteroperator/validation/clusterversion.go
+++ b/pkg/apis/clusteroperator/validation/clusterversion.go
@@ -23,6 +23,23 @@ import (
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
+// validDeploymentTypes is a map containing an entry for every valid DeploymentType value.
+var validDeploymentTypes = map[clusteroperator.ClusterDeploymentType]bool{
+	clusteroperator.ClusterDeploymentTypeOrigin:     true,
+	clusteroperator.ClusterDeploymentTypeEnterprise: true,
+}
+
+// validDeploymentTypeValues is an array of every valid DeploymentType value.
+var validDeploymentTypeValues = func() []string {
+	validValues := make([]string, len(validDeploymentTypes))
+	i := 0
+	for dt := range validDeploymentTypes {
+		validValues[i] = string(dt)
+		i++
+	}
+	return validValues
+}()
+
 // ValidateClusterVersion validates a cluster version being created.
 func ValidateClusterVersion(cv *clusteroperator.ClusterVersion) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -67,6 +84,18 @@ func ValidateClusterVersionSpec(spec *clusteroperator.ClusterVersionSpec, fldPat
 	vmImagesPath := fldPath.Child("vmImages")
 	if spec.VMImages == (clusteroperator.VMImages{}) {
 		allErrs = append(allErrs, field.Required(vmImagesPath, "must define VM images"))
+	}
+
+	deploymentTypePath := fldPath.Child("deploymentType")
+	if spec.DeploymentType == "" {
+		allErrs = append(allErrs, field.Required(deploymentTypePath, "must define deployment type"))
+	} else if !validDeploymentTypes[spec.DeploymentType] {
+		allErrs = append(allErrs, field.NotSupported(deploymentTypePath, spec.DeploymentType, validDeploymentTypeValues))
+	}
+
+	versionPath := fldPath.Child("version")
+	if spec.Version == "" {
+		allErrs = append(allErrs, field.Required(versionPath, "must define version"))
 	}
 
 	return allErrs

--- a/pkg/apis/clusteroperator/validation/clusterversion_test.go
+++ b/pkg/apis/clusteroperator/validation/clusterversion_test.go
@@ -49,6 +49,8 @@ func getValidClusterVersion() *clusteroperator.ClusterVersion {
 					},
 				},
 			},
+			DeploymentType: clusteroperator.ClusterDeploymentTypeOrigin,
+			Version:        "3.7.0",
 		},
 	}
 }
@@ -124,6 +126,33 @@ func TestValidateClusterVersion(t *testing.T) {
 			clusterVersion: func() *clusteroperator.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.VMImages = clusteroperator.VMImages{}
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "missing deployment type",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.DeploymentType = ""
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "invalid deployment type",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.DeploymentType = "badtype"
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "missing version",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.Version = ""
 				return c
 			}(),
 			valid: false,

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -41,7 +41,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"sshSecret": {
 							SchemaProps: spec.SchemaProps{
-								Description: "SSHSecret refers to a secret that contains the ssh private key to access EC2 instances in this cluster",
+								Description: "SSHSecret refers to a secret that contains the ssh private key to access EC2 instances in this cluster.",
 								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 							},
 						},
@@ -207,20 +207,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "ClusterConfigSpec contains OpenShift configuration for a cluster",
 					Properties: map[string]spec.Schema{
-						"deploymentType": {
-							SchemaProps: spec.SchemaProps{
-								Description: "DeploymentType indicates the type of OpenShift deployment to create",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"openshiftVersion": {
-							SchemaProps: spec.SchemaProps{
-								Description: "OpenShiftVersion is the version of OpenShift to install",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
 						"sdnPluginName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "SDNPluginName is the name of the SDN plugin to use for this install",
@@ -243,7 +229,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"deploymentType", "openshiftVersion", "sdnPluginName"},
+					Required: []string{"sdnPluginName"},
 				},
 			},
 			Dependencies: []string{},
@@ -640,8 +626,22 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref: ref("github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.VMImages"),
 							},
 						},
+						"deploymentType": {
+							SchemaProps: spec.SchemaProps{
+								Description: "DeploymentType indicates the type of OpenShift deployment to create.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"version": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Version is the version of OpenShift to install.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
-					Required: []string{"imageFormat", "vmImages"},
+					Required: []string{"imageFormat", "vmImages", "deploymentType", "version"},
 				},
 			},
 			Dependencies: []string{
@@ -10122,15 +10122,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
 					Description: "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
-					Properties: map[string]spec.Schema{
-						"Duration": {
-							SchemaProps: spec.SchemaProps{
-								Type:   []string{"integer"},
-								Format: "int64",
-							},
-						},
-					},
-					Required: []string{"Duration"},
+					Properties:  map[string]spec.Schema{},
 				},
 			},
 			Dependencies: []string{},

--- a/pkg/registry/clusteroperator/clusterversion/storage_test.go
+++ b/pkg/registry/clusteroperator/clusterversion/storage_test.go
@@ -56,6 +56,8 @@ func validClusterVersion(name string) *clusteroperatorapi.ClusterVersion {
 					},
 				},
 			},
+			DeploymentType: clusteroperatorapi.ClusterDeploymentTypeOrigin,
+			Version:        "v3.9.0",
 		},
 	}
 }

--- a/test/integration/clustercontroller_test.go
+++ b/test/integration/clustercontroller_test.go
@@ -99,6 +99,8 @@ func TestClusterCreate(t *testing.T) {
 							},
 						},
 					},
+					DeploymentType: v1alpha1.ClusterDeploymentTypeOrigin,
+					Version:        "v3.7.0",
 				},
 			}
 			clusterOperatorClient.ClusteroperatorV1alpha1().ClusterVersions(testNamespace).Create(clusterVersion)


### PR DESCRIPTION
Rename OpenshiftVersion to just Version to better accomodate possiblity
of installing base Kubernetes in the future.

Version will at worst, look something like "v3.9.0-alpha.4+e7d9503-18"
and at best, something like "v3.9.0". We may add validation on this
format once it's content is more solidified.