### PR TITLE
Use an openshift-ansible image appropriate for a ClusterVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,9 @@
 ## Creating a Sample Cluster
   * `contrib/examples/create-cluster.sh`
 
-## Testing Provisioning
-
-Provisioning code is currently disabled to avoid doing anything unintentional
-until we have a better handle on getting it working and cleaning up what it
-creates.
-
-To enable and test:
-
-  1. Enable using real AWS by supplying the use_real_aws parameter to the contrib/ansible/deploy-devel.yaml playbook.
-		* `ansible-playbook contrib/ansible/deploy-devel.yaml -e "use_real_aws=true"`
-  1. Create a Cluster. Prefer a name for the Cluster that is prefaced with your username. This makes it easier to associate to you resources created in the AWS, making them easier to find and clean up. By default, if you are using the contrib/examples/create-cluster.sh script, the cluster will be prefaced with your username.
-  1. You should see some action in the controller manager logs, and a provisioning job and associated pod.
+When using the `create-cluster.sh` script, provisioning on AWS is disabled by default.
+To enable it, you must either set the USE_REAL_AWS variable or specify a
+real openshift-ansible image to use in the ANSIBLE_IMAGE variable.
+	* `USE_REAL_AWS=1 contrib/examples/create-cluster.sh`
+	* `ANSIBLE_IMAGE=openshift/origin-ansible:latest contrib/examples/create-cluster.sh`
 

--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -470,8 +470,6 @@ func startInfraController(ctx ControllerContext) (bool, error) {
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-infra-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-infra-controller"),
-		ctx.Options.AnsibleImage,
-		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentClusterSyncs), ctx.Stop)
 	return true, nil
 }
@@ -485,8 +483,6 @@ func startMachineSetController(ctx ControllerContext) (bool, error) {
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-machine-set-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-machine-set-controller"),
-		ctx.Options.AnsibleImage,
-		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentMachineSetSyncs), ctx.Stop)
 	return true, nil
 }
@@ -512,8 +508,6 @@ func startMasterController(ctx ControllerContext) (bool, error) {
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-master-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-master-controller"),
-		ctx.Options.AnsibleImage,
-		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentMasterSyncs), ctx.Stop)
 	return true, nil
 }
@@ -527,8 +521,6 @@ func startAcceptController(ctx ControllerContext) (bool, error) {
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-accept-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-accept-controller"),
-		ctx.Options.AnsibleImage,
-		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentAcceptSyncs), ctx.Stop)
 	return true, nil
 }
@@ -542,8 +534,6 @@ func startComponentsController(ctx ControllerContext) (bool, error) {
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-components-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-components-controller"),
-		ctx.Options.AnsibleImage,
-		v1.PullPolicy(ctx.Options.AnsibleImagePullPolicy),
 	).Run(int(ctx.Options.ConcurrentComponentSyncs), ctx.Stop)
 	return true, nil
 }

--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -6,9 +6,6 @@
   vars:
     aws_section: default
     ssh_priv_key: '~/.ssh/libra.pem'
-    use_real_aws: false
-    ansible_image: "fake-openshift-ansible:canary"
-    ansible_image_pull_policy: "Never"
   tasks:
   - name: create cluster-operator namespace
     command: oc create namespace cluster-operator
@@ -33,11 +30,6 @@
     when: cli_aws_section is defined
 
   - set_fact:
-      ansible_image: "openshift/origin-ansible:latest"
-      ansible_image_pull_policy: "Always"
-    when: use_real_aws
-
-  - set_fact:
       l_serving_ca: "{{ lookup('file', playbook_dir + '/../../ca.pem') | b64encode }}"
       l_serving_cert: "{{ lookup('file', playbook_dir + '/../../apiserver.pem') | b64encode }}"
       l_serving_key: "{{ lookup('file', playbook_dir + '/../../apiserver-key.pem') | b64encode }}"
