### PR TITLE
Add labels for owner relationships

### DIFF
--- a/cmd/cluster-operator-apiserver/app/testing/server_test.go
+++ b/cmd/cluster-operator-apiserver/app/testing/server_test.go
@@ -47,7 +47,7 @@ func TestRun(t *testing.T) {
 			},
 			MachineSets: []clusteroperator.ClusterMachineSet{
 				{
-					Name: "master",
+					ShortName: "master",
 					MachineSetConfig: clusteroperator.MachineSetConfig{
 						NodeType: clusteroperator.NodeTypeMaster,
 						Infra:    true,

--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -43,14 +43,14 @@ objects:
       aws:
         instanceType: "m4.xlarge"
     machineSets:
-    - name: master
+    - shortName: master
       nodeType: Master
       size: 1
-    - name: infra
+    - shortName: infra
       nodeType: Compute
       infra: true
       size: 1
-    - name: compute
+    - shortName: compute
       nodeType: Compute
       size: 1
 

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -361,8 +361,8 @@ type MachineSetList struct {
 
 // ClusterMachineSet is the specification of a machine set in a cluster
 type ClusterMachineSet struct {
-	// Name is a unique name for the machine set within the cluster
-	Name string
+	// ShortName is a unique name for the machine set within the cluster
+	ShortName string
 
 	// MachineSetConfig is the configuration for the MachineSet
 	MachineSetConfig

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -362,8 +362,8 @@ type MachineSetList struct {
 
 // ClusterMachineSet is the specification of a machine set in a cluster
 type ClusterMachineSet struct {
-	// Name is a unique name for the machine set within the cluster
-	Name string `json:"name"`
+	// ShortName is a unique name for the machine set within the cluster
+	ShortName string `json:"shortName"`
 
 	// MachineSetConfig is the configuration for the MachineSet
 	MachineSetConfig `json:",inline"`

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -304,7 +304,7 @@ func Convert_clusteroperator_ClusterList_To_v1alpha1_ClusterList(in *clusteroper
 }
 
 func autoConvert_v1alpha1_ClusterMachineSet_To_clusteroperator_ClusterMachineSet(in *ClusterMachineSet, out *clusteroperator.ClusterMachineSet, s conversion.Scope) error {
-	out.Name = in.Name
+	out.ShortName = in.ShortName
 	if err := Convert_v1alpha1_MachineSetConfig_To_clusteroperator_MachineSetConfig(&in.MachineSetConfig, &out.MachineSetConfig, s); err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func Convert_v1alpha1_ClusterMachineSet_To_clusteroperator_ClusterMachineSet(in 
 }
 
 func autoConvert_clusteroperator_ClusterMachineSet_To_v1alpha1_ClusterMachineSet(in *clusteroperator.ClusterMachineSet, out *ClusterMachineSet, s conversion.Scope) error {
-	out.Name = in.Name
+	out.ShortName = in.ShortName
 	if err := Convert_clusteroperator_MachineSetConfig_To_v1alpha1_MachineSetConfig(&in.MachineSetConfig, &out.MachineSetConfig, s); err != nil {
 		return err
 	}

--- a/pkg/apis/clusteroperator/validation/cluster.go
+++ b/pkg/apis/clusteroperator/validation/cluster.go
@@ -47,14 +47,14 @@ func validateClusterSpec(spec *clusteroperator.ClusterSpec, fldPath *field.Path)
 	versionPath := fldPath.Child("clusterVersionRef")
 	masterCount := 0
 	infraCount := 0
-	machineSetNames := map[string]bool{}
+	machineSetShortNames := map[string]bool{}
 	for i := range spec.MachineSets {
 		machineSet := spec.MachineSets[i]
 		allErrs = append(allErrs, validateClusterMachineSet(&machineSet, machineSetsPath.Index(i))...)
-		if machineSetNames[machineSet.Name] {
-			allErrs = append(allErrs, field.Duplicate(machineSetsPath.Index(i).Child("name"), machineSet.Name))
+		if machineSetShortNames[machineSet.ShortName] {
+			allErrs = append(allErrs, field.Duplicate(machineSetsPath.Index(i).Child("shortName"), machineSet.ShortName))
 		}
-		machineSetNames[machineSet.Name] = true
+		machineSetShortNames[machineSet.ShortName] = true
 		if machineSet.NodeType == clusteroperator.NodeTypeMaster {
 			masterCount++
 			if masterCount > 1 {
@@ -86,8 +86,8 @@ func validateClusterSpec(spec *clusteroperator.ClusterSpec, fldPath *field.Path)
 
 func validateClusterMachineSet(machineSet *clusteroperator.ClusterMachineSet, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	for _, msg := range apivalidation.NameIsDNSSubdomain(machineSet.Name, false) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), machineSet.Name, msg))
+	for _, msg := range apivalidation.NameIsDNSSubdomain(machineSet.ShortName, false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("shortName"), machineSet.ShortName, msg))
 	}
 	allErrs = append(allErrs, validateMachineSetConfig(&machineSet.MachineSetConfig, fldPath)...)
 	return allErrs

--- a/pkg/apis/clusteroperator/validation/cluster_test.go
+++ b/pkg/apis/clusteroperator/validation/cluster_test.go
@@ -40,7 +40,7 @@ func getValidClusterSpec() clusteroperator.ClusterSpec {
 	return clusteroperator.ClusterSpec{
 		MachineSets: []clusteroperator.ClusterMachineSet{
 			{
-				Name: "master",
+				ShortName: "master",
 				MachineSetConfig: clusteroperator.MachineSetConfig{
 					NodeType: clusteroperator.NodeTypeMaster,
 					Infra:    true,
@@ -63,13 +63,13 @@ func getClusterVersionReference() corev1.ObjectReference {
 }
 
 // getTestMachineSet gets a ClusterMachineSet initialized with either compute or master node type
-func getTestMachineSet(size int, name string, master bool, infra bool) clusteroperator.ClusterMachineSet {
+func getTestMachineSet(size int, shortName string, master bool, infra bool) clusteroperator.ClusterMachineSet {
 	nodeType := clusteroperator.NodeTypeCompute
 	if master {
 		nodeType = clusteroperator.NodeTypeMaster
 	}
 	return clusteroperator.ClusterMachineSet{
-		Name: name,
+		ShortName: shortName,
 		MachineSetConfig: clusteroperator.MachineSetConfig{
 			NodeType: nodeType,
 			Size:     size,

--- a/pkg/controller/components/components_controller.go
+++ b/pkg/controller/components/components_controller.go
@@ -55,9 +55,8 @@ const (
 
 	controllerLogName = "components"
 
-	// jobPrefix is used when generating a name for the configmap and job used for each
-	// Ansible execution.
-	jobPrefix = "job-components-"
+	// jobType is the type of job run by this controller.
+	jobType = "components"
 )
 
 var (
@@ -108,7 +107,7 @@ func NewController(
 	c.machineSetsSynced = machineSetInformer.Informer().HasSynced
 
 	jobOwnerControl := &jobOwnerControl{controller: c}
-	c.jobControl = controller.NewJobControl(jobPrefix, machineSetKind, kubeClient, jobInformer.Lister(), jobOwnerControl, logger)
+	c.jobControl = controller.NewJobControl(jobType, machineSetKind, kubeClient, jobInformer.Lister(), jobOwnerControl, logger)
 	jobInformer.Informer().AddEventHandler(c.jobControl)
 	c.jobsSynced = jobInformer.Informer().HasSynced
 
@@ -331,6 +330,9 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 			image,
 			pullPolicy,
 		)
+		labels := controller.JobLabelsForMachineSetController(machineSet, jobType)
+		controller.AddLabels(job, labels)
+		controller.AddLabels(configMap, labels)
 		return job, configMap, nil
 	}), nil
 }

--- a/pkg/controller/infra/infra_controller_test.go
+++ b/pkg/controller/infra/infra_controller_test.go
@@ -111,7 +111,7 @@ func newCluster() *clusteroperator.Cluster {
 		Spec: clusteroperator.ClusterSpec{
 			MachineSets: []clusteroperator.ClusterMachineSet{
 				{
-					Name: "master",
+					ShortName: "master",
 					MachineSetConfig: clusteroperator.MachineSetConfig{
 						NodeType: clusteroperator.NodeTypeMaster,
 						Infra:    true,

--- a/pkg/controller/jobcontrol.go
+++ b/pkg/controller/jobcontrol.go
@@ -364,7 +364,7 @@ func (c *jobControl) onJobEvent(obj interface{}, eventType string) {
 func (c *jobControl) createJob(ownerKey string, owner metav1.Object, jobFactory JobFactory, logger log.FieldLogger) (*kbatch.Job, error) {
 	logger.Infof("Creating new %q job", c.jobPrefix)
 
-	name := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s%s-", c.jobPrefix, owner.GetName()))
+	name := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%s-", c.jobPrefix, owner.GetName()))
 
 	if jobFactory == nil {
 		logger.Warn("asked to build new job but no job factory supplied")

--- a/pkg/controller/jobcontrol_test.go
+++ b/pkg/controller/jobcontrol_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	testJobPrefix = "test-job-"
+	testJobPrefix = "test-job"
 	testOwnerKey  = "test-owner-key"
 )
 

--- a/pkg/controller/jobsync.go
+++ b/pkg/controller/jobsync.go
@@ -261,7 +261,5 @@ func (s *jobSync) addFinalizer(original metav1.Object) error {
 }
 
 func (s *jobSync) getFinalizerName() string {
-	// Add a valid alphanumeric character to the end of the finalizer since the job
-	// prefix is likely to end in an invalid hyphen character.
-	return fmt.Sprintf("openshift/cluster-operator-%s1", s.jobControl.GetJobPrefix())
+	return fmt.Sprintf("openshift/cluster-operator-%s", s.jobControl.GetJobPrefix())
 }

--- a/pkg/controller/jobsync_test.go
+++ b/pkg/controller/jobsync_test.go
@@ -38,7 +38,7 @@ const (
 	testName      = "test-name"
 	testKey       = "test-namespace/test-name"
 	testJobName   = "test-job-abc"
-	testFinalizer = "openshift/cluster-operator-test-job-1"
+	testFinalizer = "openshift/cluster-operator-test-job"
 )
 
 var (

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -337,9 +337,9 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "ClusterMachineSet is the specification of a machine set in a cluster",
 					Properties: map[string]spec.Schema{
-						"name": {
+						"shortName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Name is a unique name for the machine set within the cluster",
+								Description: "ShortName is a unique name for the machine set within the cluster",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -386,7 +386,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"name", "nodeType", "infra", "size", "nodeLabels"},
+					Required: []string{"shortName", "nodeType", "infra", "size", "nodeLabels"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/registry/clusteroperator/cluster/storage_test.go
+++ b/pkg/registry/clusteroperator/cluster/storage_test.go
@@ -50,7 +50,7 @@ func validNewCluster(name string) *clusteroperatorapi.Cluster {
 		Spec: clusteroperatorapi.ClusterSpec{
 			MachineSets: []clusteroperatorapi.ClusterMachineSet{
 				{
-					Name: "master",
+					ShortName: "master",
 					MachineSetConfig: clusteroperatorapi.MachineSetConfig{
 						NodeType: clusteroperatorapi.NodeTypeMaster,
 						Infra:    true,

--- a/test/integration/jobutils.go
+++ b/test/integration/jobutils.go
@@ -193,7 +193,7 @@ func completeInfraProvision(t *testing.T, kubeClient *kubefake.Clientset, cluste
 		kubeClient,
 		clusterOperatorClient,
 		cluster.Namespace, cluster.Name,
-		clusterJobRef(t, kubeClient, "job-infra-"),
+		clusterJobRef(t, kubeClient, "infra"),
 		waitForClusterProvisioned,
 	) {
 		return false
@@ -262,11 +262,11 @@ func completeInfraDeprovision(t *testing.T, kubeClient *kubefake.Clientset, clus
 		kubeClient,
 		clusterOperatorClient,
 		cluster.Namespace, cluster.Name,
-		clusterJobRef(t, kubeClient, "job-infra-"),
+		clusterJobRef(t, kubeClient, "infra"),
 		func(client clientset.Interface, namespace, name string) error {
 			return waitForObjectToNotExistOrNotHaveFinalizer(
 				namespace, name,
-				"openshift/cluster-operator-job-infra-1",
+				"openshift/cluster-operator-infra",
 				func(namespace, name string) (metav1.Object, error) {
 					return getCluster(client, namespace, name)
 				},
@@ -285,7 +285,7 @@ func completeMachineSetProvision(t *testing.T, kubeClient *kubefake.Clientset, c
 		kubeClient,
 		clusterOperatorClient,
 		machineSet.Namespace, machineSet.Name,
-		machineSetJobRef(t, kubeClient, "provision-machineset-"),
+		machineSetJobRef(t, kubeClient, "provision"),
 		func(client clientset.Interface, namespace, name string) error {
 			return waitForMachineSetStatus(
 				client,
@@ -336,11 +336,11 @@ func completeMachineSetDeprovision(t *testing.T, kubeClient *kubefake.Clientset,
 		kubeClient,
 		clusterOperatorClient,
 		machineSet.Namespace, machineSet.Name,
-		machineSetJobRef(t, kubeClient, "provision-machineset-"),
+		machineSetJobRef(t, kubeClient, "provision"),
 		func(client clientset.Interface, namespace, name string) error {
 			return waitForObjectToNotExistOrNotHaveFinalizer(
 				namespace, name,
-				"openshift/cluster-operator-provision-machineset-1",
+				"openshift/cluster-operator-provision",
 				func(namespace, name string) (metav1.Object, error) {
 					return getCluster(client, namespace, name)
 				},
@@ -375,7 +375,7 @@ func completeMachineSetInstall(t *testing.T, kubeClient *kubefake.Clientset, clu
 		kubeClient,
 		clusterOperatorClient,
 		machineSet.Namespace, machineSet.Name,
-		machineSetJobRef(t, kubeClient, "job-master-"),
+		machineSetJobRef(t, kubeClient, "master"),
 		func(client clientset.Interface, namespace, name string) error {
 			return waitForMachineSetStatus(
 				client,
@@ -398,7 +398,7 @@ func completeMachineSetAccept(t *testing.T, kubeClient *kubefake.Clientset, clus
 		kubeClient,
 		clusterOperatorClient,
 		machineSet.Namespace, machineSet.Name,
-		machineSetJobRef(t, kubeClient, "job-accept-"),
+		machineSetJobRef(t, kubeClient, "accept"),
 		func(client clientset.Interface, namespace, name string) error {
 			return waitForMachineSetStatus(
 				client,


### PR DESCRIPTION
* MachineSets will have the following labels.
   - `cluster-uid` matching the UID of the owning cluster
   - `cluster` matching the name of the owning cluster
   - `machine-set-short-name` matching the short name from the cluster spec for the machine set
* Jobs and Configmaps will have the following labels.
   - `cluster-uid` or `machine-set-uid` matching the UID of the owning resource
   - `cluster` or `machine-set` matching the name of the owning resource
   - `job-type` type of the job (e.g., "provision", "infra", "accept")
   - if owning resource is a machine set, then all of the labels from the owning machine set
* For example, a components job will have the following labels.
    - `cluster-uid`: uid of the cluster
    - `cluster`: name of the cluster
    - `machine-set-uid`: uid of the master machine set
    - `machine-set`: name of the master machine set
    - `machine-set-short-name`: short name of the master machine set (e.g., "master")
    - `job-type`: "components"
* The `Name` of the machine set specified in the cluster spec has been changed to `ShortName` to disambiguate it from the full name of the MachineSet resource.
* Cluster controller will associate MachineSet resources with the machine sets in the cluster spec using the `machine-set-short-name` label rather than using the name of the MachineSet resource.
* Job prefixes have all been shortened down to the same as the job type (e.g., "infra")

Get the machine sets for a cluster named "cluster1".
```console
oc get machineset -l cluster=cluster1
```

Get the machine set with the short name "master" for a cluster named "cluster1".
```console
oc get machineset -l cluster=cluster1,machine-set-short-name=master
```

Get the provision job for the machine set with the short name "master" for a cluster named "cluster1".
```console
oc get job -l cluster=cluster1,machine-set-short-name=master,job=provision
```