### PR TITLE
Avoid race when handling failed job

### DIFF
--- a/pkg/controller/jobcontrol.go
+++ b/pkg/controller/jobcontrol.go
@@ -220,8 +220,7 @@ func (c *jobControl) ControlJobs(
 			return JobControlJobSucceeded, generationJob, nil
 		}
 		if getJobConditionStatus(generationJob, kbatch.JobFailed) == kapi.ConditionTrue {
-			err := c.deleteOldJobs(ownerKey, []*kbatch.Job{generationJob}, logger)
-			return JobControlJobFailed, generationJob, err
+			return JobControlJobFailed, generationJob, nil
 		}
 		return JobControlJobWorking, generationJob, nil
 	}


### PR DESCRIPTION
When handling a failed job, it's not necessary to delete the job immediately, since we'll do that when we realize it's not our current job.

If we do delete it immediately, we can end up thinking that the job went missing and stop retrying:
```
time="2018-02-19T17:09:23Z" level=debug msg="Started syncing" controller=machineSet key=myproject/abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="job working" controller=machineSet job=provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject owner=abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=info msg="Deleting old jobs: [myproject/provision-machineset-abutcher-cluster-infra-b5xk5-hdw87]" controller=machineSet namespace=myproject owner=abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Update" controller=master
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Update" controller=accept
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Update" controller=machineSet
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Update" controller=components
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Update" controller=infra
time="2018-02-19T17:09:23Z" level=debug msg="getting owner myproject/abutcher-cluster-infra-b5xk5" controller=machineSet job=provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject
time="2018-02-19T17:09:23Z" level=debug msg="enqueueing owner for updated job" controller=machineSet job=provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Delete" controller=master
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Delete" controller=accept
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Delete" controller=machineSet
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Delete" controller=infra
time="2018-02-19T17:09:23Z" level=debug msg="onJobEvent: Delete" controller=components
time="2018-02-19T17:09:23Z" level=debug msg="getting owner myproject/abutcher-cluster-infra-b5xk5" controller=machineSet job=provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject
time="2018-02-19T17:09:23Z" level=debug msg="job deletion observed" controller=machineSet job=provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject
time="2018-02-19T17:09:23Z" level=debug msg="enqueueing owner for deleted job" controller=machineSet job=provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject
time="2018-02-19T17:09:23Z" level=debug msg="about to patch machineset with {\"status\":{\"provisionJob\":null}}" machineset=myproject/abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="Finished syncing" controller=machineSet duration="10.304µs" key=myproject/abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="Started syncing" controller=machineSet key=myproject/abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="lost current job" controller=machineSet job=myproject/provision-machineset-abutcher-cluster-infra-b5xk5-hdw87 namespace=myproject owner=abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="about to patch machineset with {\"status\":{\"conditions\":[{\"lastProbeTime\":\"2018-02-19T17:09:23Z\",\"lastTransitionTime\":\"2018-02-19T17:09:23Z\",\"message\":\"
Job not found.\",\"reason\":\"JobMissing\",\"status\":\"False\",\"type\":\"HardwareProvisioning\"},{\"lastProbeTime\":\"2018-02-19T17:09:23Z\",\"lastTransitionTime\":\"2018-02-19T17:09:23Z\",\"message\":\"Job no
t found.\",\"reason\":\"JobMissing\",\"status\":\"True\",\"type\":\"HardwareProvisioningFailed\"}],\"provisionJob\":null,\"provisionedJobGeneration\":1}}" machineset=myproject/abutcher-cluster-infra-b5xk5
time="2018-02-19T17:09:23Z" level=debug msg="Finished syncing" controller=machineSet duration="11.01µs" key=myproject/abutcher-cluster-infra-b5xk5
```