### PR TITLE
Restart jobs when they fail

### DIFF
--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -276,8 +276,7 @@ type ClusterStatus struct {
 	Provisioned bool
 
 	// ProvisionedJobGeneration is the generation of the cluster resource used to
-	// to generate the latest completed infra provisioning job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful infra provisioning job.
 	ProvisionedJobGeneration int64
 
 	// ProvisionJob is the job that is actively performing provisioning
@@ -443,8 +442,7 @@ type MachineSetStatus struct {
 	ComponentsInstalled bool
 
 	// ComponentsInstalledJobGeneration is the generation of the machine set resource used to
-	// to generate the latest completed component installation job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful component installation job.
 	ComponentsInstalledJobGeneration int64
 
 	// ComponentInstallationJob is the job that is actively performing installation
@@ -457,8 +455,7 @@ type MachineSetStatus struct {
 	Installed bool
 
 	// InstalledJobGeneration is the generation of the machine set resource used to
-	// to generate the latest completed installation job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful installation job.
 	InstalledJobGeneration int64
 
 	// InstallationJob is the job that is actively performing installation
@@ -471,8 +468,7 @@ type MachineSetStatus struct {
 	Provisioned bool
 
 	// ProvisionedJobGeneration is the generation of the machine set resource used to
-	// to generate the latest completed hardware provisioning job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// to generate the latest successful hardware provisioning job.
 	ProvisionedJobGeneration int64
 
 	// ProvisionJob is the job that is actively performing provisioning
@@ -484,8 +480,7 @@ type MachineSetStatus struct {
 	Accepted bool
 
 	// AcceptedJobGeneration is the generation of the machine set resource used to
-	// run the latest completed accept job. The value will be set regardless of
-	// the job having succceeded or failed.
+	// run the latest successful accept job.
 	AcceptedJobGeneration int64
 
 	// AcceptJob is the job that is actively running to accept nodes from this machine

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -279,11 +279,6 @@ type ClusterStatus struct {
 	// generate the latest successful infra provisioning job.
 	ProvisionedJobGeneration int64
 
-	// ProvisionJob is the job that is actively performing provisioning
-	// on the cluster.
-	// +optional
-	ProvisionJob *corev1.LocalObjectReference
-
 	// Running is true if the master of the cluster is running and can be accessed using
 	// the KubeconfigSecret
 	Running bool
@@ -445,11 +440,6 @@ type MachineSetStatus struct {
 	// generate the latest successful component installation job.
 	ComponentsInstalledJobGeneration int64
 
-	// ComponentInstallationJob is the job that is actively performing installation
-	// of components on the machine set.
-	// +optional
-	ComponentInstallationJob *corev1.LocalObjectReference
-
 	// Installed is true if the software required for this machine set is installed
 	// and running.
 	Installed bool
@@ -457,11 +447,6 @@ type MachineSetStatus struct {
 	// InstalledJobGeneration is the generation of the machine set resource used to
 	// generate the latest successful installation job.
 	InstalledJobGeneration int64
-
-	// InstallationJob is the job that is actively performing installation
-	// on the machine set.
-	// +optional
-	InstallationJob *corev1.LocalObjectReference
 
 	// Provisioned is true if the hardware that corresponds to this MachineSet has
 	// been provisioned
@@ -471,22 +456,12 @@ type MachineSetStatus struct {
 	// to generate the latest successful hardware provisioning job.
 	ProvisionedJobGeneration int64
 
-	// ProvisionJob is the job that is actively performing provisioning
-	// on the machine set.
-	// +optional
-	ProvisionJob *corev1.LocalObjectReference
-
 	// Accepted is true if machine set nodes have been accepted on the master
 	Accepted bool
 
 	// AcceptedJobGeneration is the generation of the machine set resource used to
 	// run the latest successful accept job.
 	AcceptedJobGeneration int64
-
-	// AcceptJob is the job that is actively running to accept nodes from this machine
-	// set on the master.
-	// +optional
-	AcceptJob *corev1.LocalObjectReference
 }
 
 // MachineSetCondition contains details for the current condition of a MachineSet

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -282,11 +282,6 @@ type ClusterStatus struct {
 	// generate the latest successful infra provisioning job.
 	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
 
-	// ProvisionJob is the job that is actively performing provisioning
-	// on the cluster.
-	// +optional
-	ProvisionJob *corev1.LocalObjectReference `json:"provisionJob,omitempty"`
-
 	// Running is true if the master of the cluster is running and can be accessed using
 	// the KubeconfigSecret
 	Running bool `json:"running"`
@@ -448,11 +443,6 @@ type MachineSetStatus struct {
 	// generate the latest successful component installation job.
 	ComponentsInstalledJobGeneration int64 `json:"componentsInstalledJobGeneration"`
 
-	// ComponentInstallationJob is the job that is actively performing installation
-	// of components on the machine set.
-	// +optional
-	ComponentInstallationJob *corev1.LocalObjectReference `json:"componentInstallationJob,omitempty"`
-
 	// Installed is true if the software required for this machine set is installed
 	// and running.
 	Installed bool `json:"installed"`
@@ -460,11 +450,6 @@ type MachineSetStatus struct {
 	// InstalledJobGeneration is the generation of the machine set resource used to
 	// generate the latest successful installation job.
 	InstalledJobGeneration int64 `json:"installedJobGeneration"`
-
-	// InstallationJob is the job that is actively performing installation
-	// on the machine set.
-	// +optional
-	InstallationJob *corev1.LocalObjectReference `json:"installationJob,omitempty"`
 
 	// Provisioned is true if the hardware that corresponds to this MachineSet has
 	// been provisioned
@@ -474,22 +459,12 @@ type MachineSetStatus struct {
 	// generate the latest successful hardware provisioning job.
 	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
 
-	// ProvisionJob is the job that is actively performing provisioning
-	// on the machine set.
-	// +optional
-	ProvisionJob *corev1.LocalObjectReference `json:"provisionJob,omitempty"`
-
 	// Accepted is true if machine set nodes have been accepted on the master
 	Accepted bool `json:"accepted"`
 
 	// AcceptedJobGeneration is the generation of the machine set resource used to
 	// run the latest successful accept job.
 	AcceptedJobGeneration int64 `json:"acceptedJobGeneration"`
-
-	// AcceptJob is the job that is actively running to accept nodes from this machine
-	// set on the master.
-	// +optional
-	AcceptJob *corev1.LocalObjectReference `json:"acceptJob,omitempty"`
 }
 
 // MachineSetCondition contains details for the current condition of a MachineSet

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -279,8 +279,7 @@ type ClusterStatus struct {
 	Provisioned bool `json:"provisioned"`
 
 	// ProvisionedJobGeneration is the generation of the cluster resource used to
-	// to generate the latest completed infra provisioning job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful infra provisioning job.
 	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
 
 	// ProvisionJob is the job that is actively performing provisioning
@@ -446,8 +445,7 @@ type MachineSetStatus struct {
 	ComponentsInstalled bool `json:"componentsInstalled"`
 
 	// ComponentsInstalledJobGeneration is the generation of the machine set resource used to
-	// to generate the latest completed component installation job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful component installation job.
 	ComponentsInstalledJobGeneration int64 `json:"componentsInstalledJobGeneration"`
 
 	// ComponentInstallationJob is the job that is actively performing installation
@@ -460,8 +458,7 @@ type MachineSetStatus struct {
 	Installed bool `json:"installed"`
 
 	// InstalledJobGeneration is the generation of the machine set resource used to
-	// to generate the latest completed installation job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful installation job.
 	InstalledJobGeneration int64 `json:"installedJobGeneration"`
 
 	// InstallationJob is the job that is actively performing installation
@@ -474,8 +471,7 @@ type MachineSetStatus struct {
 	Provisioned bool `json:"provisioned"`
 
 	// ProvisionedJobGeneration is the generation of the machine set resource used to
-	// to generate the latest completed hardware provisioning job. The value will be set
-	// regardless of the job having succeeded or failed.
+	// generate the latest successful hardware provisioning job.
 	ProvisionedJobGeneration int64 `json:"provisionedJobGeneration"`
 
 	// ProvisionJob is the job that is actively performing provisioning
@@ -487,8 +483,7 @@ type MachineSetStatus struct {
 	Accepted bool `json:"accepted"`
 
 	// AcceptedJobGeneration is the generation of the machine set resource used to
-	// run the latest completed accept job. The value will be set regardless of
-	// the job having succceeded or failed.
+	// run the latest successful accept job.
 	AcceptedJobGeneration int64 `json:"acceptedJobGeneration"`
 
 	// AcceptJob is the job that is actively running to accept nodes from this machine

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -378,7 +378,6 @@ func autoConvert_v1alpha1_ClusterStatus_To_clusteroperator_ClusterStatus(in *Clu
 	out.AdminKubeconfig = (*v1.LocalObjectReference)(unsafe.Pointer(in.AdminKubeconfig))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
-	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	out.Running = in.Running
 	out.Conditions = *(*[]clusteroperator.ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	out.ClusterVersionRef = (*v1.ObjectReference)(unsafe.Pointer(in.ClusterVersionRef))
@@ -397,7 +396,6 @@ func autoConvert_clusteroperator_ClusterStatus_To_v1alpha1_ClusterStatus(in *clu
 	out.AdminKubeconfig = (*v1.LocalObjectReference)(unsafe.Pointer(in.AdminKubeconfig))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
-	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	out.Running = in.Running
 	out.Conditions = *(*[]ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	out.ClusterVersionRef = (*v1.ObjectReference)(unsafe.Pointer(in.ClusterVersionRef))
@@ -781,16 +779,12 @@ func autoConvert_v1alpha1_MachineSetStatus_To_clusteroperator_MachineSetStatus(i
 	out.Conditions = *(*[]clusteroperator.MachineSetCondition)(unsafe.Pointer(&in.Conditions))
 	out.ComponentsInstalled = in.ComponentsInstalled
 	out.ComponentsInstalledJobGeneration = in.ComponentsInstalledJobGeneration
-	out.ComponentInstallationJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ComponentInstallationJob))
 	out.Installed = in.Installed
 	out.InstalledJobGeneration = in.InstalledJobGeneration
-	out.InstallationJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.InstallationJob))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
-	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	out.Accepted = in.Accepted
 	out.AcceptedJobGeneration = in.AcceptedJobGeneration
-	out.AcceptJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.AcceptJob))
 	return nil
 }
 
@@ -805,16 +799,12 @@ func autoConvert_clusteroperator_MachineSetStatus_To_v1alpha1_MachineSetStatus(i
 	out.Conditions = *(*[]MachineSetCondition)(unsafe.Pointer(&in.Conditions))
 	out.ComponentsInstalled = in.ComponentsInstalled
 	out.ComponentsInstalledJobGeneration = in.ComponentsInstalledJobGeneration
-	out.ComponentInstallationJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ComponentInstallationJob))
 	out.Installed = in.Installed
 	out.InstalledJobGeneration = in.InstalledJobGeneration
-	out.InstallationJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.InstallationJob))
 	out.Provisioned = in.Provisioned
 	out.ProvisionedJobGeneration = in.ProvisionedJobGeneration
-	out.ProvisionJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.ProvisionJob))
 	out.Accepted = in.Accepted
 	out.AcceptedJobGeneration = in.AcceptedJobGeneration
-	out.AcceptJob = (*v1.LocalObjectReference)(unsafe.Pointer(in.AcceptJob))
 	return nil
 }
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -278,15 +278,6 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			**out = **in
 		}
 	}
-	if in.ProvisionJob != nil {
-		in, out := &in.ProvisionJob, &out.ProvisionJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]ClusterCondition, len(*in))
@@ -677,42 +668,6 @@ func (in *MachineSetStatus) DeepCopyInto(out *MachineSetStatus) {
 		*out = make([]MachineSetCondition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ComponentInstallationJob != nil {
-		in, out := &in.ComponentInstallationJob, &out.ComponentInstallationJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
-	if in.InstallationJob != nil {
-		in, out := &in.InstallationJob, &out.InstallationJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
-	if in.ProvisionJob != nil {
-		in, out := &in.ProvisionJob, &out.ProvisionJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
-	if in.AcceptJob != nil {
-		in, out := &in.AcceptJob, &out.AcceptJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
 		}
 	}
 	return

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -278,15 +278,6 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			**out = **in
 		}
 	}
-	if in.ProvisionJob != nil {
-		in, out := &in.ProvisionJob, &out.ProvisionJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]ClusterCondition, len(*in))
@@ -677,42 +668,6 @@ func (in *MachineSetStatus) DeepCopyInto(out *MachineSetStatus) {
 		*out = make([]MachineSetCondition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ComponentInstallationJob != nil {
-		in, out := &in.ComponentInstallationJob, &out.ComponentInstallationJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
-	if in.InstallationJob != nil {
-		in, out := &in.InstallationJob, &out.InstallationJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
-	if in.ProvisionJob != nil {
-		in, out := &in.ProvisionJob, &out.ProvisionJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
-		}
-	}
-	if in.AcceptJob != nil {
-		in, out := &in.AcceptJob, &out.AcceptJob
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LocalObjectReference)
-			**out = **in
 		}
 	}
 	return

--- a/pkg/controller/accept/accept_controller.go
+++ b/pkg/controller/accept/accept_controller.go
@@ -317,31 +317,6 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 	}), nil
 }
 
-func (s *jobSyncStrategy) GetOwnerCurrentJob(owner metav1.Object) string {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machine set: %#v", owner)
-		return ""
-	}
-	if machineSet.Status.AcceptJob == nil {
-		return ""
-	}
-	return machineSet.Status.AcceptJob.Name
-}
-
-func (s *jobSyncStrategy) SetOwnerCurrentJob(owner metav1.Object, jobName string) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machine set: %#v", owner)
-		return
-	}
-	if jobName == "" {
-		machineSet.Status.AcceptJob = nil
-	} else {
-		machineSet.Status.AcceptJob = &kapi.LocalObjectReference{Name: jobName}
-	}
-}
-
 func (s *jobSyncStrategy) DeepCopyOwner(owner metav1.Object) metav1.Object {
 	machineSet, ok := owner.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/accept/accept_controller.go
+++ b/pkg/controller/accept/accept_controller.go
@@ -384,18 +384,6 @@ func (s *jobSyncStrategy) OnJobCompletion(owner metav1.Object) {
 	machineSet.Status.AcceptedJobGeneration = machineSet.Generation
 }
 
-func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machine set: %#v", owner)
-		return
-	}
-	// AcceptedJobGeneration is set even when the job failed because we
-	// do not want to run the accept job again until there have been
-	// changes in the spec of the machine set.
-	machineSet.Status.AcceptedJobGeneration = machineSet.Generation
-}
-
 func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error {
 	originalMachineSet, ok := original.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/components/components_controller.go
+++ b/pkg/controller/components/components_controller.go
@@ -384,18 +384,6 @@ func (s *jobSyncStrategy) OnJobCompletion(owner metav1.Object) {
 	machineSet.Status.ComponentsInstalledJobGeneration = machineSet.Generation
 }
 
-func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return
-	}
-	// ComponentsInstalledJobGeneration is set even when the job failed because we
-	// do not want to run the component installation job again until there have been
-	// changes in the spec of the machine set.
-	machineSet.Status.ComponentsInstalledJobGeneration = machineSet.Generation
-}
-
 func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error {
 	originalMachineSet, ok := original.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/components/components_controller.go
+++ b/pkg/controller/components/components_controller.go
@@ -317,31 +317,6 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 	}), nil
 }
 
