### PR TITLE
Fix deploy when libra.pem not pass protected.

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -48,6 +48,7 @@
   - name: check for password-protected ssh key
     command: "grep ENCRYPTED {{ ssh_priv_key }}"
     ignore_errors: yes
+    failed_when: false
     changed_when: no
     register: pass_protect_ssh
 


### PR DESCRIPTION
Logic was wrong for when the libra.pem is not encrypted, task would fail
when we actually want it to continue.