### PR TITLE
Allow machineset scaling

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -455,6 +455,7 @@ func (c *Controller) manageMachineSets(machineSets []*clusteroperator.MachineSet
 	clusterMachineSets := make([]*clusteroperator.MachineSet, len(cluster.Spec.MachineSets))
 	machineSetsToCreate := []*clusteroperator.MachineSet{}
 	machineSetsToDelete := []*clusteroperator.MachineSet{}
+	machineSetsToUpdate := []*clusteroperator.MachineSet{}
 
 	// Organize machine sets
 	for _, machineSet := range machineSets {
@@ -487,7 +488,7 @@ func (c *Controller) manageMachineSets(machineSets []*clusteroperator.MachineSet
 		}
 		machineSetConfig.Hardware = mergedHardwareSpec
 
-		machineSetToCreate, deleteMachineSet, err := c.manageMachineSet(cluster, clusterVersion, clusterMachineSets[i], machineSetConfig, machineSetPrefixes[i])
+		machineSetToCreate, updateMachineSet, deleteMachineSet, err := c.manageMachineSet(cluster, clusterVersion, clusterMachineSets[i], machineSetConfig, machineSetPrefixes[i])
 		if err != nil {
 			errCh <- err
 			continue
@@ -498,6 +499,8 @@ func (c *Controller) manageMachineSets(machineSets []*clusteroperator.MachineSet
 		}
 		if deleteMachineSet {
 			machineSetsToDelete = append(machineSetsToDelete, clusterMachineSets[i])
+		} else if updateMachineSet {
+			machineSetsToUpdate = append(machineSetsToUpdate, clusterMachineSets[i])
 		}
 	}
 
@@ -543,10 +546,26 @@ func (c *Controller) manageMachineSets(machineSets []*clusteroperator.MachineSet
 		wg.Wait()
 	}
 
+	if len(machineSetsToUpdate) > 0 {
+		var wg sync.WaitGroup
+		wg.Add(len(machineSetsToUpdate))
+		for i, ms := range machineSetsToUpdate {
+			go func(ix int, machineSet *clusteroperator.MachineSet) {
+				defer wg.Done()
+				if _, err := c.client.ClusteroperatorV1alpha1().MachineSets(cluster.Namespace).Update(machineSet); err != nil {
+					errCh <- err
+				} else {
+					colog.WithMachineSet(clusterLog, machineSet).Info("updated machine set")
+				}
+			}(i, ms)
+		}
+		wg.Wait()
+	}
+
 	if len(machineSetsToDelete) > 0 {
 		var wg sync.WaitGroup
 		wg.Add(len(machineSetsToDelete))
-		for i, ng := range machineSetsToDelete {
+		for i, ms := range machineSetsToDelete {
 			go func(ix int, machineSet *clusteroperator.MachineSet) {
 				defer wg.Done()
 				if err := c.client.ClusteroperatorV1alpha1().MachineSets(cluster.Namespace).Delete(machineSet.Name, &metav1.DeleteOptions{}); err != nil {
@@ -559,7 +578,7 @@ func (c *Controller) manageMachineSets(machineSets []*clusteroperator.MachineSet
 					colog.WithMachineSet(clusterLog, machineSet).Info("deleted machine set")
 				}
 
-			}(i, ng)
+			}(i, ms)
 		}
 		wg.Wait()
 	}
@@ -575,32 +594,52 @@ func (c *Controller) manageMachineSets(machineSets []*clusteroperator.MachineSet
 	return nil
 }
 
-// manageMachineSet determines whether or not a machine set needs to be created because it does not exist, or replaced because it is out of date.
-func (c *Controller) manageMachineSet(cluster *clusteroperator.Cluster, clusterVersion *clusteroperator.ClusterVersion, machineSet *clusteroperator.MachineSet, clusterMachineSetConfig clusteroperator.MachineSetConfig, machineSetNamePrefix string) (*clusteroperator.MachineSet, bool, error) {
+// shouldRecreateMachineSet will return true if the machine set config has changed with
+// the exception of size.
+func shouldRecreateMachineSet(existingConfig, newConfig clusteroperator.MachineSetConfig) bool {
+	existingConfig.Size = 0
+	newConfig.Size = 0
+	return !apiequality.Semantic.DeepEqual(existingConfig, newConfig)
+}
+
+// manageMachineSet determines whether or not a machine set needs to be created because it does not exist,
+// replaced because it is out of date, or updated in case of its size having changed.
+// return values:
+// - machineSet to create (MachineSet)
+// - should update machineset (bool)
+// - should delete machineset (bool)
+// - error
+func (c *Controller) manageMachineSet(cluster *clusteroperator.Cluster, clusterVersion *clusteroperator.ClusterVersion, machineSet *clusteroperator.MachineSet, clusterMachineSetConfig clusteroperator.MachineSetConfig, machineSetNamePrefix string) (*clusteroperator.MachineSet, bool, bool, error) {
 	clusterLog := colog.WithCluster(c.logger, cluster)
 	if machineSet == nil {
 		clusterLog.Debugf("building new machine set")
 		machineSet, err := buildNewMachineSet(cluster, clusterVersion, clusterMachineSetConfig, machineSetNamePrefix)
-		return machineSet, false, err
+		return machineSet, false, false, err
 	}
 
 	msLog := colog.WithMachineSet(clusterLog, machineSet)
 
-	if !apiequality.Semantic.DeepEqual(machineSet.Spec.MachineSetConfig, clusterMachineSetConfig) {
+	if shouldRecreateMachineSet(machineSet.Spec.MachineSetConfig, clusterMachineSetConfig) {
 		msLog.Infof("machine set configuration has changed from %v to %v",
 			machineSet.Spec.MachineSetConfig, clusterMachineSetConfig)
 		machineSet, err := buildNewMachineSet(cluster, clusterVersion, clusterMachineSetConfig, machineSetNamePrefix)
-		return machineSet, true, err
+		return machineSet, false, true, err
 	}
 
 	if machineSet.Spec.ClusterVersionRef.UID != clusterVersion.UID {
 		msLog.Infof("machine set cluster version has changed from %v to %s/%s",
 			machineSet.Spec.ClusterVersionRef, clusterVersion.Namespace, clusterVersion.Name)
 		machineSet, err := buildNewMachineSet(cluster, clusterVersion, clusterMachineSetConfig, machineSetNamePrefix)
-		return machineSet, true, err
+		return machineSet, false, true, err
 	}
 
-	return nil, false, nil
+	if machineSet.Spec.Size != clusterMachineSetConfig.Size {
+		machineSet.Spec.Size = clusterMachineSetConfig.Size
+		msLog.Infof("machine set size has changed from %d to %d", clusterMachineSetConfig.Size, machineSet.Spec.Size)
+		return nil, true, false, nil
+	}
+
+	return nil, false, false, nil
 }
 
 func (c *Controller) calculateStatus(clusterLog log.FieldLogger, cluster *clusteroperator.Cluster, resolvedClusterVersion *clusteroperator.ClusterVersion, machineSets []*clusteroperator.MachineSet) (clusteroperator.ClusterStatus, error) {

--- a/pkg/controller/cluster/cluster_controller_test.go
+++ b/pkg/controller/cluster/cluster_controller_test.go
@@ -117,6 +117,54 @@ func newCluster(cv *clusteroperator.ClusterVersion, computeNames ...string) *clu
 	return newClusterWithSizes(cv, 1, computes...)
 }
 
+// newClusterWithMasterInstanceType creates a new cluster with the specified instance type for the
+// master machine set and the specified cluster compute machine sets. If a clusterversion is
+// provided we set the spec version ref, as well as the status version ref. This implies
+// that the caller has added the provided version to the store.
+func newClusterWithMasterInstanceType(cv *clusteroperator.ClusterVersion, instanceType string, computes ...clusteroperator.ClusterMachineSet) *clusteroperator.Cluster {
+	cluster := &clusteroperator.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       testClusterUUID,
+			Name:      testClusterName,
+			Namespace: testNamespace,
+		},
+		Spec: clusteroperator.ClusterSpec{
+			MachineSets: append(computes, clusteroperator.ClusterMachineSet{
+				Name: "master",
+				MachineSetConfig: clusteroperator.MachineSetConfig{
+					Size:     1,
+					Infra:    true,
+					NodeType: clusteroperator.NodeTypeMaster,
+					Hardware: &clusteroperator.MachineSetHardwareSpec{
+						AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+							InstanceType: instanceType,
+						},
+					},
+				},
+			}),
+		},
+		Status: clusteroperator.ClusterStatus{
+			MasterMachineSetName: testClusterName + "-master-random",
+			InfraMachineSetName:  testClusterName + "-master-random",
+		},
+	}
+
+	// If clusterversion was provided we assume it exists in the store and set both
+	// the spec and the status:
+	if cv != nil {
+		cluster.Spec.ClusterVersionRef = clusteroperator.ClusterVersionReference{
+			Name:      cv.Name,
+			Namespace: cv.Namespace,
+		}
+		cluster.Status.ClusterVersionRef = &corev1.ObjectReference{
+			Name:      cv.Name,
+			Namespace: cv.Namespace,
+			UID:       cv.UID,
+		}
+	}
+	return cluster
+}
+
 // newClusterWithSizes creates a new cluster with the specified size for the
 // master machine set and the specified cluster compute machine sets. If a clusterversion is
 // provided we set the spec version ref, as well as the status version ref. This implies
@@ -212,6 +260,47 @@ func newMachineSetsWithSizes(store cache.Store, cluster *clusteroperator.Cluster
 		machineSet := newMachineSet(name, cluster, true)
 		machineSet.Spec.NodeType = clusteroperator.NodeTypeMaster
 		machineSet.Spec.Size = masterSize
+		machineSet.Spec.Infra = true
+		machineSet.Spec.ClusterVersionRef = corev1.ObjectReference{
+			Name:      clusterVersion.Name,
+			Namespace: clusterVersion.Namespace,
+			UID:       clusterVersion.UID,
+		}
+		machineSets = append(machineSets, machineSet)
+	}
+	for _, compute := range computes {
+		name := fmt.Sprintf("%s-%s-random", cluster.Name, compute.Name)
+		machineSet := newMachineSet(name, cluster, true)
+		machineSet.Spec.MachineSetConfig = compute.MachineSetConfig
+		machineSet.Spec.ClusterVersionRef = corev1.ObjectReference{
+			Name:      clusterVersion.Name,
+			Namespace: clusterVersion.Namespace,
+			UID:       clusterVersion.UID,
+		}
+		machineSets = append(machineSets, machineSet)
+	}
+	if store != nil {
+		for _, machineSet := range machineSets {
+			store.Add(machineSet)
+		}
+	}
+	return machineSets
+}
+
+// newMachineSetsWithMasterInstanceType creates new machine sets, with the specific instance type for the master and
+// stores them in the specified store.
+func newMachineSetsWithMasterInstanceType(store cache.Store, cluster *clusteroperator.Cluster, clusterVersion *clusteroperator.ClusterVersion, masterInstanceType string, computes ...clusteroperator.ClusterMachineSet) []*clusteroperator.MachineSet {
+	machineSets := []*clusteroperator.MachineSet{}
+	if len(masterInstanceType) > 0 {
+		name := fmt.Sprintf("%s-master-random", cluster.Name)
+		machineSet := newMachineSet(name, cluster, true)
+		machineSet.Spec.NodeType = clusteroperator.NodeTypeMaster
+		machineSet.Spec.Size = 1
+		machineSet.Spec.Hardware = &clusteroperator.MachineSetHardwareSpec{
+			AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+				InstanceType: masterInstanceType,
+			},
+		}
 		machineSet.Spec.Infra = true
 		machineSet.Spec.ClusterVersionRef = corev1.ObjectReference{
 			Name:      clusterVersion.Name,
@@ -385,6 +474,49 @@ func (ea expectedMachineSetCreateAction) validate(t *testing.T, action clientgot
 // action for creating a machine set.
 func newExpectedMachineSetCreateAction(cluster *clusteroperator.Cluster, name string) expectedMachineSetCreateAction {
 	return newExpectedMachineSetCreateActionWithHardwareSpec(cluster, name, nil)
+}
+
+// expectedMachineSetUpdateAction is an expected client action to update a
+// machine set.
+type expectedMachineSetUpdateAction struct {
+	namePrefix string
+	size       int
+}
+
+func (ea expectedMachineSetUpdateAction) resource() schema.GroupVersionResource {
+	return clusteroperator.SchemeGroupVersion.WithResource("machinesets")
+}
+
+func (ea expectedMachineSetUpdateAction) verb() string {
+	return "update"
+}
+
+func (ea expectedMachineSetUpdateAction) validate(t *testing.T, action clientgotesting.Action) bool {
+	updateAction, ok := action.(clientgotesting.UpdateAction)
+	if !ok {
+		t.Errorf("update action is not a UpdateAction: %t", updateAction)
+		return false
+	}
+	updatedObject := updateAction.GetObject()
+	machineSet, ok := updatedObject.(*clusteroperator.MachineSet)
+	if !ok {
+		t.Errorf("machine set update action object is not a MachineSet: %t", updatedObject)
+		return false
+	}
+	if !strings.HasPrefix(machineSet.Name, ea.namePrefix) {
+		return false
+	}
+	if e, a := ea.size, machineSet.Spec.Size; e != a {
+		t.Errorf("unexpected size: expected %d, got %d", e, a)
+		return false
+	}
+	return true
+}
+
+// newExpectedMachineSetUpdateAction creates a new expected client
+// action for updating a machine set.
+func newExpectedMachineSetUpdateAction(cluster *clusteroperator.Cluster, name string, size int) expectedMachineSetUpdateAction {
+	return expectedMachineSetUpdateAction{namePrefix: cluster.Name + "-" + name, size: size}
 }
 
 // newExpectedMachineSetCreateActionWithHardwareSpec creates a new expected
@@ -1057,6 +1189,120 @@ func TestSyncClusterMachineSetsRemoved(t *testing.T) {
 // specifications in the cluster spec have been mutated.
 func TestSyncClusterMachineSetSpecMutated(t *testing.T) {
 	cases := []struct {
+		name                         string
+		clusterMasterInstanceType    string
+		realizedMasterInstanceType   string
+		clusterComputeInstanceTypes  []string
+		realizedComputeInstanceTypes []string
+	}{
+		{
+			name: "master only",
+			clusterMasterInstanceType:  "a",
+			realizedMasterInstanceType: "b",
+		},
+		{
+			name: "single compute",
+			clusterMasterInstanceType:    "a",
+			realizedMasterInstanceType:   "a",
+			clusterComputeInstanceTypes:  []string{"b"},
+			realizedComputeInstanceTypes: []string{"c"},
+		},
+		{
+			name: "multiple computes",
+			clusterMasterInstanceType:    "a",
+			realizedMasterInstanceType:   "a",
+			clusterComputeInstanceTypes:  []string{"b", "c"},
+			realizedComputeInstanceTypes: []string{"d", "e"},
+		},
+		{
+			name: "master and computes",
+			clusterMasterInstanceType:    "a",
+			realizedMasterInstanceType:   "b",
+			clusterComputeInstanceTypes:  []string{"c", "d"},
+			realizedComputeInstanceTypes: []string{"e", "f"},
+		},
+		{
+			name: "subset of computes",
+			clusterMasterInstanceType:    "a",
+			realizedMasterInstanceType:   "b",
+			clusterComputeInstanceTypes:  []string{"c", "d", "e"},
+			realizedComputeInstanceTypes: []string{"g", "h", "e"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if a, b := len(tc.clusterComputeInstanceTypes), len(tc.realizedComputeInstanceTypes); a != b {
+				t.Skipf("clusterComputeInstanceTypes length must be equal to realizedComputeInstanceTypes length: %v, %v", a, b)
+			}
+
+			controller, clusterStore, machineSetStore, clusterVerStore, _, clusterOperatorClient := newTestController()
+
+			clusterComputes := make([]clusteroperator.ClusterMachineSet, len(tc.clusterComputeInstanceTypes))
+			realizedComputes := make([]clusteroperator.ClusterMachineSet, len(tc.realizedComputeInstanceTypes))
+			for i := range tc.clusterComputeInstanceTypes {
+				name := fmt.Sprintf("compute%v", i)
+				clusterComputes[i] = clusteroperator.ClusterMachineSet{
+					MachineSetConfig: clusteroperator.MachineSetConfig{
+						NodeType: clusteroperator.NodeTypeCompute,
+						Size:     1,
+						Hardware: &clusteroperator.MachineSetHardwareSpec{
+							AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+								InstanceType: tc.clusterComputeInstanceTypes[i],
+							},
+						},
+					},
+					Name: name,
+				}
+				realizedComputes[i] = clusteroperator.ClusterMachineSet{
+					MachineSetConfig: clusteroperator.MachineSetConfig{
+						NodeType: clusteroperator.NodeTypeCompute,
+						Size:     1,
+						Hardware: &clusteroperator.MachineSetHardwareSpec{
+							AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+								InstanceType: tc.realizedComputeInstanceTypes[i],
+							},
+						},
+					},
+					Name: name,
+				}
+			}
+			cv := newClusterVer(testClusterVerNS, testClusterVerName, testClusterVerUID)
+			cluster := newClusterWithMasterInstanceType(cv, tc.clusterMasterInstanceType, clusterComputes...)
+			cluster.Status.MachineSetCount = len(clusterComputes) + 1
+			clusterVerStore.Add(cv)
+			clusterStore.Add(cluster)
+			newMachineSetsWithMasterInstanceType(machineSetStore, cluster, cv, tc.realizedMasterInstanceType, realizedComputes...)
+
+			controller.syncCluster(getKey(cluster, t))
+
+			expectedActions := []expectedClientAction{}
+			if tc.clusterMasterInstanceType != tc.realizedMasterInstanceType {
+				expectedActions = append(expectedActions,
+					newExpectedMachineSetDeleteAction(cluster, "master"),
+					newExpectedMachineSetCreateAction(cluster, "master"),
+				)
+			}
+			for i, clusterCompute := range clusterComputes {
+				if clusterCompute.Hardware.AWS.InstanceType == tc.realizedComputeInstanceTypes[i] {
+					continue
+				}
+				expectedActions = append(expectedActions,
+					newExpectedMachineSetDeleteAction(cluster, clusterCompute.Name),
+					newExpectedMachineSetCreateAction(cluster, clusterCompute.Name),
+				)
+			}
+
+			validateClientActions(t, "TestSyncClusterMachineSetSpecMutated."+tc.name, clusterOperatorClient, expectedActions...)
+
+			validateControllerExpectations(t, "TestSyncClusterMachineSetSpecMutated."+tc.name, controller, cluster, len(expectedActions)/2, len(expectedActions)/2)
+		})
+	}
+}
+
+// TestSyncClusterMachineSetSpecScaled tests syncing a cluster when machine set
+// sizes in the cluster spec have been mutated.
+func TestSyncClusterMachineSetSpecScaled(t *testing.T) {
+	cases := []struct {
 		name                 string
 		clusterMasterSize    int
 		realizedMasterSize   int
@@ -1136,8 +1382,7 @@ func TestSyncClusterMachineSetSpecMutated(t *testing.T) {
 			expectedActions := []expectedClientAction{}
 			if tc.clusterMasterSize != tc.realizedMasterSize {
 				expectedActions = append(expectedActions,
-					newExpectedMachineSetDeleteAction(cluster, "master"),
-					newExpectedMachineSetCreateAction(cluster, "master"),
+					newExpectedMachineSetUpdateAction(cluster, "master", tc.clusterMasterSize),
 				)
 			}
 			for i, clusterCompute := range clusterComputes {
@@ -1145,14 +1390,11 @@ func TestSyncClusterMachineSetSpecMutated(t *testing.T) {
 					continue
 				}
 				expectedActions = append(expectedActions,
-					newExpectedMachineSetDeleteAction(cluster, clusterCompute.Name),
-					newExpectedMachineSetCreateAction(cluster, clusterCompute.Name),
+					newExpectedMachineSetUpdateAction(cluster, clusterCompute.Name, clusterCompute.Size),
 				)
 			}
 
-			validateClientActions(t, "TestSyncClusterMachineSetsMutated."+tc.name, clusterOperatorClient, expectedActions...)
-
-			validateControllerExpectations(t, "TestSyncClusterMachineSetsMutated."+tc.name, controller, cluster, len(expectedActions)/2, len(expectedActions)/2)
+			validateClientActions(t, "TestSyncClusterMachineSetSpecScaled."+tc.name, clusterOperatorClient, expectedActions...)
 		})
 	}
 }
@@ -1297,11 +1539,16 @@ func TestSyncClusterComplex(t *testing.T) {
 
 	cv := newClusterVer(testClusterVerNS, testClusterVerName, testClusterVerUID)
 	clusterVerStore.Add(cv)
-	cluster := newClusterWithSizes(cv, 1,
+	cluster := newClusterWithMasterInstanceType(cv, "a",
 		clusteroperator.ClusterMachineSet{
 			MachineSetConfig: clusteroperator.MachineSetConfig{
 				Size:     1,
 				NodeType: clusteroperator.NodeTypeCompute,
+				Hardware: &clusteroperator.MachineSetHardwareSpec{
+					AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+						InstanceType: "a",
+					},
+				},
 			},
 			Name: "realized and un-mutated",
 		},
@@ -1309,6 +1556,11 @@ func TestSyncClusterComplex(t *testing.T) {
 			MachineSetConfig: clusteroperator.MachineSetConfig{
 				Size:     1,
 				NodeType: clusteroperator.NodeTypeCompute,
+				Hardware: &clusteroperator.MachineSetHardwareSpec{
+					AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+						InstanceType: "a",
+					},
+				},
 			},
 			Name: "realized but mutated",
 		},
@@ -1322,11 +1574,16 @@ func TestSyncClusterComplex(t *testing.T) {
 	)
 	clusterStore.Add(cluster)
 
-	newMachineSetsWithSizes(machineSetStore, cluster, cv, 2,
+	newMachineSetsWithMasterInstanceType(machineSetStore, cluster, cv, "b",
 		clusteroperator.ClusterMachineSet{
 			MachineSetConfig: clusteroperator.MachineSetConfig{
 				Size:     1,
 				NodeType: clusteroperator.NodeTypeCompute,
+				Hardware: &clusteroperator.MachineSetHardwareSpec{
+					AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+						InstanceType: "a",
+					},
+				},
 			},
 			Name: "realized and un-mutated",
 		},
@@ -1334,6 +1591,11 @@ func TestSyncClusterComplex(t *testing.T) {
 			MachineSetConfig: clusteroperator.MachineSetConfig{
 				Size:     2,
 				NodeType: clusteroperator.NodeTypeCompute,
+				Hardware: &clusteroperator.MachineSetHardwareSpec{
+					AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+						InstanceType: "b",
+					},
+				},
 			},
 			Name: "realized but mutated",
 		},


### PR DESCRIPTION
Modifies cluster controller to ignore size when deciding whether to recreate a machineset due to a spec change.

Updates unit tests to use instance type instead of size to test machineset mutation.