-func (s *jobSyncStrategy) GetOwnerCurrentJob(owner metav1.Object) string {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return ""
-	}
-	if machineSet.Status.ComponentInstallationJob == nil {
-		return ""
-	}
-	return machineSet.Status.ComponentInstallationJob.Name
-}
-
-func (s *jobSyncStrategy) SetOwnerCurrentJob(owner metav1.Object, jobName string) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return
-	}
-	if jobName == "" {
-		machineSet.Status.ComponentInstallationJob = nil
-	} else {
-		machineSet.Status.ComponentInstallationJob = &kapi.LocalObjectReference{Name: jobName}
-	}
-}
-
 func (s *jobSyncStrategy) DeepCopyOwner(owner metav1.Object) metav1.Object {
 	machineSet, ok := owner.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -322,31 +322,6 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 	return s.controller.getJobFactory(cluster, playbook), nil
 }
 
-func (s *jobSyncStrategy) GetOwnerCurrentJob(owner metav1.Object) string {
-	cluster, ok := owner.(*clusteroperator.Cluster)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a cluster: %#v", owner)
-		return ""
-	}
-	if cluster.Status.ProvisionJob == nil {
-		return ""
-	}
-	return cluster.Status.ProvisionJob.Name
-}
-
-func (s *jobSyncStrategy) SetOwnerCurrentJob(owner metav1.Object, jobName string) {
-	cluster, ok := owner.(*clusteroperator.Cluster)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a cluster: %#v", owner)
-		return
-	}
-	if jobName == "" {
-		cluster.Status.ProvisionJob = nil
-	} else {
-		cluster.Status.ProvisionJob = &kapi.LocalObjectReference{Name: jobName}
-	}
-}
-
 func (s *jobSyncStrategy) DeepCopyOwner(owner metav1.Object) metav1.Object {
 	cluster, ok := owner.(*clusteroperator.Cluster)
 	if !ok {

--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -389,18 +389,6 @@ func (s *jobSyncStrategy) OnJobCompletion(owner metav1.Object) {
 	cluster.Status.ProvisionedJobGeneration = cluster.Generation
 }
 
-func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
-	cluster, ok := owner.(*clusteroperator.Cluster)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a cluster: %#v", owner)
-		return
-	}
-	// ProvisionedJobGeneration is set even when the job failed because we
-	// do not want to run the provision job again until there have been
-	// changes in the spec of the cluster.
-	cluster.Status.ProvisionedJobGeneration = cluster.Generation
-}
-
 func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error {
 	originalCluster, ok := original.(*clusteroperator.Cluster)
 	if !ok {

--- a/pkg/controller/jobsync.go
+++ b/pkg/controller/jobsync.go
@@ -192,9 +192,6 @@ func (s *jobSync) setOwnerStatusForLostJob(original metav1.Object, deleting bool
 	s.strategy.SetOwnerJobSyncCondition(owner, workingCondtion, kapi.ConditionFalse, reason, message, UpdateConditionNever)
 	s.strategy.SetOwnerJobSyncCondition(owner, workingFailedCondtion, kapi.ConditionTrue, reason, message, UpdateConditionAlways)
 	s.strategy.SetOwnerCurrentJob(owner, "")
-	if !deleting {
-		s.strategy.OnJobFailure(owner)
-	}
 	return s.strategy.UpdateOwnerStatus(original, owner)
 }
 

--- a/pkg/controller/jobsync_test.go
+++ b/pkg/controller/jobsync_test.go
@@ -681,7 +681,6 @@ func TestJobSyncWithLostCurrentJobResult(t *testing.T) {
 	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessing, kapi.ConditionFalse, ReasonJobMissing, gomock.Any(), gomock.Any())
 	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessingFailed, kapi.ConditionTrue, ReasonJobMissing, gomock.Any(), gomock.Any())
 	mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "")
