### PR TITLE
Add SSHUser to cluster hardware info.

### DIFF
--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -60,6 +60,7 @@ objects:
           name: aws-credentials
         sshSecret:
           name: ssh-private-key
+        sshUser: centos
         sslSecret:
           name: ssl-cert
         region: "us-east-1"

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -42,8 +42,7 @@ const (
 # Common/Cluster Variables #
 # ------------------------ #
 # Variables in this section affect all areas of the cluster
-# TODO:
-ansible_ssh_user: centos
+ansible_ssh_user: [[ .SSHUser ]]
 
 ################################################################################
 # Ensure these variables are set for bootstrap
@@ -287,6 +286,7 @@ type clusterParams struct {
 	Name       string
 	Region     string
 	SSHKeyName string
+	SSHUser    string
 }
 
 type machineSetParams struct {
@@ -321,6 +321,7 @@ func GenerateClusterWideVars(name string, hardwareSpec *coapi.ClusterHardwareSpe
 		Name:       name,
 		Region:     hardwareSpec.AWS.Region,
 		SSHKeyName: hardwareSpec.AWS.KeyPairName,
+		SSHUser:    hardwareSpec.AWS.SSHUser,
 	}
 
 	var buf bytes.Buffer

--- a/pkg/ansible/generate_test.go
+++ b/pkg/ansible/generate_test.go
@@ -32,6 +32,7 @@ func testCluster() *coapi.Cluster {
 	cluster.Spec.Hardware.AWS = &coapi.AWSClusterSpec{
 		Region:      "east-99",
 		KeyPairName: "mykey",
+		SSHUser:     "centos",
 	}
 	return cluster
 }
@@ -78,6 +79,7 @@ func TestGenerateClusterVars(t *testing.T) {
 				"openshift_aws_elb_basename: testcluster",
 				"openshift_aws_ssh_key_name: mykey",
 				"openshift_aws_region: east-99",
+				"ansible_ssh_user: centos",
 			},
 		},
 	}

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -196,6 +196,10 @@ type AWSClusterSpec struct {
 	// EC2 instances in this cluster
 	SSHSecret corev1.LocalObjectReference
 
+	// SSHUser refers to the username that should be used for Ansible to SSH to the system. (default: clusteroperator)
+	// +optional
+	SSHUser string
+
 	// SSLSecret refers to a secret that contains the SSL certificate to use
 	// for this cluster. The secret is expected to contain the following keys:
 	// - ca.crt - the certificate authority certificate

--- a/pkg/apis/clusteroperator/v1alpha1/defaults.go
+++ b/pkg/apis/clusteroperator/v1alpha1/defaults.go
@@ -20,12 +20,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const defaultSSHUser = "clusteroperator"
+
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
 func SetDefaults_ClusterSpec(spec *ClusterSpec) {
-	// No defaults
+	if spec.Hardware.AWS != nil && spec.Hardware.AWS.SSHUser == "" {
+		spec.Hardware.AWS.SSHUser = defaultSSHUser
+	}
 }
 
 func SetDefaults_MachineSetSpec(spec *MachineSetSpec) {

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -199,6 +199,10 @@ type AWSClusterSpec struct {
 	// EC2 instances in this cluster.
 	SSHSecret corev1.LocalObjectReference `json:"sshSecret"`
 
+	// SSHUser refers to the username that should be used for Ansible to SSH to the system. (default: clusteroperator)
+	// +optional
+	SSHUser string `json:"sshUser"`
+
 	// SSLSecret refers to a secret that contains the SSL certificate to use
 	// for this cluster. The secret is expected to contain the following keys:
 	// - ca.crt - the certificate authority certificate

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -102,6 +102,7 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 func autoConvert_v1alpha1_AWSClusterSpec_To_clusteroperator_AWSClusterSpec(in *AWSClusterSpec, out *clusteroperator.AWSClusterSpec, s conversion.Scope) error {
 	out.AccountSecret = in.AccountSecret
 	out.SSHSecret = in.SSHSecret
+	out.SSHUser = in.SSHUser
 	out.SSLSecret = in.SSLSecret
 	out.KeyPairName = in.KeyPairName
 	out.Region = in.Region
@@ -118,6 +119,7 @@ func Convert_v1alpha1_AWSClusterSpec_To_clusteroperator_AWSClusterSpec(in *AWSCl
 func autoConvert_clusteroperator_AWSClusterSpec_To_v1alpha1_AWSClusterSpec(in *clusteroperator.AWSClusterSpec, out *AWSClusterSpec, s conversion.Scope) error {
 	out.AccountSecret = in.AccountSecret
 	out.SSHSecret = in.SSHSecret
+	out.SSHUser = in.SSHUser
 	out.SSLSecret = in.SSLSecret
 	out.KeyPairName = in.KeyPairName
 	out.Region = in.Region

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -45,6 +45,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 							},
 						},
+						"sshUser": {
+							SchemaProps: spec.SchemaProps{
+								Description: "SSHUser refers to the username that should be used for Ansible to SSH to the system. (default: clusteroperator)",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 						"sslSecret": {
 							SchemaProps: spec.SchemaProps{
 								Description: "SSLSecret refers to a secret that contains the SSL certificate to use for this cluster. The secret is expected to contain the following keys: - ca.crt - the certificate authority certificate - server.crt - the server certificate - server.key - the server key",


### PR DESCRIPTION
This is added to sit along-side the SSHKey.

Today this setting is largely dependent on the AMI and we require the
user to exist already.

Long term this setting will probably die, being replaced by global
cluster operator configuration for a user that we will ensure is created
on every host via the upcoming config DaemonSet work from kwoodson.
For now this gives us flexibility to adjust per cluster as ami's come
and go.