### PR TITLE
Circumvent long delays in job completion after pod success

### DIFF
--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -210,7 +210,10 @@ func (r *jobGenerator) GeneratePlaybookJob(name string, hardware *clusteroperato
 
 	completions := int32(1)
 	deadline := int64((24 * time.Hour).Seconds())
-	backoffLimit := int32(123456) // effectively limitless
+	// Only run pod three times. Otherwise, it can take the job controller too
+	// long to notice when the pod has completed. If all three pod runs fail,
+	// jobSync will create a new job.
+	backoffLimit := int32(3)
 
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/jobsync_test.go
+++ b/pkg/controller/jobsync_test.go
@@ -367,7 +367,7 @@ func TestJobSyncForCompletedJob(t *testing.T) {
 			mockJobSyncStrategy.EXPECT().GetJobFactory(owner, tc.deleting).
 				Return(mockJobFactory, nil)
 			mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, true, mockJobFactory).
-				Return(JobControlJobWorking, job, nil)
+				Return(JobControlJobSucceeded, job, nil)
 
 			// Update owner status to reflect completed job
 			mockJobSyncStrategy.EXPECT().DeepCopyOwner(owner).
@@ -439,15 +439,12 @@ func TestJobSyncForFailedJob(t *testing.T) {
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
 	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
-		Return(JobControlJobWorking, job, nil)
+		Return(JobControlJobFailed, job, nil)
 
 	// Update owner status to reflect failed job
 	mockJobSyncStrategy.EXPECT().DeepCopyOwner(owner).
 		Return(ownerCopy)
-	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessing, kapi.ConditionFalse, ReasonJobFailed, gomock.Any(), gomock.Any())
-	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessingFailed, kapi.ConditionTrue, ReasonJobFailed, gomock.Any(), gomock.Any())
 	mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "")
-	mockJobSyncStrategy.EXPECT().OnJobFailure(ownerCopy)
 	mockJobSyncStrategy.EXPECT().UpdateOwnerStatus(owner, ownerCopy)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)


### PR DESCRIPTION
The job controller uses longer and longer delays as the pods of a job fail. For the compute provision jobs, there can be large delays, in excess of 5 minutes, between when a pod completes successfully and when a job is updated to have a completed status. For clust-op controllers that wait for other jobs to complete before starting their jobs, this can significantly increase the time that it takes to stand up a cluster.

As part of a circumvention to this problem, this PR limits the number of failures for our jobs to 3 and re-creates the job when that limit is reached. As future work, it would be good to also (1) include some backoff wait between job failure and job creation and (2) stop the job re-creation after a sufficiently long time of failures.

Note: In the interest of avoiding a rebase, this is built on top of #88. If needed, I can separate it into its own PR.