-	mockJobSyncStrategy.EXPECT().OnJobFailure(ownerCopy)
 	mockJobSyncStrategy.EXPECT().UpdateOwnerStatus(owner, ownerCopy)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)

--- a/pkg/controller/jobsync_test.go
+++ b/pkg/controller/jobsync_test.go
@@ -148,11 +148,9 @@ func TestJobSyncForDeletedOwner(t *testing.T) {
 			}
 
 			if tc.expectControl {
-				mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-					Return(testJobName)
 				mockJobSyncStrategy.EXPECT().GetJobFactory(owner, true).
 					Return(mockJobFactory, nil)
-				mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, true, mockJobFactory).
+				mockJobControl.EXPECT().ControlJobs(testKey, owner, true, mockJobFactory).
 					Return(JobControlNoWork, nil, nil)
 			}
 
@@ -181,9 +179,6 @@ func TestJobSyncWithErrorGettingJobFactory(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName).
-		AnyTimes()
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(true).
 		AnyTimes()
@@ -215,13 +210,11 @@ func TestJobSyncWithErrorControllingJobs(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlResult(""), nil, fmt.Errorf("error controlling jobs"))
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -249,13 +242,11 @@ func TestJobSyncWithPendingExpectationsResult(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlPendingExpectations, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -283,13 +274,11 @@ func TestJobSyncWithNoWorkResult(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlNoWork, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -354,8 +343,6 @@ func TestJobSyncForCompletedJob(t *testing.T) {
 
 			mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 				Return(owner, nil)
-			mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-				Return(testJobName)
 			if !tc.deleting {
 				mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 					Return(true)
@@ -366,7 +353,7 @@ func TestJobSyncForCompletedJob(t *testing.T) {
 			}
 			mockJobSyncStrategy.EXPECT().GetJobFactory(owner, tc.deleting).
 				Return(mockJobFactory, nil)
-			mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, true, mockJobFactory).
+			mockJobControl.EXPECT().ControlJobs(testKey, owner, true, mockJobFactory).
 				Return(JobControlJobSucceeded, job, nil)
 
 			// Update owner status to reflect completed job
@@ -381,7 +368,6 @@ func TestJobSyncForCompletedJob(t *testing.T) {
 				mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessed, kapi.ConditionTrue, ReasonJobCompleted, gomock.Any(), gomock.Any())
 				mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessingFailed, kapi.ConditionFalse, ReasonJobCompleted, gomock.Any(), gomock.Any())
 			}
-			mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "")
 			if !tc.deleting {
 				mockJobSyncStrategy.EXPECT().OnJobCompletion(ownerCopy)
 			}
