### PR TITLE
trying to use a password-protected ssh key isn't supported

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -45,6 +45,16 @@
       l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
       l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
 
+  - name: check for password-protected ssh key
+    command: "grep ENCRYPTED {{ ssh_priv_key }}"
+    ignore_errors: yes
+    changed_when: no
+    register: pass_protect_ssh
+
+  - fail:
+      msg: password protected ssh key not supported
+    when: pass_protect_ssh.rc == 0
+
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template
     shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p SERVING_CA={{ l_serving_ca }} -p SERVING_CERT={{ l_serving_cert }} -p SERVING_KEY={{ l_serving_key }} AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} ANSIBLE_IMAGE={{ ansible_image }} ANSIBLE_IMAGE_PULL_POLICY={{ ansible_image_pull_policy }} | oc apply -f -"


### PR DESCRIPTION
deployment will fail in non-obvious ways later, so just detect and bail out if we see a password protected ssh key trying to be used