### PR TITLE
cluster-api installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ CLUSTER_OPERATOR_IMAGE               = $(REGISTRY)cluster-operator-$(ARCH):$(VER
 CLUSTER_OPERATOR_MUTABLE_IMAGE       = $(REGISTRY)cluster-operator-$(ARCH):$(MUTABLE_TAG)
 FAKE_OPENSHIFT_ANSIBLE_IMAGE         = $(REGISTRY)fake-openshift-ansible:$(VERSION)
 FAKE_OPENSHIFT_ANSIBLE_MUTABLE_IMAGE = $(REGISTRY)fake-openshift-ansible:$(MUTABLE_TAG)
+CLUSTER_OPERATOR_ANSIBLE_IMAGE       = $(REGISTRY)cluster-operator-ansible:$(VERSION)
+CLUSTER_OPERATOR_ANSIBLE_MUTABLE_IMAGE = $(REGISTRY)cluster-operator-ansible:$(MUTABLE_TAG)
 PLAYBOOK_MOCK_IMAGE                  = $(REGISTRY)playbook-mock:$(VERSION)
 PLAYBOOK_MOCK_MUTABLE_IMAGE          = $(REGISTRY)playbook-mock:$(MUTABLE_TAG)
 
@@ -293,7 +295,7 @@ clean-coverage:
 
 # Building Docker Images for our executables
 ############################################
-images: cluster-operator-image fake-openshift-ansible-image playbook-mock-image
+images: cluster-operator-image fake-openshift-ansible-image playbook-mock-image cluster-operator-ansible-image
 
 images-all: $(addprefix arch-image-,$(ALL_ARCH))
 arch-image-%:
@@ -321,6 +323,13 @@ ifeq ($(ARCH),amd64)
 	docker tag $(CLUSTER_OPERATOR_IMAGE) $(REGISTRY)cluster-operator:$(VERSION)
 	docker tag $(CLUSTER_OPERATOR_MUTABLE_IMAGE) $(REGISTRY)cluster-operator:$(MUTABLE_TAG)
 endif
+
+CLUSTER_OP_ANSIBLE_REPO   ?= https://github.com/openshift/openshift-ansible.git
+CLUSTER_OP_ANSIBLE_BRANCH ?= release-3.9
+
+cluster-operator-ansible-image: build/cluster-operator-ansible/Dockerfile build/cluster-operator-ansible/cluster-api-prep/deploy-cluster-api.yaml build/cluster-operator-ansible/cluster-api-prep/files/cluster-api-template.yaml
+	docker build -t $(CLUSTER_OPERATOR_ANSIBLE_IMAGE) --build-arg=CO_ANSIBLE_URL=$(CLUSTER_OP_ANSIBLE_REPO) --build-arg=CO_ANSIBLE_BRANCH=$(CLUSTER_OP_ANSIBLE_BRANCH) build/cluster-operator-ansible
+	docker tag $(CLUSTER_OPERATOR_ANSIBLE_IMAGE) $(CLUSTER_OPERATOR_ANSIBLE_MUTABLE_IMAGE)
 
 fake-openshift-ansible-image: build/fake-openshift-ansible/Dockerfile $(BINDIR)/fake-openshift-ansible
 	$(call build-and-tag,"fake-openshift-ansible",$(FAKE_OPENSHIFT_ANSIBLE_IMAGE),$(FAKE_OPENSHIFT_ANSIBLE_MUTABLE_IMAGE))

--- a/build/cluster-operator-ansible/Dockerfile
+++ b/build/cluster-operator-ansible/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openshift/origin-ansible:latest
+
+ARG CO_ANSIBLE_URL=https://github.com/openshift/openshift-ansible.git
+ARG CO_ANSIBLE_BRANCH=release-3.9
+ARG CLONE_LOCATION=/usr/share/ansible/openshift-ansible
+
+USER root
+
+RUN rm -rf ${CLONE_LOCATION}
+RUN git clone ${CO_ANSIBLE_URL} ${CLONE_LOCATION} && \
+    cd ${CLONE_LOCATION} && \
+    git checkout ${CO_ANSIBLE_BRANCH}
+
+WORKDIR ${CLONE_LOCATION}
+
+RUN mkdir ${CLONE_LOCATION}/playbooks/cluster-api-prep && ln -s ../../roles ./playbooks/cluster-api-prep
+COPY cluster-api-prep/ ${CLONE_LOCATION}/playbooks/cluster-api-prep
+
+USER 1001:0

--- a/build/cluster-operator-ansible/cluster-api-prep/deploy-cluster-api.yaml
+++ b/build/cluster-operator-ansible/cluster-api-prep/deploy-cluster-api.yaml
@@ -1,0 +1,94 @@
+---
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+#- name: set the master facts for hostname to elb
+#  hosts: masters
+#  gather_facts: no
+#  remote_user: root
+#  tasks:
+#  - import_role:
+#      name: openshift_aws
+#      tasks_from: master_facts.yml
+
+#- name: run the init
+#  import_playbook: ../init/main.yml
+
+- name: install cluster-api
+  hosts: masters[0]
+  gather_facts: no
+  remote_user: root
+  vars:
+    cluster_api_namespace: kube-cluster
+  tasks:
+  - name: import lib_openshift
+    import_role:
+      name: lib_openshift
+
+  - name: slurp local template content
+    slurp:
+      src: files/cluster-api-template.yaml
+    delegate_to: localhost
+    register: template
+
+  - name: "create {{ cluster_api_namespace }} namesapce"
+    oc_project:
+      state: present
+      name: "{{ cluster_api_namespace }}"
+      display_name: "Cluster API"
+      node_selector:
+      - node-role.kubernetes.io/master=true
+
+  - name: create certificates
+    when: cluster_api_cert is not defined
+    block:
+    - name: create certificates
+      oc_adm_ca_server_cert:
+        signer_cert: /etc/origin/master/ca.crt
+        signer_key: /etc/origin/master/ca.key
+        signer_serial: /etc/origin/master/ca.serial.txt
+        hostnames: "clusterapi.{{ cluster_api_namespace }},clusterapi.{{ cluster_api_namespace }}.svc"
+        cert: /tmp/clusterapi.crt
+        key: /tmp/clusterapi.key
+      register: cert_out
+      run_once: true
+    - debug: var=cert_out
+
+    - name: slurp certificate data
+      slurp:
+        path: /tmp/clusterapi.crt
+      register: clusterapi_crt
+      run_once: true
+
+    - name: slurp key data
+      slurp:
+        path: /tmp/clusterapi.key
+      register: clusterapi_key
+      run_once: true
+
+    - name: save generated cert/key data
+      set_fact:
+        cluster_api_cert: "{{ clusterapi_crt.content }}"
+        cluster_api_key: "{{ clusterapi_key.content }}"
+        cluster_api_ca_bundle: "{{ clusterapi_crt.content }}"
+
+  - name: process template
+    oc_process:
+      namespace: "{{ cluster_api_namespace }}"
+      state: present
+      create: true
+      content: "{{ template.content | b64decode }}"
+      params:
+         CLUSTER_API_NAMESPACE: "{{ cluster_api_namespace }}"
+         SERVING_CA: "{{ cluster_api_ca_bundle }}"
+         SERVING_CERT: "{{ cluster_api_cert }}"
+         SERVING_KEY: "{{ cluster_api_key }}"
+    run_once: true
+    register: template_out
+
+  - debug:
+      var: template_out

--- a/build/cluster-operator-ansible/cluster-api-prep/files/cluster-api-template.yaml
+++ b/build/cluster-operator-ansible/cluster-api-prep/files/cluster-api-template.yaml
@@ -1,0 +1,335 @@
+########
+#
+# Template for deploying the Cluster Operator.
+#
+# Parameters:
+#   CLUSTER_API_NAMESPACE: namespace to hold clusterapi objects/services
+#   SERVING_CERT: base-64-encoded, pem cert to use for ssl communication with the Cluster API Server. Required.
+#   SERVING_KEY: base-64-encoded, pem private key for the cert to use for ssl communication with the Cluster API Server. Required.
+#   SERVING_CA: base-64-encoded, pem CA cert for the ssl certs. Required.
+#   IMAGE: clusterapi container image location
+#   IMAGE_PULL_POLICY: control image pull policy for clusterapi containers
+#
+########
+
+apiVersion: v1
+kind: Template
+metadata:
+  name: cluster-operator-deploy-cluster-api-template
+
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: cluster-api-apiserver
+    namespace: ${CLUSTER_API_NAMESPACE}
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: cluster-api-controller-manager
+    namespace: ${CLUSTER_API_NAMESPACE}
+
+- apiVersion: apiregistration.k8s.io/v1beta1
+  kind: APIService
+  metadata:
+    name: v1alpha1.cluster.k8s.io
+    labels:
+      api: clusterapi
+  spec:
+    version: v1alpha1
+    group: cluster.k8s.io
+    groupPriorityMinimum: 2000
+    priority: 200
+    service:
+      name: clusterapi
+      namespace: ${CLUSTER_API_NAMESPACE}
+    versionPriority: 10
+    caBundle: ${SERVING_CA}
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: clusterapi
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: cluster-api-apiserver
+  spec:
+    ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 6443
+    selector:
+      app: cluster-api-apiserver
+
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: cluster-api-apiserver
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: cluster-api-apiserver
+  spec:
+    selector:
+      matchLabels:
+        app: cluster-api-apiserver
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: cluster-api-apiserver
+      spec:
+        serviceAccountName: cluster-api-apiserver
+        containers:
+        - name: apiserver
+          image: ${IMAGE}
+          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          volumeMounts:
+          - name: cluster-apiserver-certs
+            mountPath: /var/run/cluster-api-apiserver
+            readOnly: true
+          command:
+          - "./apiserver"
+          args:
+          - "--etcd-servers=http://localhost:2379"
+          - "--tls-cert-file=/var/run/cluster-api-apiserver/tls.crt"
+          - "--tls-private-key-file=/var/run/cluster-api-apiserver/tls.key"
+          - "--loglevel=10"
+          - "--secure-port=6443"
+          ports:
+          - containerPort: 6443
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 6443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 6443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 40Mi
+            limits:
+              cpu: 100m
+              memory: 60Mi
+        - name: etcd
+          image: quay.io/coreos/etcd:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 30Mi
+          env:
+          - name: ETCD_DATA_DIR
+            value: /etcd-data-dir
+          command:
+          - /usr/local/bin/etcd
+          - --listen-client-urls
+          - http://0.0.0.0:2379
+          - --advertise-client-urls
+          - http://localhost:2379
+          ports:
+          - containerPort: 2379
+          volumeMounts:
+          - name: etcd-data-dir
+            mountPath: /etcd-data-dir
+          readinessProbe:
+            httpGet:
+              port: 2379
+              path: /health
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              port: 2379
+              path: /health
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: etcd-data-dir
+          emptyDir: {}
+        - name: cluster-apiserver-certs
+          secret:
+            secretName: cluster-apiserver-certs
+
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: cluster-api-controller-manager
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: cluster-api-controller-manager
+  spec:
+    selector:
+      matchLabels:
+        app: cluster-api-controller-manager
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: cluster-api-controller-manager
+      spec:
+        serviceAccountName: cluster-api-controller-manager
+        nodeSelector:
+          node-role.kubernetes.io/master: "true"
+        containers:
+        - name: controller-manager
+          image: ${IMAGE}
+          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          command:
+          - "./controller-manager"
+          args:
+          - --cloud=aws
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 30Mi
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        termindationGracePeriodSeconds: 30
+
+- apiVersion: v1
+  kind: Secret
+  type: kubernetes.io/tls
+  metadata:
+    name: cluster-apiserver-certs
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: cluster-api-apiserver
+  data:
+    tls.crt: ${SERVING_CERT}
+    tls.key: ${SERVING_KEY}
+
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: "clusterapi.openshift.io:apiserver-auth-delegator"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:auth-delegator
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cluster-api-apiserver
+    namespace: ${CLUSTER_API_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: "clusterapi.openshift.io:apiserver-authentication-reader"
+    # using this template outside of of the oc_process module
+    # requires variablizing the namespace, but since our primary
+    # use case is via oc_process we'll hardcode the namespace
+    #namespace: ${KUBE_NAMESPACE}
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: extension-apiserver-authentication-reader
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cluster-api-apiserver
+    namespace: ${CLUSTER_API_NAMESPACE}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: "clusterapi.openshift.io:controller-manager"
+  rules:
+  # configmaps for leader election
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-operator-controller-manager"]
+    verbs: ["get", "update"]
+  # events for recording events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+  # allow all operations on all resources in our API group
+  - apiGroups: ["cluster.k8s.io"]
+    resources: ["*"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # allow operations on required resources in any namespace a cluster is created
+  - apiGroups: [""]
+    resources: ["configmaps", "pods", "secrets", "nodes"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["*"]
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: "clusterapi.openshift.io:controller-manager"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: "clusterapi.openshift.io:controller-manager"
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cluster-api-apiserver
+    namespace: ${CLUSTER_API_NAMESPACE}
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cluster-api-controller-manager
+    namespace: ${CLUSTER_API_NAMESPACE}
+
+
+parameters:
+# namespace to install clusterapi services onto
+- name: CLUSTER_API_NAMESPACE
+  value: kube-cluster
+# Do not change
+- name: KUBE_NAMESPACE
+  value: kube-system
+# pull policy (for testing)
+- name: IMAGE_PULL_POLICY
+  value: Always
+# CA cert for API Server SSL cert
+- name: SERVING_CA
+# Private key for API Server SSL cert
+- name: SERVING_CERT
+# Public API Server SSL cert
+- name: SERVING_KEY
+# location of container image
+- name: IMAGE
+  value: quay.io/openshift/kubernetes-cluster-api:latest


### PR DESCRIPTION
new ansible automation to deploy cluster-api images onto a cluster (based on template from https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/cloud/google/config/configtemplate.go )

lay additional ansible files on top of openshift-ansible at playbooks/cluster-api-prep/deploy-cluster-api.yaml

provide the following ansible variables for deployment:
cluster_api_image: location of container image to pull/run (default quay.io/openshift/kubernets-cluster-api:latest)
it will generate a certificate, or you can provide your own:
cluster_api_ca_bundle: CA bundle for cluster-api services
cluster_api_cert: certificate for services
cluster_api_key: key for services