@@ -396,63 +382,6 @@ func TestJobSyncForCompletedJob(t *testing.T) {
 
 		})
 	}
-}
-
-// TestJobSyncForFailedJob tests jobSync.Sync when ControlJobs returns that
-// there is a job working and the job has failed.
-func TestJobSyncForFailedJob(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	logger, loggerHook := test.Logger()
-
-	mockJobSyncStrategy := NewMockJobSyncStrategy(mockCtrl)
-	mockJobControl := NewMockJobControl(mockCtrl)
-	mockJobFactory := NewMockJobFactory(mockCtrl)
-
-	owner := &metav1.ObjectMeta{}
-	ownerCopy := &metav1.ObjectMeta{}
-	needsProcessing := true
-
-	jobTransitionTime := metav1.Date(2018, time.February, 1, 2, 3, 4, 5, time.UTC)
-	job := &kbatch.Job{
-		Status: kbatch.JobStatus{
-			Conditions: []kbatch.JobCondition{
-				{
-					Type:               kbatch.JobFailed,
-					Status:             kapi.ConditionTrue,
-					Reason:             "Failed",
-					Message:            "Done",
-					LastTransitionTime: jobTransitionTime,
-					LastProbeTime:      jobTransitionTime,
-				},
-			},
-		},
-	}
-
-	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
-		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
-	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
-		Return(needsProcessing)
-	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
-		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
-		Return(JobControlJobFailed, job, nil)
-
-	// Update owner status to reflect failed job
-	mockJobSyncStrategy.EXPECT().DeepCopyOwner(owner).
-		Return(ownerCopy)
-	mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "")
-	mockJobSyncStrategy.EXPECT().UpdateOwnerStatus(owner, ownerCopy)
-
-	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
-	err := jobSync.Sync(testKey)
-
-	assert.NoError(t, err, "unexpected error from Sync")
-
-	assert.Empty(t, test.GetDireLogEntries(loggerHook), "unexpected dire log entries")
 }
 
 // TestJobSyncForInProgressJob tests jobSync.Sync when ControlJobs returns