@@ -58,10 +50,9 @@
 
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template
-    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p SERVING_CA={{ l_serving_ca }} -p SERVING_CERT={{ l_serving_cert }} -p SERVING_KEY={{ l_serving_key }} AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} ANSIBLE_IMAGE={{ ansible_image }} ANSIBLE_IMAGE_PULL_POLICY={{ ansible_image_pull_policy }} | oc apply -f -"
+    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p SERVING_CA={{ l_serving_ca }} -p SERVING_CERT={{ l_serving_cert }} -p SERVING_KEY={{ l_serving_key }} AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} | oc apply -f -"
 
   - name: deploy playbook-mock for testing with fake-openshift-ansible
     shell: "oc apply -n cluster-operator -f {{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"
-    when: not use_real_aws | bool
 
 

--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -18,6 +18,8 @@ objects:
           ami: ami-833d37f9
     deploymentType: origin
     version: "v3.9.0"
+    openshiftAnsibleImage: ${ANSIBLE_IMAGE}
+    openshiftAnsibleImagePullPolicy: ${ANSIBLE_IMAGE_PULL_POLICY}
 - apiVersion: clusteroperator.openshift.io/v1alpha1
   kind: Cluster
   metadata:
@@ -62,3 +64,11 @@ parameters:
   displayName: Cluster Version Namespace
   description: Namespace where cluster verions should live
   value: cluster-operator
+- name: ANSIBLE_IMAGE
+  displayName: Openshift Ansible Image
+  description: Name and tag of the Openshift Ansible image to use to run the ansible jobs
+  value: "openshift/origin-ansible:latest"
+- name: ANSIBLE_IMAGE_PULL_POLICY
+  displayName: Openshift Ansible Image Pull Policy
+  description: Policy to use when pulling the Openshift Ansible image
+  value: "Always"

--- a/contrib/examples/create-cluster.sh
+++ b/contrib/examples/create-cluster.sh
@@ -28,4 +28,17 @@ else
 	CLUSTER_YAML="cluster.yaml"
 fi
 
-oc process -f contrib/examples/${CLUSTER_YAML} -p CLUSTER_NAME=$(whoami)-cluster | oc apply -f -
+if [ -z ${USE_REAL_AWS} ]
+then
+	: ${ANSIBLE_IMAGE:="fake-openshift-ansible:canary"}
+	: ${ANSIBLE_IMAGE_PULL_POLICY:="Never"}
+else	
+	: ${ANSIBLE_IMAGE:="openshift/origin-ansible:latest"}
+	: ${ANSIBLE_IMAGE_PULL_POLICY:="Always"}
+fi
+
+oc process -f contrib/examples/${CLUSTER_YAML} \
+	-p CLUSTER_NAME=$(whoami)-cluster \
+	-p ANSIBLE_IMAGE=${ANSIBLE_IMAGE} \
+	-p ANSIBLE_IMAGE_PULL_POLICY=${ANSIBLE_IMAGE_PULL_POLICY} \
+	| oc apply -f -

--- a/contrib/examples/deploy.yaml
+++ b/contrib/examples/deploy.yaml
@@ -330,10 +330,6 @@ objects:
           - "1"
           - --log-level
           - "debug"
-          - --ansible-image
-          - ${ANSIBLE_IMAGE}
-          - --ansible-image-pull-policy
-          - ${ANSIBLE_IMAGE_PULL_POLICY}
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -406,9 +402,3 @@ parameters:
 - name: AWS_ACCESS_KEY_ID
 - name: AWS_SECRET_ACCESS_KEY
 - name: AWS_SSH_PRIVATE_KEY
-# Ansible image to use for running playbooks
-- name: ANSIBLE_IMAGE
-  value: fake-openshift-ansible:canary
-# Policy for pulling the ansible image
-- name: ANSIBLE_IMAGE_PULL_POLICY
-  value: Never

