### PR TITLE
allow providing custom ssh key and custom cluster definition

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -5,6 +5,7 @@
   gather_facts: no
   vars:
     aws_section: default
+    ssh_priv_key: '~/.ssh/libra.pem'
     use_real_aws: false
     ansible_image: "fake-openshift-ansible:canary"
     ansible_image_pull_policy: "Never"
@@ -24,6 +25,10 @@
       creates: "{{ playbook_dir }}/../../apiserver.pem"
 
   - set_fact:
+      ssh_priv_key: "{{ cli_ssh_priv_key }}"
+    when: cli_ssh_priv_key is defined
+
+  - set_fact:
       aws_section: "{{ cli_aws_section }}"
     when: cli_aws_section is defined
 
@@ -38,7 +43,7 @@
       l_serving_key: "{{ lookup('file', playbook_dir + '/../../apiserver-key.pem') | b64encode }}"
       l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
       l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
-      l_aws_ssh_private_key: "{{ lookup('file', '~/.ssh/libra.pem') | b64encode }}"
+      l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
 
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template

--- a/contrib/examples/create-cluster.sh
+++ b/contrib/examples/create-cluster.sh
@@ -21,4 +21,11 @@ oc get secret ssh-private-key -n cluster-operator -o yaml | sed -E '/(namespace:
 oc get secret ssl-cert -n cluster-operator -o yaml | sed -E '/(namespace:|annotations|last-applied-configuration:|selfLink|uid:|resourceVersion:)/d' | oc apply -f -
 
 
-oc process -f contrib/examples/cluster.yaml -p CLUSTER_NAME=$(whoami)-cluster | oc apply -f -
+if [ -e contrib/examples/$(whoami)-cluster.yaml ]
+then
+	CLUSTER_YAML="$(whoami)-cluster.yaml"
+else
+	CLUSTER_YAML="cluster.yaml"
+fi
+
+oc process -f contrib/examples/${CLUSTER_YAML} -p CLUSTER_NAME=$(whoami)-cluster | oc apply -f -


### PR DESCRIPTION
add ability to use something besides hardcoded libra.pem ssh key filename

use $(whoami)-cluster.yaml as cluster definition if file exists