@@ -479,20 +408,17 @@ func TestJobSyncForInProgressJob(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlJobWorking, job, nil)
 
 	// Update owner status to reflect in-progress job
 	mockJobSyncStrategy.EXPECT().DeepCopyOwner(owner).
 		Return(ownerCopy)
 	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessing, kapi.ConditionTrue, ReasonJobRunning, gomock.Any(), gomock.Any())
-	mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "in-progress-job")
 	mockJobSyncStrategy.EXPECT().UpdateOwnerStatus(owner, ownerCopy)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -520,13 +446,11 @@ func TestJobSyncWithJobWorkingResultButNoJobReturned(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlJobWorking, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -554,134 +478,12 @@ func TestJobSyncWithCreatingJobResult(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlCreatingJob, nil, nil)
-
-	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
-	err := jobSync.Sync(testKey)
-
-	assert.NoError(t, err, "unexpected error from Sync")
-
-	assert.Empty(t, test.GetDireLogEntries(loggerHook), "unexpected dire log entries")
-}
-
-// TestJobSyncWithDeletingJobsResultWithCurrentJob tests jobSync.Sync when
-// ControlJobs returns that it is deleting jobs and there is a current job.
-func TestJobSyncWithDeletingJobsResultWithCurrentJob(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	logger, loggerHook := test.Logger()
-
-	mockJobSyncStrategy := NewMockJobSyncStrategy(mockCtrl)
-	mockJobControl := NewMockJobControl(mockCtrl)
-	mockJobFactory := NewMockJobFactory(mockCtrl)
-
-	owner := &metav1.ObjectMeta{}
-	ownerCopy := &metav1.ObjectMeta{}
-	needsProcessing := true
-
-	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
-		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
-	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
-		Return(needsProcessing)
-	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
-		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
-		Return(JobControlDeletingJobs, nil, nil)
-
-	// Update owner status to reflect outdated job
-	mockJobSyncStrategy.EXPECT().DeepCopyOwner(owner).
-		Return(ownerCopy)
-	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessing, kapi.ConditionFalse, ReasonSpecChanged, gomock.Any(), gomock.Any())
-	mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "")
-	mockJobSyncStrategy.EXPECT().UpdateOwnerStatus(owner, ownerCopy)
-
-	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
-	err := jobSync.Sync(testKey)
-
-	assert.NoError(t, err, "unexpected error from Sync")
-
-	assert.Empty(t, test.GetDireLogEntries(loggerHook), "unexpected dire log entries")
-}
-
-// TestJobSyncWithDeletingJobsResultWithoutCurrentJob tests jobSync.Sync when
-// ControlJobs returns that it is deleting jobs and there is not a current
-// job.
-func TestJobSyncWithDeletingJobsResultWithoutCurrentJob(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	logger, loggerHook := test.Logger()
-
-	mockJobSyncStrategy := NewMockJobSyncStrategy(mockCtrl)
-	mockJobControl := NewMockJobControl(mockCtrl)
-	mockJobFactory := NewMockJobFactory(mockCtrl)
-
-	owner := &metav1.ObjectMeta{}
-	needsProcessing := true
-
-	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
-		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return("")
-	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
-		Return(needsProcessing)
-	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
-		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, mockJobFactory).
-		Return(JobControlDeletingJobs, nil, nil)
-
-	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
-	err := jobSync.Sync(testKey)
-
-	assert.NoError(t, err, "unexpected error from Sync")
-
-	assert.Empty(t, test.GetDireLogEntries(loggerHook), "unexpected dire log entries")
-}
-
-// TestJobSyncWithLostCurrentJobResult tests jobSync.Sync when ControlJobs
-// returns that the current job has been lost.
-func TestJobSyncWithLostCurrentJobResult(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	logger, loggerHook := test.Logger()
-
-	mockJobSyncStrategy := NewMockJobSyncStrategy(mockCtrl)
-	mockJobControl := NewMockJobControl(mockCtrl)
-	mockJobFactory := NewMockJobFactory(mockCtrl)
-
-	owner := &metav1.ObjectMeta{}
-	ownerCopy := &metav1.ObjectMeta{}
-	needsProcessing := true
-
-	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
-		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return(testJobName)
-	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
-		Return(needsProcessing)
-	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
-		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, testJobName, needsProcessing, mockJobFactory).
-		Return(JobControlLostCurrentJob, nil, nil)
-
-	// Update owner status to reflect lost current job
-	mockJobSyncStrategy.EXPECT().DeepCopyOwner(owner).
-		Return(ownerCopy)
-	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessing, kapi.ConditionFalse, ReasonJobMissing, gomock.Any(), gomock.Any())
-	mockJobSyncStrategy.EXPECT().SetOwnerJobSyncCondition(ownerCopy, JobSyncProcessingFailed, kapi.ConditionTrue, ReasonJobMissing, gomock.Any(), gomock.Any())
-	mockJobSyncStrategy.EXPECT().SetOwnerCurrentJob(ownerCopy, "")
-	mockJobSyncStrategy.EXPECT().UpdateOwnerStatus(owner, ownerCopy)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
 	err := jobSync.Sync(testKey)
