### PR TITLE
Switch to t2.medium for test cluster.

### DIFF
--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -41,7 +41,7 @@ objects:
         keyPairName: "libra"
     defaultHardwareSpec:
       aws:
-        instanceType: "m4.xlarge"
+        instanceType: "t2.medium"
     machineSets:
     - name: master
       nodeType: Master


### PR DESCRIPTION
More commonly used for development, and seems to work fine for our purposes.