### PR TITLE
Run all playbook jobs in parallel

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -479,7 +479,6 @@ func startMachineSetController(ctx ControllerContext) (bool, error) {
 		return false, nil
 	}
 	go machineset.NewController(
-		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-machine-set-controller"),
@@ -507,7 +506,6 @@ func startMasterController(ctx ControllerContext) (bool, error) {
 		return false, nil
 	}
 	go master.NewController(
-		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-master-controller"),
@@ -523,7 +521,6 @@ func startAcceptController(ctx ControllerContext) (bool, error) {
 		return false, nil
 	}
 	go accept.NewController(
-		ctx.InformerFactory.Clusteroperator().V1alpha1().Clusters(),
 		ctx.InformerFactory.Clusteroperator().V1alpha1().MachineSets(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-accept-controller"),

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -394,6 +394,9 @@ type MachineSetSpec struct {
 	// MachineSetConfig is the configuration for the MachineSet
 	MachineSetConfig
 
+	// ClusterHardware specifies the hardware that the cluster will run on
+	ClusterHardware ClusterHardwareSpec
+
 	// ClusterVersionRef references the clusterversion the machine set is running.
 	ClusterVersionRef corev1.ObjectReference
 }

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -397,6 +397,9 @@ type MachineSetSpec struct {
 	// MachineSetConfig is the configuration for the MachineSet
 	MachineSetConfig `json:",inline"`
 
+	// ClusterHardware specifies the hardware that the cluster will run on
+	ClusterHardware ClusterHardwareSpec `json:"clusterHardware"`
+
 	// ClusterVersionRef references the clusterversion the machine set is running.
 	ClusterVersionRef corev1.ObjectReference `json:"clusterVersionRef"`
 }

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -745,6 +745,9 @@ func autoConvert_v1alpha1_MachineSetSpec_To_clusteroperator_MachineSetSpec(in *M
 	if err := Convert_v1alpha1_MachineSetConfig_To_clusteroperator_MachineSetConfig(&in.MachineSetConfig, &out.MachineSetConfig, s); err != nil {
 		return err
 	}
+	if err := Convert_v1alpha1_ClusterHardwareSpec_To_clusteroperator_ClusterHardwareSpec(&in.ClusterHardware, &out.ClusterHardware, s); err != nil {
+		return err
+	}
 	out.ClusterVersionRef = in.ClusterVersionRef
 	return nil
 }
@@ -756,6 +759,9 @@ func Convert_v1alpha1_MachineSetSpec_To_clusteroperator_MachineSetSpec(in *Machi
 
 func autoConvert_clusteroperator_MachineSetSpec_To_v1alpha1_MachineSetSpec(in *clusteroperator.MachineSetSpec, out *MachineSetSpec, s conversion.Scope) error {
 	if err := Convert_clusteroperator_MachineSetConfig_To_v1alpha1_MachineSetConfig(&in.MachineSetConfig, &out.MachineSetConfig, s); err != nil {
+		return err
+	}
+	if err := Convert_clusteroperator_ClusterHardwareSpec_To_v1alpha1_ClusterHardwareSpec(&in.ClusterHardware, &out.ClusterHardware, s); err != nil {
 		return err
 	}
 	out.ClusterVersionRef = in.ClusterVersionRef

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -654,6 +654,7 @@ func (in *MachineSetList) DeepCopyObject() runtime.Object {
 func (in *MachineSetSpec) DeepCopyInto(out *MachineSetSpec) {
 	*out = *in
 	in.MachineSetConfig.DeepCopyInto(&out.MachineSetConfig)
+	in.ClusterHardware.DeepCopyInto(&out.ClusterHardware)
 	out.ClusterVersionRef = in.ClusterVersionRef
 	return
 }

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -654,6 +654,7 @@ func (in *MachineSetList) DeepCopyObject() runtime.Object {
 func (in *MachineSetSpec) DeepCopyInto(out *MachineSetSpec) {
 	*out = *in
 	in.MachineSetConfig.DeepCopyInto(&out.MachineSetConfig)
+	in.ClusterHardware.DeepCopyInto(&out.ClusterHardware)
 	out.ClusterVersionRef = in.ClusterVersionRef
 	return
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1047,6 +1047,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"clusterHardware": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterHardware specifies the hardware that the cluster will run on",
+								Ref:         ref("github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec"),
+							},
+						},
 						"clusterVersionRef": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ClusterVersionRef references the clusterversion the machine set is running.",
@@ -1054,11 +1060,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"nodeType", "infra", "size", "nodeLabels", "clusterVersionRef"},
+					Required: []string{"nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "k8s.io/api/core/v1.ObjectReference"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "k8s.io/api/core/v1.ObjectReference"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetStatus": {
 			Schema: spec.Schema{
@@ -10173,7 +10179,15 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
 					Description: "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
-					Properties:  map[string]spec.Schema{},
+					Properties: map[string]spec.Schema{
+						"Duration": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"integer"},
+								Format: "int64",
+							},
+						},
+					},
+					Required: []string{"Duration"},
 				},
 			},
 			Dependencies: []string{},

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -341,7 +341,6 @@ func startServerAndControllers(t *testing.T) (
 		}(),
 		func() func() {
 			controller := machinesetcontroller.NewController(
-				coSharedInformers.Clusters(),
 				coSharedInformers.MachineSets(),
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,
@@ -353,7 +352,6 @@ func startServerAndControllers(t *testing.T) (
 		}(),
 		func() func() {
 			controller := mastercontroller.NewController(
-				coSharedInformers.Clusters(),
 				coSharedInformers.MachineSets(),
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,
@@ -365,7 +363,6 @@ func startServerAndControllers(t *testing.T) (
 		}(),
 		func() func() {
 			controller := acceptcontroller.NewController(
-				coSharedInformers.Clusters(),
 				coSharedInformers.MachineSets(),
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,


### PR DESCRIPTION
* Each controller runs its playbook without worrying about whether other playbooks that set up dependencies have been run yet. If those dependencies are have not been set up yet, then the dependent playbook will fail and be retried. This greatly simplifies the controllers because they do not have to worry about checking on the state into which other controllers have put the kube objects.
* A MachineSet object contains all of the information that is needed to run playbooks for the MachineSet. Controllers syncing a MachineSet no longer need to fetch the owning Cluster.

In my experience, running all the ansible playbooks in parallel has actually slowed the total time that it takes to go from cold start to a working cluster. This may be due to the exponential backoffs of the jobs making it so that the successful run of each job starts later than it would have if the controller started it as soon as its dependent job completed. We may be able to improve upon this by tweaking the settings for the jobs.