@@ -708,13 +510,11 @@ func TestJobSyncWithUnkownJobsResult(t *testing.T) {
 
 	mockJobSyncStrategy.EXPECT().GetOwner(testKey).
 		Return(owner, nil)
-	mockJobSyncStrategy.EXPECT().GetOwnerCurrentJob(owner).
-		Return("")
 	mockJobSyncStrategy.EXPECT().DoesOwnerNeedProcessing(owner).
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, mockJobFactory).
 		Return(JobControlResult("other-result"), nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)

--- a/pkg/controller/jobsyncstrategy.go
+++ b/pkg/controller/jobsyncstrategy.go
@@ -61,9 +61,6 @@ type JobSyncStrategy interface {
 	// completes successfully.
 	OnJobCompletion(owner metav1.Object)
 
-	// OnJobFailure is called when the processing job for the owner fails.
-	OnJobFailure(owner metav1.Object)
-
 	// UpdateOwnerStatus updates the status of the owner from the original
 	// copy to the owner copy.
 	UpdateOwnerStatus(original, owner metav1.Object) error

--- a/pkg/controller/jobsyncstrategy.go
+++ b/pkg/controller/jobsyncstrategy.go
@@ -36,13 +36,6 @@ type JobSyncStrategy interface {
 	// GetJobFactory gets a factory for building a job to do the processing.
 	GetJobFactory(owner metav1.Object, deleting bool) (JobFactory, error)
 
-	// GetOwnerCurrentJob gets the name of the current job for the owner. If
-	// there is not a current job, then returns an empty string.
-	GetOwnerCurrentJob(owner metav1.Object) string
-
-	// SetOwnerCurrentJob sets the name of the current job for the owner.
-	SetOwnerCurrentJob(owner metav1.Object, jobName string)
-
 	// DeepCopyOwner returns a deep copy of the owner object.
 	DeepCopyOwner(owner metav1.Object) metav1.Object
 

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -403,18 +403,6 @@ func (s *jobSyncStrategy) OnJobCompletion(owner metav1.Object) {
 	machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
 }
 
-func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return
-	}
-	// ProvisionedJobGeneration is set even when the job failed because we
-	// do not want to run the provision job again until there have been
-	// changes in the spec of the machine set.
-	machineSet.Status.ProvisionedJobGeneration = machineSet.Generation
-}
-
 func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error {
 	originalMachineSet, ok := original.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -336,31 +336,6 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 	}), nil
 }
 
-func (s *jobSyncStrategy) GetOwnerCurrentJob(owner metav1.Object) string {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return ""
-	}
-	if machineSet.Status.ProvisionJob == nil {
-		return ""
-	}
-	return machineSet.Status.ProvisionJob.Name
-}
-
-func (s *jobSyncStrategy) SetOwnerCurrentJob(owner metav1.Object, jobName string) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return
-	}
-	if jobName == "" {
-		machineSet.Status.ProvisionJob = nil
-	} else {
-		machineSet.Status.ProvisionJob = &kapi.LocalObjectReference{Name: jobName}
-	}
-}
-
 func (s *jobSyncStrategy) DeepCopyOwner(owner metav1.Object) metav1.Object {
 	machineSet, ok := owner.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -405,18 +405,6 @@ func (s *jobSyncStrategy) OnJobCompletion(owner metav1.Object) {
 	machineSet.Status.InstalledJobGeneration = machineSet.Generation
 }
 
-func (s *jobSyncStrategy) OnJobFailure(owner metav1.Object) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return
-	}
-	// InstalledJobGeneration is set even when the job failed because we
-	// do not want to run the installation job again until there have been
-	// changes in the spec of the machine set.
-	machineSet.Status.InstalledJobGeneration = machineSet.Generation
-}
-
 func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error {
 	originalMachineSet, ok := original.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -338,31 +338,6 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 	}), nil
 }
 
