### PR TITLE
Deprovision clusters and machine sets

### DIFF
--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -328,6 +328,10 @@ const (
 	ClusterInfraProvisioningFailed ClusterConditionType = "InfraProvisioningFailed"
 	// ClusterInfraProvisioned represents success of the infra provisioning for this cluster.
 	ClusterInfraProvisioned ClusterConditionType = "InfraProvisioned"
+	// ClusterInfraDeprovisioning is true when cluster infrastructure is in the process of deprovisioning
+	ClusterInfraDeprovisioning ClusterConditionType = "InfraDeprovisioning"
+	// ClusterInfraDeprovisioningFailed is true when the job to deprovision cluster infrastructure has failed.
+	ClusterInfraDeprovisioningFailed ClusterConditionType = "InfraDeprovisioningFailed"
 	// ClusterReady means the cluster is able to service requests
 	ClusterReady ClusterConditionType = "Ready"
 )
@@ -522,6 +526,14 @@ const (
 	// MachineSetHardwareProvisioningFailed is true if the last provisioning attempt
 	// for this machine set failed.
 	MachineSetHardwareProvisioningFailed MachineSetConditionType = "HardwareProvisioningFailed"
+
+	// MachineSetHardwareDeprovisioning is true if the cloud resources for this
+	// machine set are in the process of deprovisioning.
+	MachineSetHardwareDeprovisioning MachineSetConditionType = "HardwareDeprovisioning"
+
+	// MachineSetHardwareDeprovisioningFailed is true if the last deprovisioning attempt
+	// for this machine set failed.
+	MachineSetHardwareDeprovisioningFailed MachineSetConditionType = "HardwareDeprovisioningFailed"
 
 	// MachineSetHardwareProvisioned is true if the corresponding cloud resource(s) for
 	// this machine set have been provisioned (ie. AWS autoscaling group)

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -331,6 +331,10 @@ const (
 	ClusterInfraProvisioningFailed ClusterConditionType = "InfraProvisioningFailed"
 	// ClusterInfraProvisioned represents success of the infra provisioning for this cluster.
 	ClusterInfraProvisioned ClusterConditionType = "InfraProvisioned"
+	// ClusterInfraDeprovisioning is true when cluster infrastructure is in the process of deprovisioning
+	ClusterInfraDeprovisioning ClusterConditionType = "InfraDeprovisioning"
+	// ClusterInfraDeprovisioningFailed is true when the job to deprovision cluster infrastructure has failed.
+	ClusterInfraDeprovisioningFailed ClusterConditionType = "InfraDeprovisioningFailed"
 	// ClusterReady means the cluster is able to service requests
 	ClusterReady ClusterConditionType = "Ready"
 )
@@ -529,6 +533,14 @@ const (
 	// MachineSetHardwareProvisioned is true if the corresponding cloud resource(s) for
 	// this machine set have been provisioned (ie. AWS autoscaling group)
 	MachineSetHardwareProvisioned MachineSetConditionType = "HardwareProvisioned"
+
+	// MachineSetHardwareDeprovisioning is true if the cloud resources for this
+	// machine set are in the process of deprovisioning.
+	MachineSetHardwareDeprovisioning MachineSetConditionType = "HardwareDeprovisioning"
+
+	// MachineSetHardwareDeprovisioningFailed is true if the last deprovisioning attempt
+	// for this machine set failed.
+	MachineSetHardwareDeprovisioningFailed MachineSetConditionType = "HardwareDeprovisioningFailed"
 
 	// MachineSetInstalling is true if OpenShift is being installed on
 	// this machine set.

--- a/pkg/controller/accept/accept_controller.go
+++ b/pkg/controller/accept/accept_controller.go
@@ -103,7 +103,7 @@ func NewController(
 	jobInformer.Informer().AddEventHandler(c.jobControl)
 	c.jobsSynced = jobInformer.Informer().HasSynced
 
-	c.jobSync = controller.NewJobSync(c.jobControl, &jobSyncStrategy{controller: c}, logger)
+	c.jobSync = controller.NewJobSync(c.jobControl, &jobSyncStrategy{controller: c}, false, logger)
 
 	c.syncHandler = c.jobSync.Sync
 	c.enqueueMachineSet = c.enqueue
@@ -290,7 +290,10 @@ func (s *jobSyncStrategy) DoesOwnerNeedProcessing(owner metav1.Object) bool {
 	return true
 }
 
-func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object) (controller.JobFactory, error) {
+func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (controller.JobFactory, error) {
+	if deleting {
+		return nil, fmt.Errorf("should not be undoing on deletes")
+	}
 	machineSet, ok := owner.(*clusteroperator.MachineSet)
 	if !ok {
 		return nil, fmt.Errorf("could not convert owner from JobSync into a machine set")
@@ -403,10 +406,6 @@ func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error
 		return fmt.Errorf("could not convert owner from JobSync into a machine set: %#v", owner)
 	}
 	return controller.PatchMachineSetStatus(s.controller.client, originalMachineSet, machineSet)
-}
-
-func (s *jobSyncStrategy) ProcessDeletedOwner(owner metav1.Object) error {
-	return nil
 }
 
 func convertJobSyncConditionType(conditionType controller.JobSyncConditionType) clusteroperator.MachineSetConditionType {

--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -373,6 +373,11 @@ func (c *Controller) syncCluster(key string) error {
 	}
 	clusterLog := colog.WithCluster(c.logger, cluster)
 
+	if cluster.DeletionTimestamp != nil {
+		clusterLog.Debug("skipping sync since cluster is being deleted")
+		return nil
+	}
+
 	clusterNeedsSync := c.expectations.SatisfiedExpectations(key)
 
 	// List all active machine sets owned by this cluster

--- a/pkg/controller/jobcontrol.go
+++ b/pkg/controller/jobcontrol.go
@@ -98,6 +98,8 @@ type JobControl interface {
 	// ObserveOwnerDeletion observes that the owner with the specified key was
 	// deleted.
 	ObserveOwnerDeletion(ownerKey string)
+
+	GetJobPrefix() string
 }
 
 var _ cache.ResourceEventHandler = (JobControl)(nil)
@@ -243,6 +245,10 @@ func (c *jobControl) ControlJobs(
 
 func (c *jobControl) ObserveOwnerDeletion(ownerKey string) {
 	c.expectations.DeleteExpectations(ownerKey)
+}
+
+func (c *jobControl) GetJobPrefix() string {
+	return c.jobPrefix
 }
 
 func (c *jobControl) isControlledJob(job *kbatch.Job) bool {

--- a/pkg/controller/jobsyncstrategy.go
+++ b/pkg/controller/jobsyncstrategy.go
@@ -34,7 +34,7 @@ type JobSyncStrategy interface {
 	DoesOwnerNeedProcessing(owner metav1.Object) bool
 
 	// GetJobFactory gets a factory for building a job to do the processing.
-	GetJobFactory(owner metav1.Object) (JobFactory, error)
+	GetJobFactory(owner metav1.Object, deleting bool) (JobFactory, error)
 
 	// GetOwnerCurrentJob gets the name of the current job for the owner. If
 	// there is not a current job, then returns an empty string.
@@ -67,8 +67,4 @@ type JobSyncStrategy interface {
 	// UpdateOwnerStatus updates the status of the owner from the original
 	// copy to the owner copy.
 	UpdateOwnerStatus(original, owner metav1.Object) error
-
-	// ProcessDeletedOwner processes an owner that has been marked for
-	// deletion.
-	ProcessDeletedOwner(owner metav1.Object) error
 }

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -102,7 +102,7 @@ func NewController(
 	jobInformer.Informer().AddEventHandler(c.jobControl)
 	c.jobsSynced = jobInformer.Informer().HasSynced
 
-	c.jobSync = controller.NewJobSync(c.jobControl, &jobSyncStrategy{controller: c}, logger)
+	c.jobSync = controller.NewJobSync(c.jobControl, &jobSyncStrategy{controller: c}, false, logger)
 
 	c.syncHandler = c.jobSync.Sync
 	c.enqueueMachineSet = c.enqueue
@@ -314,7 +314,10 @@ func (s *jobSyncStrategy) DoesOwnerNeedProcessing(owner metav1.Object) bool {
 	return machineSet.Status.InstalledJobGeneration != machineSet.Generation
 }
 
-func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object) (controller.JobFactory, error) {
+func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (controller.JobFactory, error) {
+	if deleting {
+		return nil, fmt.Errorf("should not be undoing on deletes")
+	}
 	machineSet, ok := owner.(*clusteroperator.MachineSet)
 	if !ok {
 		return nil, fmt.Errorf("could not convert owner from JobSync into a machineset")
@@ -424,10 +427,6 @@ func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error
 		return fmt.Errorf("could not convert owner from JobSync into a machineset")
 	}
 	return controller.PatchMachineSetStatus(s.controller.client, originalMachineSet, machineSet)
-}
-
-func (s *jobSyncStrategy) ProcessDeletedOwner(owner metav1.Object) error {
-	return nil
 }
 
 func convertJobSyncConditionType(conditionType controller.JobSyncConditionType) clusteroperator.MachineSetConditionType {

--- a/pkg/controller/mockjobcontrol_generated_test.go
+++ b/pkg/controller/mockjobcontrol_generated_test.go
@@ -89,6 +89,18 @@ func (mr *MockJobControlMockRecorder) ObserveOwnerDeletion(ownerKey interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveOwnerDeletion", reflect.TypeOf((*MockJobControl)(nil).ObserveOwnerDeletion), ownerKey)
 }
 
+// GetJobPrefix mocks base method
+func (m *MockJobControl) GetJobPrefix() string {
+	ret := m.ctrl.Call(m, "GetJobPrefix")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetJobPrefix indicates an expected call of GetJobPrefix
+func (mr *MockJobControlMockRecorder) GetJobPrefix() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobPrefix", reflect.TypeOf((*MockJobControl)(nil).GetJobPrefix))
+}
+
 // MockJobOwnerControl is a mock of JobOwnerControl interface
 type MockJobOwnerControl struct {
 	ctrl     *gomock.Controller

--- a/pkg/controller/mockjobsyncstrategy_generated_test.go
+++ b/pkg/controller/mockjobsyncstrategy_generated_test.go
@@ -60,16 +60,16 @@ func (mr *MockJobSyncStrategyMockRecorder) DoesOwnerNeedProcessing(owner interfa
 }
 
 // GetJobFactory mocks base method
-func (m *MockJobSyncStrategy) GetJobFactory(owner v10.Object) (JobFactory, error) {
-	ret := m.ctrl.Call(m, "GetJobFactory", owner)
+func (m *MockJobSyncStrategy) GetJobFactory(owner v10.Object, deleting bool) (JobFactory, error) {
+	ret := m.ctrl.Call(m, "GetJobFactory", owner, deleting)
 	ret0, _ := ret[0].(JobFactory)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetJobFactory indicates an expected call of GetJobFactory
-func (mr *MockJobSyncStrategyMockRecorder) GetJobFactory(owner interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobFactory", reflect.TypeOf((*MockJobSyncStrategy)(nil).GetJobFactory), owner)
+func (mr *MockJobSyncStrategyMockRecorder) GetJobFactory(owner, deleting interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobFactory", reflect.TypeOf((*MockJobSyncStrategy)(nil).GetJobFactory), owner, deleting)
 }
 
 // GetOwnerCurrentJob mocks base method
@@ -146,16 +146,4 @@ func (m *MockJobSyncStrategy) UpdateOwnerStatus(original, owner v10.Object) erro
 // UpdateOwnerStatus indicates an expected call of UpdateOwnerStatus
 func (mr *MockJobSyncStrategyMockRecorder) UpdateOwnerStatus(original, owner interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOwnerStatus", reflect.TypeOf((*MockJobSyncStrategy)(nil).UpdateOwnerStatus), original, owner)
-}
-
-// ProcessDeletedOwner mocks base method
-func (m *MockJobSyncStrategy) ProcessDeletedOwner(owner v10.Object) error {
-	ret := m.ctrl.Call(m, "ProcessDeletedOwner", owner)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ProcessDeletedOwner indicates an expected call of ProcessDeletedOwner
-func (mr *MockJobSyncStrategyMockRecorder) ProcessDeletedOwner(owner interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessDeletedOwner", reflect.TypeOf((*MockJobSyncStrategy)(nil).ProcessDeletedOwner), owner)
 }

--- a/test/integration/jobutils.go
+++ b/test/integration/jobutils.go
@@ -1,0 +1,388 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kbatch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	// avoid error `clusteroperator/v1alpha1 is not enabled`
+	_ "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/install"
+
+	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	"github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+)
+
+// completeProcessingJob completes a processing job for the object with the
+// specified namespace and name. Verification is performed to wait for the
+// object to be in a state where the job is running before completing the job
+// and to wait for the object to be in a state where the job has been
+// completed successfully after the job is completed.
+func completeProcessingJob(
+	t *testing.T,
+	jobLabel string,
+	kubeClient *kubefake.Clientset,
+	namespace, name string,
+	getFromStore func(namespace, name string) (metav1.Object, error),
+	getJobRef func(metav1.Object) *corev1.LocalObjectReference,
+	verifyJobCompleted func(namespace, name string) error,
+) bool {
+	if err := waitForObjectStatus(
+		namespace, name,
+		getFromStore,
+		func(obj metav1.Object) bool { return getJobRef(obj) != nil },
+	); err != nil {
+		t.Fatalf("error waiting for %s job creation for object %s/%s: %v", jobLabel, namespace, name, err)
+	}
+
+	obj, err := getFromStore(namespace, name)
+	if !assert.NoError(t, err, "error getting object %s/%s for %s job", namespace, name, jobLabel) {
+		return false
+	}
+	if !assert.NotNil(t, obj, "expecting object %s/%s to exist for %s job", namespace, name, jobLabel) {
+		return false
+	}
+	jobRef := getJobRef(obj)
+	if !assert.NotNil(t, jobRef, "expecting object %s/%s to be associated with a %s job", namespace, name, jobLabel) {
+		return false
+	}
+	job, err := getJob(kubeClient, namespace, jobRef.Name)
+	if !assert.NoError(t, err, "error getting %s job for object %s/%s", jobLabel, namespace, name) {
+		return false
+	}
+	if !assert.NotNil(t, job, "expecting %s job to exist for object %s/%s", jobLabel, namespace, name) {
+		return false
+	}
+
+	if err := completeJob(kubeClient, job); err != nil {
+		t.Fatalf("error updating %s job for object %s/%s: %v", jobLabel, namespace, name, err)
+	}
+
+	if err := verifyJobCompleted(namespace, name); err != nil {
+		t.Fatalf("error waiting for %s job completion for object %s/%s: %v", jobLabel, namespace, name, err)
+	}
+
+	return true
+}
+
+// completeClusterProcessingJob completes a processing job for the cluster
+// with the specified namespace and name. Verification is performed to wait
+// for the cluster to be in a state where the job is running before completing
+// the job and to wait for the cluster to be in a state where the job has been
+// completed successfully after the job is completed.
+func completeClusterProcessingJob(
+	t *testing.T,
+	jobLabel string,
+	kubeClient *kubefake.Clientset,
+	clusterOperatorClient clientset.Interface,
+	namespace, name string,
+	getJobRef func(*v1alpha1.Cluster) *corev1.LocalObjectReference,
+	verifyJobCompleted func(clientset.Interface /*namespace*/, string /*name*/, string) error,
+) bool {
+	return completeProcessingJob(
+		t,
+		jobLabel,
+		kubeClient,
+		namespace, name,
+		func(namespace, name string) (metav1.Object, error) {
+			return getCluster(clusterOperatorClient, namespace, name)
+		},
+		func(obj metav1.Object) *corev1.LocalObjectReference {
+			return getJobRef(obj.(*v1alpha1.Cluster))
+		},
+		func(namespace, name string) error {
+			return verifyJobCompleted(clusterOperatorClient, namespace, name)
+		},
+	)
+}
+
+// completeMachineSetProcessingJob completes a processing job for the machine
+// set with the specified namespace and name. Verification is performed to
+// wait for the machine set to be in a state where the job is running before
+// completing the job and to wait for the machine set to be in a state where
+// the job has been completed successfully after the job is completed.
+func completeMachineSetProcessingJob(
+	t *testing.T,
+	jobLabel string,
+	kubeClient *kubefake.Clientset,
+	clusterOperatorClient clientset.Interface,
+	namespace, name string,
+	getJobRef func(*v1alpha1.MachineSet) *corev1.LocalObjectReference,
+	verifyJobCompleted func(clientset.Interface /*namespace*/, string /*name*/, string) error,
+) bool {
+	return completeProcessingJob(
+		t,
+		jobLabel,
+		kubeClient,
+		namespace, name,
+		func(namespace, name string) (metav1.Object, error) {
+			return getMachineSet(clusterOperatorClient, namespace, name)
+		},
+		func(obj metav1.Object) *corev1.LocalObjectReference {
+			return getJobRef(obj.(*v1alpha1.MachineSet))
+		},
+		func(namespace, name string) error {
+			return verifyJobCompleted(clusterOperatorClient, namespace, name)
+		},
+	)
+}
+
+// completeMachineSetsProcessingJobs completes the processing jobs for the
+// specified machine sets. Verification is performed to
+// wait for the machine sets to be in a state where the job is running before
+// completing the jobs and to wait for the machine sets to be in a state where
+// the job has been completed successfully after the jobs are completed.
+func completeMachineSetsProcessingJobs(
+	machineSets []*v1alpha1.MachineSet,
+	verification func(*v1alpha1.MachineSet) bool,
+) bool {
+	errCh := make(chan error, len(machineSets))
+
+	var wg sync.WaitGroup
+	wg.Add(len(machineSets))
+	for i, ms := range machineSets {
+		go func(ix int, machineSet *v1alpha1.MachineSet) {
+			defer wg.Done()
+			if !verification(machineSet) {
+				errCh <- fmt.Errorf("verification of machine set %s/%s failed for job", machineSet.Namespace, machineSet.Name)
+			}
+		}(i, ms)
+	}
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return false
+		}
+	default:
+	}
+	return true
+}
+
+// completeInfraProvision waits for the cluster to be provisioning,
+// completes the provision job, and waits for the cluster to be provisioned.
+func completeInfraProvision(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, cluster *v1alpha1.Cluster) bool {
+	if !completeClusterProcessingJob(
+		t,
+		"provision",
+		kubeClient,
+		clusterOperatorClient,
+		cluster.Namespace, cluster.Name,
+		func(cluster *v1alpha1.Cluster) *corev1.LocalObjectReference { return cluster.Status.ProvisionJob },
+		waitForClusterProvisioned,
+	) {
+		return false
+	}
+
+	storedCluster, err := getCluster(clusterOperatorClient, cluster.Namespace, cluster.Name)
+	if !assert.NoError(t, err, "error getting stored cluster") {
+		return false
+	}
+	if !assert.NotEmpty(t, storedCluster.Finalizers, "cluster should have a finalizer for infra provisioning") {
+		return false
+	}
+
+	return true
+}
+
+// completeInfraDeprovision waits for the cluster to be deprovisioning,
+// completes the deprovision job, and waits for the cluster to have its
+// provision finalizer removed.
+func completeInfraDeprovision(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, cluster *v1alpha1.Cluster) bool {
+	return completeClusterProcessingJob(
+		t,
+		"deprovision",
+		kubeClient,
+		clusterOperatorClient,
+		cluster.Namespace, cluster.Name,
+		func(cluster *v1alpha1.Cluster) *corev1.LocalObjectReference { return cluster.Status.ProvisionJob },
+		func(client clientset.Interface, namespace, name string) error {
+			return waitForObjectToNotExistOrNotHaveFinalizer(
+				namespace, name,
+				"openshift/cluster-operator-job-infra-1",
+				func(namespace, name string) (metav1.Object, error) {
+					return getCluster(client, namespace, name)
+				},
+			)
+		},
+	)
+}
+
+// completeMachineSetProvision waits for the machine set to be
+// provisioning, completes the provision job, and waits for the machine set
+// to be provisioned.
+func completeMachineSetProvision(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, machineSet *v1alpha1.MachineSet) bool {
+	if !completeMachineSetProcessingJob(
+		t,
+		"provision",
+		kubeClient,
+		clusterOperatorClient,
+		machineSet.Namespace, machineSet.Name,
+		func(machineSet *v1alpha1.MachineSet) *corev1.LocalObjectReference {
+			return machineSet.Status.ProvisionJob
+		},
+		func(client clientset.Interface, namespace, name string) error {
+			return waitForMachineSetStatus(
+				client,
+				namespace, name,
+				func(machineSet *v1alpha1.MachineSet) bool {
+					return machineSet.Status.Provisioned
+				},
+			)
+		},
+	) {
+		return false
+	}
+
+	storedMachineSet, err := getMachineSet(clusterOperatorClient, machineSet.Namespace, machineSet.Name)
+	if !assert.NoError(t, err, "error getting stored machine set") {
+		return false
+	}
+	if !assert.NotEmpty(t, storedMachineSet.Finalizers, "machine set should have a finalizer for provisioning") {
+		return false
+	}
+
+	return true
+}
+
+// completeComputeMachineSetsProvision waits for the compute machine sets of
+// the cluster to be provisioning, completes the provision jobs, and waits for
+// the machine set to be provisioned.
+func completeComputeMachineSetsProvision(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, cluster *v1alpha1.Cluster) bool {
+	machineSets, err := getComputeMachineSets(clusterOperatorClient, cluster)
+	if !assert.NoError(t, err, "could not get machine sets for cluster") {
+		return false
+	}
+	return completeMachineSetsProcessingJobs(
+		machineSets,
+		func(machineSet *v1alpha1.MachineSet) bool {
+			return completeMachineSetProvision(t, kubeClient, clusterOperatorClient, machineSet)
+		},
+	)
+}
+
+// completeInfraDeprovisionJob waits for the cluster to be deprovisioning,
+// completes the deprovision job, and waits for the cluster to have its
+// provision finalizer removed.
+func completeMachineSetDeprovision(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, machineSet *v1alpha1.MachineSet) bool {
+	return completeMachineSetProcessingJob(
+		t,
+		"deprovision",
+		kubeClient,
+		clusterOperatorClient,
+		machineSet.Namespace, machineSet.Name,
+		func(machineSet *v1alpha1.MachineSet) *corev1.LocalObjectReference {
+			return machineSet.Status.ProvisionJob
+		},
+		func(client clientset.Interface, namespace, name string) error {
+			return waitForObjectToNotExistOrNotHaveFinalizer(
+				namespace, name,
+				"openshift/cluster-operator-provision-machineset-1",
+				func(namespace, name string) (metav1.Object, error) {
+					return getCluster(client, namespace, name)
+				},
+			)
+		},
+	)
+}
+
+// completeComputeMachineSetsProvision waits for the compute machine sets of
+// the cluster to be deprovisioning, completes the deprovision jobs, and waits
+// for the machine sets to have their provision finalizers removed.
+func completeMachineSetsDeprovision(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, cluster *v1alpha1.Cluster) bool {
+	machineSets, err := getMachineSetsForCluster(clusterOperatorClient, cluster)
+	if !assert.NoError(t, err, "could not get machine sets for cluster") {
+		return false
+	}
+	return completeMachineSetsProcessingJobs(
+		machineSets,
+		func(machineSet *v1alpha1.MachineSet) bool {
+			return completeMachineSetDeprovision(t, kubeClient, clusterOperatorClient, machineSet)
+		},
+	)
+}
+
+// completeMachineSetInstall waits for the machine set to be
+// installing, completes the install job, and waits for the machine set
+// to be installed.
+func completeMachineSetInstall(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, machineSet *v1alpha1.MachineSet) bool {
+	return completeMachineSetProcessingJob(
+		t,
+		"install",
+		kubeClient,
+		clusterOperatorClient,
+		machineSet.Namespace, machineSet.Name,
+		func(machineSet *v1alpha1.MachineSet) *corev1.LocalObjectReference {
+			return machineSet.Status.InstallationJob
+		},
+		func(client clientset.Interface, namespace, name string) error {
+			return waitForMachineSetStatus(
+				client,
+				namespace, name,
+				func(machineSet *v1alpha1.MachineSet) bool {
+					return machineSet.Status.Installed
+				},
+			)
+		},
+	)
+}
+
+// completeMachineSetProvision waits for the machine set to be
+// accepting, completes the accept job, and waits for the machine set
+// to be accepted.
+func completeMachineSetAccept(t *testing.T, kubeClient *kubefake.Clientset, clusterOperatorClient clientset.Interface, machineSet *v1alpha1.MachineSet) bool {
+	return completeMachineSetProcessingJob(
+		t,
+		"accept",
+		kubeClient,
+		clusterOperatorClient,
+		machineSet.Namespace, machineSet.Name,
+		func(machineSet *v1alpha1.MachineSet) *corev1.LocalObjectReference {
+			return machineSet.Status.AcceptJob
+		},
+		func(client clientset.Interface, namespace, name string) error {
+			return waitForMachineSetStatus(
+				client,
+				namespace, name,
+				func(machineSet *v1alpha1.MachineSet) bool {
+					return machineSet.Status.Accepted
+				},
+			)
+		},
+	)
+}
+
+func completeJob(kubeClient *kubefake.Clientset, job *kbatch.Job) error {
+	job.Status.Conditions = []kbatch.JobCondition{
+		{
+			Type:   kbatch.JobComplete,
+			Status: kapi.ConditionTrue,
+		},
+	}
+	_, err := kubeClient.Batch().Jobs(job.Namespace).Update(job)
+	return err
+}

--- a/test/integration/waitutils.go
+++ b/test/integration/waitutils.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	"github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+)
+
+func waitForObjectStatus(namespace, name string, getFromStore func(namespace, name string) (metav1.Object, error), checkStatus func(metav1.Object) bool) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+		func() (bool, error) {
+			obj, err := getFromStore(namespace, name)
+			if err != nil {
+				return false, nil
+			}
+			return checkStatus(obj), nil
+		},
+	)
+}
+
+// waitForObjectToNotExist waits for the object with the specified name to not
+// exist in the specified namespace.
+func waitForObjectToNotExist(namespace, name string, getFromStore func(namespace, name string) (metav1.Object, error)) error {
+	return waitForObjectStatus(
+		namespace, name,
+		func(namespace, name string) (metav1.Object, error) {
+			obj, err := getFromStore(namespace, name)
+			if errors.IsNotFound(err) {
+				return nil, nil
+			}
+			return obj, err
+		},
+		func(obj metav1.Object) bool { return obj == nil },
+	)
+}
+
+// waitForObjectToNotExistOrNotHaveFinalizer waits for the object with the
+// specified namespace and name to either not exist or to not have the
+// specified finalizer.
+func waitForObjectToNotExistOrNotHaveFinalizer(namespace, name string, finalizer string, getFromStore func(namespace, name string) (metav1.Object, error)) error {
+	return waitForObjectStatus(
+		namespace, name,
+		func(namespace, name string) (metav1.Object, error) {
+			obj, err := getFromStore(namespace, name)
+			if errors.IsNotFound(err) {
+				return nil, nil
+			}
+			return obj, err
+		},
+		func(obj metav1.Object) bool {
+			return obj == nil || !sets.NewString(obj.GetFinalizers()...).Has(finalizer)
+		},
+	)
+}
+
+func waitForClusterStatus(client clientset.Interface, namespace, name string, checkStatus func(*v1alpha1.Cluster) bool) error {
+	return waitForObjectStatus(
+		namespace,
+		name,
+		func(namespace, name string) (metav1.Object, error) { return getCluster(client, namespace, name) },
+		func(obj metav1.Object) bool { return checkStatus(obj.(*v1alpha1.Cluster)) },
+	)
+}
+
+func waitForMachineSetStatus(client clientset.Interface, namespace, name string, checkStatus func(*v1alpha1.MachineSet) bool) error {
+	return waitForObjectStatus(
+		namespace,
+		name,
+		func(namespace, name string) (metav1.Object, error) { return getMachineSet(client, namespace, name) },
+		func(obj metav1.Object) bool { return checkStatus(obj.(*v1alpha1.MachineSet)) },
+	)
+}
+
+// waitForClusterToExist waits for the Cluster with the specified name to
+// exist in the specified namespace.
+func waitForClusterToExist(client clientset.Interface, namespace, name string) error {
+	return waitForClusterStatus(
+		client,
+		namespace, name,
+		func(cluster *v1alpha1.Cluster) bool { return cluster != nil },
+	)
+}
+
+// waitForClusterToNotExist waits for the Cluster with the specified name to not
+// exist in the specified namespace.
+func waitForClusterToNotExist(client clientset.Interface, namespace, name string) error {
+	return waitForObjectToNotExist(
+		namespace, name,
+		func(namespace, name string) (metav1.Object, error) {
+			return getCluster(client, namespace, name)
+		},
+	)
+}
+
+// waitForMachineSetToExist waits for the MachineSet with the specified name to
+// exist in the specified namespace.
+func waitForMachineSetToExist(client clientset.Interface, namespace, name string) error {
+	return waitForMachineSetStatus(
+		client,
+		namespace, name,
+		func(machineSet *v1alpha1.MachineSet) bool { return machineSet != nil },
+	)
+}
+
+// waitForMachineSetToNotExist waits for the MachineSet with the specified name to not
+// exist in the specified namespace.
+func waitForMachineSetToNotExist(client clientset.Interface, namespace, name string) error {
+	return waitForObjectToNotExist(
+		namespace, name,
+		func(namespace, name string) (metav1.Object, error) {
+			return getMachineSet(client, namespace, name)
+		},
+	)
+}
+
+// waitForClusterMachineSetCount waits for the status of the cluster to
+// reflect that the machine sets have been created.
+func waitForClusterMachineSetCount(client clientset.Interface, namespace string, name string) error {
+	return waitForClusterStatus(
+		client,
+		namespace, name,
+		func(cluster *v1alpha1.Cluster) bool {
+			return cluster.Status.MachineSetCount == len(cluster.Spec.MachineSets)
+		},
+	)
+}
+
+// waitForClusterProvisioning waits for the cluster to be in a state of provisioning.
+func waitForClusterProvisioning(client clientset.Interface, namespace, name string) error {
+	return waitForClusterStatus(
+		client,
+		namespace, name,
+		func(cluster *v1alpha1.Cluster) bool {
+			return cluster.Status.ProvisionJob != nil
+		},
+	)
+}
+
+// waitForClusterProvisioned waits for the cluster to be provisioned.
+func waitForClusterProvisioned(client clientset.Interface, namespace, name string) error {
+	return waitForClusterStatus(
+		client,
+		namespace, name,
+		func(cluster *v1alpha1.Cluster) bool {
+			return cluster.Status.Provisioned
+		},
+	)
+}


### PR DESCRIPTION
When a cluster or a machine set is deleted, a job is created to deprovision. The cluster or machine set is blocked from being fully deleted until the playbook completes successfully. Note that if the job fails, then the user will have to manually delete the cluster or machine set by removing the appropriate finalizer. This gives the user an opportunity to see that there was a failure and do any manual deprovisioning needed.

By default, when a cluster is deleted, the machine sets that it owns are deleted as well, since the owner reference on the machine set for the cluster has the `blockDeletion` field set to true.

There is not *yet* a playbook to deprovision the machine set. Consequently, a job to deprovision a machine set will never succeed, and a machine set will never be fully deleted with manual intervention.