--- a/pkg/ansible/image.go
+++ b/pkg/ansible/image.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ansible
+
+import (
+	"fmt"
+
+	kapi "k8s.io/api/core/v1"
+
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+)
+
+const (
+	defaultImageName = "openshift/origin-ansible"
+)
+
+// GetAnsibleImageForClusterVersion gets the openshift-ansible image and pull
+// policy to use for clusters that use the specified ClusterVersion.
+func GetAnsibleImageForClusterVersion(cv *coapi.ClusterVersion) (string, kapi.PullPolicy) {
+	image := fmt.Sprintf("%s:%s", defaultImageName, cv.Spec.Version)
+	if cv.Spec.OpenshiftAnsibleImage != nil {
+		image = *cv.Spec.OpenshiftAnsibleImage
+	}
+	pullPolicy := kapi.PullIfNotPresent
+	if cv.Spec.OpenshiftAnsibleImagePullPolicy != nil {
+		pullPolicy = *cv.Spec.OpenshiftAnsibleImagePullPolicy
+	}
+	return image, pullPolicy
+}

--- a/pkg/ansible/image.go
+++ b/pkg/ansible/image.go
@@ -35,7 +35,7 @@ func GetAnsibleImageForClusterVersion(cv *coapi.ClusterVersion) (string, kapi.Pu
 	if cv.Spec.OpenshiftAnsibleImage != nil {
 		image = *cv.Spec.OpenshiftAnsibleImage
 	}
-	pullPolicy := kapi.PullIfNotPresent
+	pullPolicy := kapi.PullAlways
 	if cv.Spec.OpenshiftAnsibleImagePullPolicy != nil {
 		pullPolicy = *cv.Spec.OpenshiftAnsibleImagePullPolicy
 	}

--- a/pkg/ansible/image_test.go
+++ b/pkg/ansible/image_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ansible
+
+import (
+	"testing"
+
+	kapi "k8s.io/api/core/v1"
+
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+)
+
+func TestGetAnsibleImageForClusterVersion(t *testing.T) {
+	cases := []struct {
+		name               string
+		image              *string
+		pullPolicy         *kapi.PullPolicy
+		expectedImage      string
+		expectedPullPolicy kapi.PullPolicy
+	}{
+		{
+			name:               "defaults",
+			expectedImage:      "openshift/origin-ansible:latest",
+			expectedPullPolicy: kapi.PullIfNotPresent,
+		},
+		{
+			name:               "custom image",
+			image:              func(s string) *string { return &s }("custom/image:tag"),
+			expectedImage:      "custom/image:tag",
+			expectedPullPolicy: kapi.PullIfNotPresent,
+		},
+		{
+			name:               "custom pull policy",
+			pullPolicy:         func(p kapi.PullPolicy) *kapi.PullPolicy { return &p }(kapi.PullAlways),
+			expectedImage:      "openshift/origin-ansible:latest",
+			expectedPullPolicy: kapi.PullAlways,
+		},
+	}
+	for _, tc := range cases {
+		cv := &coapi.ClusterVersion{
+			Spec: coapi.ClusterVersionSpec{
+				Version:                         "latest",
+				OpenshiftAnsibleImage:           tc.image,
+				OpenshiftAnsibleImagePullPolicy: tc.pullPolicy,
+			},
+		}
+		actualImage, actualPullPolicy := GetAnsibleImageForClusterVersion(cv)
+		if e, a := tc.expectedImage, actualImage; e != a {
+			t.Errorf("unexpected image: expected %v, got %v", e, a)
+		}
+		if e, a := tc.expectedPullPolicy, actualPullPolicy; e != a {
+			t.Errorf("unexpected pull policy: expected %v, got %v", e, a)
+		}
+	}
+}

--- a/pkg/ansible/image_test.go
+++ b/pkg/ansible/image_test.go
@@ -35,19 +35,19 @@ func TestGetAnsibleImageForClusterVersion(t *testing.T) {
 		{
 			name:               "defaults",
 			expectedImage:      "openshift/origin-ansible:latest",
-			expectedPullPolicy: kapi.PullIfNotPresent,
+			expectedPullPolicy: kapi.PullAlways,
 		},
 		{
 			name:               "custom image",
 			image:              func(s string) *string { return &s }("custom/image:tag"),
 			expectedImage:      "custom/image:tag",
-			expectedPullPolicy: kapi.PullIfNotPresent,
+			expectedPullPolicy: kapi.PullAlways,
 		},
 		{
 			name:               "custom pull policy",
-			pullPolicy:         func(p kapi.PullPolicy) *kapi.PullPolicy { return &p }(kapi.PullAlways),
+			pullPolicy:         func(p kapi.PullPolicy) *kapi.PullPolicy { return &p }(kapi.PullNever),
 			expectedImage:      "openshift/origin-ansible:latest",
-			expectedPullPolicy: kapi.PullAlways,
+			expectedPullPolicy: kapi.PullNever,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/ansible/jobgenerator_test.go
+++ b/pkg/ansible/jobgenerator_test.go
@@ -56,8 +56,8 @@ func TestGeneratePlaybooksJob(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		generator := NewJobGenerator("image-name", kapi.PullAlways)
-		job, configmap := generator.GeneratePlaybooksJob(testJobName, testHardware, tc.playbooks, testInventory, testVars)
+		generator := NewJobGenerator()
+		job, configmap := generator.GeneratePlaybooksJob(testJobName, testHardware, tc.playbooks, testInventory, testVars, "image-name", kapi.PullAlways)
 		if assert.Equal(t, len(tc.playbooks), len(job.Spec.Template.Spec.Containers)) {
 			for i, playbook := range tc.playbooks {
 				assert.Equal(t, playbook, job.Spec.Template.Spec.Containers[i].Name)

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -91,6 +91,19 @@ type ClusterVersionSpec struct {
 
 	// Version is the version of OpenShift to install.
 	Version string
+
+	// OpenshiftAnsibleImage is the name of the image to use to run
+	// openshift-ansible playbooks.
+	// Defaults to openshift/origin-ansbile:{TAG}, where {TAG} is
+	// the value from the Version field of this ClusterVersion.
+	// +optional
+	OpenshiftAnsibleImage *string
+
+	// OpenshiftAnsibleImagePullPolicy is the pull policy to use for
+	// OpenshiftAnsibleImage.
+	// Defaults to IfNotPreset.
+	// +optional
+	OpenshiftAnsibleImagePullPolicy *corev1.PullPolicy
 }
 
 // ClusterVersionStatus is the status of a ClusterVersion. It may be used to indicate if the

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -91,6 +91,19 @@ type ClusterVersionSpec struct {
 
 	// Version is the version of OpenShift to install.
 	Version string `json:"version"`
+
+	// OpenshiftAnsibleImage is the name of the image to use to run
+	// openshift-ansible playbooks.
+	// Defaults to openshift/origin-ansbile:{TAG}, where {TAG} is
+	// the value from the Version field of this ClusterVersion.
+	// +optional
+	OpenshiftAnsibleImage *string `json:"openshiftAnsibleImage,omitempty"`
+
+	// OpenshiftAnsibleImagePullPolicy is the pull policy to use for
+	// OpenshiftAnsibleImage.
+	// Defaults to IfNotPreset.
+	// +optional
+	OpenshiftAnsibleImagePullPolicy *corev1.PullPolicy `json:"openshiftAnsibleImagePullPolicy,omitempty"`
 }
 
 // ClusterVersionStatus is the status of a ClusterVersion. It may be used to indicate if the

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -488,6 +488,8 @@ func autoConvert_v1alpha1_ClusterVersionSpec_To_clusteroperator_ClusterVersionSp
 	}
 	out.DeploymentType = clusteroperator.ClusterDeploymentType(in.DeploymentType)
 	out.Version = in.Version
+	out.OpenshiftAnsibleImage = (*string)(unsafe.Pointer(in.OpenshiftAnsibleImage))
+	out.OpenshiftAnsibleImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.OpenshiftAnsibleImagePullPolicy))
 	return nil
 }
 
@@ -503,6 +505,8 @@ func autoConvert_clusteroperator_ClusterVersionSpec_To_v1alpha1_ClusterVersionSp
 	}
 	out.DeploymentType = ClusterDeploymentType(in.DeploymentType)
 	out.Version = in.Version
+	out.OpenshiftAnsibleImage = (*string)(unsafe.Pointer(in.OpenshiftAnsibleImage))
+	out.OpenshiftAnsibleImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.OpenshiftAnsibleImagePullPolicy))
 	return nil
 }
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -390,6 +390,24 @@ func (in *ClusterVersionReference) DeepCopy() *ClusterVersionReference {
 func (in *ClusterVersionSpec) DeepCopyInto(out *ClusterVersionSpec) {
 	*out = *in
 	in.VMImages.DeepCopyInto(&out.VMImages)
+	if in.OpenshiftAnsibleImage != nil {
+		in, out := &in.OpenshiftAnsibleImage, &out.OpenshiftAnsibleImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.OpenshiftAnsibleImagePullPolicy != nil {
+		in, out := &in.OpenshiftAnsibleImagePullPolicy, &out.OpenshiftAnsibleImagePullPolicy
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.PullPolicy)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/clusteroperator/validation/clusterversion_test.go
+++ b/pkg/apis/clusteroperator/validation/clusterversion_test.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"testing"
 
+	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
@@ -242,6 +243,60 @@ func TestValidateClusterVersion(t *testing.T) {
 			clusterVersion: func() *clusteroperator.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "30"
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "ansible pull policy - nil",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.OpenshiftAnsibleImagePullPolicy = nil
+				return c
+			}(),
+			valid: true,
+		},
+		{
+			name: "ansible pull policy - always",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullAlways)
+				return c
+			}(),
+			valid: true,
+		},
+		{
+			name: "ansible pull policy - if not present",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullIfNotPresent)
+				return c
+			}(),
+			valid: true,
+		},
+		{
+			name: "ansible pull policy - never",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullNever)
+				return c
+			}(),
+			valid: true,
+		},
+		{
+			name: "ansible pull policy - bad",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullPolicy("bad"))
+				return c
+			}(),
+			valid: false,
+		},
+		{
+			name: "ansible pull policy - empty",
+			clusterVersion: func() *clusteroperator.ClusterVersion {
+				c := getValidClusterVersion()
+				c.Spec.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullPolicy(""))
 				return c
 			}(),
 			valid: false,

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -390,6 +390,24 @@ func (in *ClusterVersionReference) DeepCopy() *ClusterVersionReference {
 func (in *ClusterVersionSpec) DeepCopyInto(out *ClusterVersionSpec) {
 	*out = *in
 	in.VMImages.DeepCopyInto(&out.VMImages)
+	if in.OpenshiftAnsibleImage != nil {
+		in, out := &in.OpenshiftAnsibleImage, &out.OpenshiftAnsibleImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.OpenshiftAnsibleImagePullPolicy != nil {
+		in, out := &in.OpenshiftAnsibleImagePullPolicy, &out.OpenshiftAnsibleImagePullPolicy
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.PullPolicy)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -119,10 +119,4 @@ type ControllerManagerConfiguration struct {
 
 	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
 	EnableContentionProfiling bool
-
-	// ansibleImage is the name of the image to use to run ansible playbooks
-	AnsibleImage string
-
-	// ansibleImagePullPolicy is the pull policy to use for ansibleImage
-	AnsibleImagePullPolicy string
 }

--- a/pkg/controller/infra/infra_controller_test.go
+++ b/pkg/controller/infra/infra_controller_test.go
@@ -59,8 +59,6 @@ func newTestController() (
 		kubeInformers.Batch().V1().Jobs(),
 		kubeClient,
 		clusterOperatorClient,
-		"",
-		"",
 	)
 
 	controller.clustersSynced = alwaysReady

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -78,8 +78,6 @@ func NewController(
 	jobInformer batchinformers.JobInformer,
 	kubeClient kubeclientset.Interface,
 	clusteroperatorClient clusteroperatorclientset.Interface,
-	ansibleImage string,
-	ansibleImagePullPolicy kapi.PullPolicy,
 ) *Controller {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
@@ -116,7 +114,7 @@ func NewController(
 
 	c.syncHandler = c.jobSync.Sync
 	c.enqueueMachineSet = c.enqueue
-	c.ansibleGenerator = ansible.NewJobGenerator(ansibleImage, ansibleImagePullPolicy)
+	c.ansibleGenerator = ansible.NewJobGenerator()
 
 	return c
 }
@@ -338,12 +336,15 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 		default:
 			playbook = computeProvisioningPlaybook
 		}
+		image, pullPolicy := ansible.GetAnsibleImageForClusterVersion(cv)
 		job, configMap := s.controller.ansibleGenerator.GeneratePlaybookJob(
 			name,
 			&machineSet.Spec.ClusterHardware,
 			playbook,
 			ansible.DefaultInventory,
 			vars,
+			image,
+			pullPolicy,
 		)
 		return job, configMap, nil
 	}), nil

--- a/pkg/controller/mockjobcontrol_generated_test.go
+++ b/pkg/controller/mockjobcontrol_generated_test.go
@@ -5,9 +5,9 @@ package controller
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/batch/v1"
-	v10 "k8s.io/api/core/v1"
-	v11 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v10 "k8s.io/api/batch/v1"
+	v11 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Mock of JobControl interface
@@ -55,10 +55,10 @@ func (_mr *_MockJobControlRecorder) OnDelete(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "OnDelete", arg0)
 }
 