-func (s *jobSyncStrategy) GetOwnerCurrentJob(owner metav1.Object) string {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return ""
-	}
-	if machineSet.Status.InstallationJob == nil {
-		return ""
-	}
-	return machineSet.Status.InstallationJob.Name
-}
-
-func (s *jobSyncStrategy) SetOwnerCurrentJob(owner metav1.Object, jobName string) {
-	machineSet, ok := owner.(*clusteroperator.MachineSet)
-	if !ok {
-		s.controller.logger.Warn("could not convert owner from JobSync into a machineset: %#v", owner)
-		return
-	}
-	if jobName == "" {
-		machineSet.Status.InstallationJob = nil
-	} else {
-		machineSet.Status.InstallationJob = &kapi.LocalObjectReference{Name: jobName}
-	}
-}
-
 func (s *jobSyncStrategy) DeepCopyOwner(owner metav1.Object) metav1.Object {
 	machineSet, ok := owner.(*clusteroperator.MachineSet)
 	if !ok {

--- a/pkg/controller/mockjobcontrol_generated_test.go
+++ b/pkg/controller/mockjobcontrol_generated_test.go
@@ -66,8 +66,8 @@ func (mr *MockJobControlMockRecorder) OnDelete(obj interface{}) *gomock.Call {
 }
 
 // ControlJobs mocks base method
-func (m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, currentJobName string, buildNewJob bool, jobFactory JobFactory) (JobControlResult, *v1.Job, error) {
-	ret := m.ctrl.Call(m, "ControlJobs", ownerKey, owner, currentJobName, buildNewJob, jobFactory)
+func (m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, buildNewJob bool, jobFactory JobFactory) (JobControlResult, *v1.Job, error) {
+	ret := m.ctrl.Call(m, "ControlJobs", ownerKey, owner, buildNewJob, jobFactory)
 	ret0, _ := ret[0].(JobControlResult)
 	ret1, _ := ret[1].(*v1.Job)
 	ret2, _ := ret[2].(error)
@@ -75,8 +75,8 @@ func (m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, currentJ
 }
 
 // ControlJobs indicates an expected call of ControlJobs
-func (mr *MockJobControlMockRecorder) ControlJobs(ownerKey, owner, currentJobName, buildNewJob, jobFactory interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlJobs", reflect.TypeOf((*MockJobControl)(nil).ControlJobs), ownerKey, owner, currentJobName, buildNewJob, jobFactory)
+func (mr *MockJobControlMockRecorder) ControlJobs(ownerKey, owner, buildNewJob, jobFactory interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlJobs", reflect.TypeOf((*MockJobControl)(nil).ControlJobs), ownerKey, owner, buildNewJob, jobFactory)
 }
 
 // ObserveOwnerDeletion mocks base method

--- a/pkg/controller/mockjobsyncstrategy_generated_test.go
+++ b/pkg/controller/mockjobsyncstrategy_generated_test.go
@@ -126,16 +126,6 @@ func (mr *MockJobSyncStrategyMockRecorder) OnJobCompletion(owner interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnJobCompletion", reflect.TypeOf((*MockJobSyncStrategy)(nil).OnJobCompletion), owner)
 }
 
-// OnJobFailure mocks base method
-func (m *MockJobSyncStrategy) OnJobFailure(owner v10.Object) {
-	m.ctrl.Call(m, "OnJobFailure", owner)
-}
-
-// OnJobFailure indicates an expected call of OnJobFailure
-func (mr *MockJobSyncStrategyMockRecorder) OnJobFailure(owner interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnJobFailure", reflect.TypeOf((*MockJobSyncStrategy)(nil).OnJobFailure), owner)
-}
-
 // UpdateOwnerStatus mocks base method
 func (m *MockJobSyncStrategy) UpdateOwnerStatus(original, owner v10.Object) error {
 	ret := m.ctrl.Call(m, "UpdateOwnerStatus", original, owner)

--- a/pkg/controller/mockjobsyncstrategy_generated_test.go
+++ b/pkg/controller/mockjobsyncstrategy_generated_test.go
@@ -72,28 +72,6 @@ func (mr *MockJobSyncStrategyMockRecorder) GetJobFactory(owner, deleting interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobFactory", reflect.TypeOf((*MockJobSyncStrategy)(nil).GetJobFactory), owner, deleting)
 }
 
-// GetOwnerCurrentJob mocks base method
-func (m *MockJobSyncStrategy) GetOwnerCurrentJob(owner v10.Object) string {
-	ret := m.ctrl.Call(m, "GetOwnerCurrentJob", owner)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetOwnerCurrentJob indicates an expected call of GetOwnerCurrentJob
-func (mr *MockJobSyncStrategyMockRecorder) GetOwnerCurrentJob(owner interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnerCurrentJob", reflect.TypeOf((*MockJobSyncStrategy)(nil).GetOwnerCurrentJob), owner)
-}
-
-// SetOwnerCurrentJob mocks base method
-func (m *MockJobSyncStrategy) SetOwnerCurrentJob(owner v10.Object, jobName string) {
-	m.ctrl.Call(m, "SetOwnerCurrentJob", owner, jobName)
-}
-
-// SetOwnerCurrentJob indicates an expected call of SetOwnerCurrentJob
-func (mr *MockJobSyncStrategyMockRecorder) SetOwnerCurrentJob(owner, jobName interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOwnerCurrentJob", reflect.TypeOf((*MockJobSyncStrategy)(nil).SetOwnerCurrentJob), owner, jobName)
-}
-
 // DeepCopyOwner mocks base method
 func (m *MockJobSyncStrategy) DeepCopyOwner(owner v10.Object) v10.Object {
 	ret := m.ctrl.Call(m, "DeepCopyOwner", owner)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -482,7 +482,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"provisionedJobGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ProvisionedJobGeneration is the generation of the cluster resource used to to generate the latest completed infra provisioning job. The value will be set regardless of the job having succeeded or failed.",
+								Description: "ProvisionedJobGeneration is the generation of the cluster resource used to generate the latest successful infra provisioning job.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},
@@ -1114,7 +1114,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"componentsInstalledJobGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ComponentsInstalledJobGeneration is the generation of the machine set resource used to to generate the latest completed component installation job. The value will be set regardless of the job having succeeded or failed.",
+								Description: "ComponentsInstalledJobGeneration is the generation of the machine set resource used to generate the latest successful component installation job.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},
@@ -1134,7 +1134,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"installedJobGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "InstalledJobGeneration is the generation of the machine set resource used to to generate the latest completed installation job. The value will be set regardless of the job having succeeded or failed.",
+								Description: "InstalledJobGeneration is the generation of the machine set resource used to generate the latest successful installation job.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},
@@ -1154,7 +1154,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"provisionedJobGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ProvisionedJobGeneration is the generation of the machine set resource used to to generate the latest completed hardware provisioning job. The value will be set regardless of the job having succeeded or failed.",
+								Description: "ProvisionedJobGeneration is the generation of the machine set resource used to generate the latest successful hardware provisioning job.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},
@@ -1174,7 +1174,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"acceptedJobGeneration": {
 							SchemaProps: spec.SchemaProps{
-								Description: "AcceptedJobGeneration is the generation of the machine set resource used to run the latest completed accept job. The value will be set regardless of the job having succceeded or failed.",
+								Description: "AcceptedJobGeneration is the generation of the machine set resource used to run the latest successful accept job.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -487,12 +487,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
-						"provisionJob": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ProvisionJob is the job that is actively performing provisioning on the cluster.",
-								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
-							},
-						},
 						"running": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Running is true if the master of the cluster is running and can be accessed using the KubeconfigSecret",
@@ -1119,12 +1113,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
-						"componentInstallationJob": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ComponentInstallationJob is the job that is actively performing installation of components on the machine set.",
-								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
-							},
-						},
 						"installed": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Installed is true if the software required for this machine set is installed and running.",
@@ -1137,12 +1125,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Description: "InstalledJobGeneration is the generation of the machine set resource used to generate the latest successful installation job.",
 								Type:        []string{"integer"},
 								Format:      "int64",
-							},
-						},
-						"installationJob": {
-							SchemaProps: spec.SchemaProps{
-								Description: "InstallationJob is the job that is actively performing installation on the machine set.",
-								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 							},
 						},
 						"provisioned": {
@@ -1159,12 +1141,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
-						"provisionJob": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ProvisionJob is the job that is actively performing provisioning on the machine set.",
-								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
-							},
-						},
 						"accepted": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Accepted is true if machine set nodes have been accepted on the master",
@@ -1179,18 +1155,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
-						"acceptJob": {
-							SchemaProps: spec.SchemaProps{
-								Description: "AcceptJob is the job that is actively running to accept nodes from this machine set on the master.",
-								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
-							},
-						},
 					},
 					Required: []string{"machineCount", "machinesReady", "conditions", "componentsInstalled", "componentsInstalledJobGeneration", "installed", "installedJobGeneration", "provisioned", "provisionedJobGeneration", "accepted", "acceptedJobGeneration"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetCondition", "k8s.io/api/core/v1.LocalObjectReference"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetCondition"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSpec": {
 			Schema: spec.Schema{

--- a/test/integration/waitutils.go
+++ b/test/integration/waitutils.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	"github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	"github.com/openshift/cluster-operator/pkg/controller"
 )
 
 func waitForObjectStatus(namespace, name string, getFromStore func(namespace, name string) (metav1.Object, error), checkStatus func(metav1.Object) bool) error {
@@ -153,7 +155,8 @@ func waitForClusterProvisioning(client clientset.Interface, namespace, name stri
 		client,
 		namespace, name,
 		func(cluster *v1alpha1.Cluster) bool {
-			return cluster.Status.ProvisionJob != nil
+			condition := controller.FindClusterCondition(cluster, v1alpha1.ClusterInfraProvisioning)
+			return condition != nil && condition.Status == corev1.ConditionTrue
 		},
 	)
 }


### PR DESCRIPTION
Modifies job sync and job control to keep retrying when a job fails. 

The job generation field in the cluster and machineset status structs now only gets a value if a job has completed successfully for a given generation.