### PR TITLE
Default to origin-ansible v3.9 instead of latest.

### DIFF
--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -67,7 +67,7 @@ parameters:
 - name: ANSIBLE_IMAGE
   displayName: Openshift Ansible Image
   description: Name and tag of the Openshift Ansible image to use to run the ansible jobs
-  value: "openshift/origin-ansible:latest"
+  value: "openshift/origin-ansible:v3.9"
 - name: ANSIBLE_IMAGE_PULL_POLICY
   displayName: Openshift Ansible Image Pull Policy
   description: Policy to use when pulling the Openshift Ansible image

--- a/contrib/examples/create-cluster.sh
+++ b/contrib/examples/create-cluster.sh
@@ -34,8 +34,8 @@ if [ -z ${USE_REAL_AWS} ]
 then
 	: ${ANSIBLE_IMAGE:="fake-openshift-ansible:canary"}
 	: ${ANSIBLE_IMAGE_PULL_POLICY:="Never"}
-else	
-	: ${ANSIBLE_IMAGE:="openshift/origin-ansible:latest"}
+else
+	: ${ANSIBLE_IMAGE:="openshift/origin-ansible:v3.9"}
 	: ${ANSIBLE_IMAGE_PULL_POLICY:="Always"}
 fi
 


### PR DESCRIPTION
Latest now picks up 3.10 changes which break, possibly because we're
trying to use them against AMIs with 3.9.