-func (_m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, buildNewJob bool, jobFactory JobFactory) (JobControlResult, *v1.Job, error) {
+func (_m *MockJobControl) ControlJobs(ownerKey string, owner v1.Object, buildNewJob bool, jobFactory JobFactory) (JobControlResult, *v10.Job, error) {
 	ret := _m.ctrl.Call(_m, "ControlJobs", ownerKey, owner, buildNewJob, jobFactory)
 	ret0, _ := ret[0].(JobControlResult)
-	ret1, _ := ret[1].(*v1.Job)
+	ret1, _ := ret[1].(*v10.Job)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -106,7 +106,7 @@ func (_m *MockJobOwnerControl) EXPECT() *_MockJobOwnerControlRecorder {
 	return _m.recorder
 }
 
-func (_m *MockJobOwnerControl) GetOwnerKey(owner v11.Object) (string, error) {
+func (_m *MockJobOwnerControl) GetOwnerKey(owner v1.Object) (string, error) {
 	ret := _m.ctrl.Call(_m, "GetOwnerKey", owner)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -117,9 +117,9 @@ func (_mr *_MockJobOwnerControlRecorder) GetOwnerKey(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOwnerKey", arg0)
 }
 
-func (_m *MockJobOwnerControl) GetOwner(namespace string, name string) (v11.Object, error) {
+func (_m *MockJobOwnerControl) GetOwner(namespace string, name string) (v1.Object, error) {
 	ret := _m.ctrl.Call(_m, "GetOwner", namespace, name)
-	ret0, _ := ret[0].(v11.Object)
+	ret0, _ := ret[0].(v1.Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -128,7 +128,7 @@ func (_mr *_MockJobOwnerControlRecorder) GetOwner(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOwner", arg0, arg1)
 }
 
-func (_m *MockJobOwnerControl) OnOwnedJobEvent(owner v11.Object) {
+func (_m *MockJobOwnerControl) OnOwnedJobEvent(owner v1.Object) {
 	_m.ctrl.Call(_m, "OnOwnedJobEvent", owner)
 }
 
@@ -157,10 +157,10 @@ func (_m *MockJobFactory) EXPECT() *_MockJobFactoryRecorder {
 	return _m.recorder
 }
 
-func (_m *MockJobFactory) BuildJob(name string) (*v1.Job, *v10.ConfigMap, error) {
+func (_m *MockJobFactory) BuildJob(name string) (*v10.Job, *v11.ConfigMap, error) {
 	ret := _m.ctrl.Call(_m, "BuildJob", name)
-	ret0, _ := ret[0].(*v1.Job)
-	ret1, _ := ret[1].(*v10.ConfigMap)
+	ret0, _ := ret[0].(*v10.Job)
+	ret1, _ := ret[1].(*v11.ConfigMap)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -659,6 +659,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"openshiftAnsibleImage": {
+							SchemaProps: spec.SchemaProps{
+								Description: "OpenshiftAnsibleImage is the name of the image to use to run openshift-ansible playbooks. Defaults to openshift/origin-ansbile:{TAG}, where {TAG} is the value from the Version field of this ClusterVersion.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"openshiftAnsibleImagePullPolicy": {
+							SchemaProps: spec.SchemaProps{
+								Description: "OpenshiftAnsibleImagePullPolicy is the pull policy to use for OpenshiftAnsibleImage. Defaults to IfNotPreset.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"imageFormat", "vmImages", "deploymentType", "version"},
 				},

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -159,8 +159,10 @@ func TestClusterCreate(t *testing.T) {
 							},
 						},
 					},
-					DeploymentType: v1alpha1.ClusterDeploymentTypeOrigin,
-					Version:        "v3.7.0",
+					DeploymentType:                  v1alpha1.ClusterDeploymentTypeOrigin,
+					Version:                         "v3.7.0",
+					OpenshiftAnsibleImage:           func(s string) *string { return &s }("test-ansible-image"),
+					OpenshiftAnsibleImagePullPolicy: func(p kapi.PullPolicy) *kapi.PullPolicy { return &p }(kapi.PullNever),
 				},
 			}
 			clusterOperatorClient.ClusteroperatorV1alpha1().ClusterVersions(testNamespace).Create(clusterVersion)
@@ -316,8 +318,6 @@ func startServerAndControllers(t *testing.T) (
 	coSharedInformers := coInformerFactory.Clusteroperator().V1alpha1()
 
 	// create controllers
-	ansibleImage := "test-ansible-image"
-	ansibleImagePullPolicy := kapi.PullNever
 	stopCh := make(chan struct{})
 	t.Log("controller start")
 	// Note that controllers must be created prior to starting the informers.
@@ -340,8 +340,6 @@ func startServerAndControllers(t *testing.T) (
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,
 				clusterOperatorClient,
-				ansibleImage,
-				ansibleImagePullPolicy,
 			)
 			return func() { controller.Run(1, stopCh) }
 		}(),
@@ -351,8 +349,6 @@ func startServerAndControllers(t *testing.T) (
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,
 				clusterOperatorClient,
-				ansibleImage,
-				ansibleImagePullPolicy,
 			)
 			return func() { controller.Run(1, stopCh) }
 		}(),
@@ -362,8 +358,6 @@ func startServerAndControllers(t *testing.T) (
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,
 				clusterOperatorClient,
-				ansibleImage,
-				ansibleImagePullPolicy,
 			)
 			return func() { controller.Run(1, stopCh) }
 		}(),
@@ -373,8 +367,6 @@ func startServerAndControllers(t *testing.T) (
 				batchSharedInformers.Jobs(),
 				fakeKubeClient,
 				clusterOperatorClient,
-				ansibleImage,
-				ansibleImagePullPolicy,
 			)
 			return func() { controller.Run(1, stopCh) }
 		}(),


### PR DESCRIPTION
* Removes the ansible image command-line arguments to controller-manager. The controllers will determine the ansible image to use based on the information in the ClusterVersion resource. The default is "openshift/origin-ansible:{TAG}", where {TAG} is `ClusterVersion.Spec.Version`. The default is overridden by specifying a value for `ClusterVersion.Spec.OpenshiftAnsibleImage`. The default pull policy is IfNotPresent. The default pull policy is overridden by specifying a value for `ClusterVersion.Spec.OpenshiftAnsibleImagePullPolicy`.
* Removes the `use_real_aws` parameter from the ansible deployment playbook. This is replaced with a `USE_REAL_AWS` variable in the create cluster script. Additionally, the ansible image and pull policy can be specified explicitly by setting the `ANSIBLE_IMAGE` and `ANSIBLE_IMAGE_PULL_POLICY` variables, respectively, when calling the create cluster script.
