### PR TITLE
Generate certs if secrets do not exist.

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -4,9 +4,14 @@
   connection: local
   gather_facts: no
   vars:
-    aws_section: default
+    # Section in ~/.aws/credentials with the AWS creds CO should use to create cloud infra and VMs:
+    aws_creds_section: default
+    # SSH key used for access to all VMs CO creates:
     ssh_priv_key: '~/.ssh/libra.pem'
+    # Namespace to deploy CO to:
     cluster_operator_namespace: "openshift-cluster-operator"
+    # Force regeneration of apiserver and default cluster cert. This will be set true if either are
+    # found to not exist.
     redeploy_certs: False
   tasks:
   - set_fact:
@@ -36,12 +41,12 @@
     when: pass_protect_ssh.rc == 0
 
   - set_fact:
-      aws_section: "{{ cli_aws_section }}"
+      aws_creds_section: "{{ cli_aws_section }}"
     when: cli_aws_section is defined
 
   - set_fact:
-      l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
-      l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
+      l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_creds_section + ' file=~/.aws/credentials') | b64encode }}"
+      l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_creds_section + ' file=~/.aws/credentials') | b64encode }}"
       l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
 
   - name: check if apiserver cert secret exists

--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -7,40 +7,22 @@
     aws_section: default
     ssh_priv_key: '~/.ssh/libra.pem'
     cluster_operator_namespace: "openshift-cluster-operator"
+    redeploy_certs: False
   tasks:
   - set_fact:
       cluster_operator_namespace: "{{ cli_cluster_operator_namespace }}"
     when: cli_cluster_operator_namespace is defined
 
+  # TODO: use k8s_raw?
   - name: create cluster-operator namespace
     command: "oc create namespace {{ cluster_operator_namespace }}"
     register: createns_reg
     failed_when: createns_reg.rc > 0 and "AlreadyExists" not in createns_reg.stderr
     changed_when: createns_reg.rc == 0
 
-  - name: generate apiserver certs
-    command: "{{ playbook_dir }}/../apiserver-aggregation-tls-setup.sh"
-    args:
-      # ensure these land in the top level of the project where expected
-      chdir: "{{ playbook_dir }}/../../"
-      # only runs if this file does not exist
-      creates: "{{ playbook_dir }}/../../apiserver.pem"
-
   - set_fact:
       ssh_priv_key: "{{ cli_ssh_priv_key }}"
     when: cli_ssh_priv_key is defined
-
-  - set_fact:
-      aws_section: "{{ cli_aws_section }}"
-    when: cli_aws_section is defined
-
-  - set_fact:
-      l_serving_ca: "{{ lookup('file', playbook_dir + '/../../ca.pem') | b64encode }}"
-      l_serving_cert: "{{ lookup('file', playbook_dir + '/../../apiserver.pem') | b64encode }}"
-      l_serving_key: "{{ lookup('file', playbook_dir + '/../../apiserver-key.pem') | b64encode }}"
-      l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
-      l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
-      l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
 
   - name: check for password-protected ssh key
     command: "grep ENCRYPTED {{ ssh_priv_key }}"
@@ -53,9 +35,100 @@
       msg: password protected ssh key not supported
     when: pass_protect_ssh.rc == 0
 
+  - set_fact:
+      aws_section: "{{ cli_aws_section }}"
+    when: cli_aws_section is defined
+
+  - set_fact:
+      l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
+      l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_section + ' file=~/.aws/credentials') | b64encode }}"
+      l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
+
+  - name: check if apiserver cert secret exists
+    command: "oc get secret cluster-operator-apiserver-cert -n {{ cluster_operator_namespace }}"
+    failed_when: false
+    changed_when: false
+    register: apiserver_cert_exists_reg
+
+  - name: check if cluster cert secret exists
+    # TODO: rename and parameterize these secret names
+    command: "oc get secret ssl-cert -n {{ cluster_operator_namespace }}"
+    failed_when: false
+    changed_when: false
+    register: cluster_cert_exists_reg
+
+  # Either secret missing triggers a full certificate redeploy
+  # TODO: could we lock ourselves out of existing clusters?
+  - set_fact:
+      redeploy_certs: True
+    when: (apiserver_cert_exists_reg.rc > 0 and "NotFound" in apiserver_cert_exists_reg.stderr) or (cluster_cert_exists_reg.rc > 0 and "NotFound" in cluster_cert_exists_reg.stderr)
+
+  - name: generate apiserver certs
+    command: "{{ playbook_dir }}/../apiserver-aggregation-tls-setup.sh"
+    args:
+      # ensure these land in the top level of the project where expected
+      chdir: "{{ playbook_dir }}/../../"
+      # only runs if this file does not exist in top level of the git repo.
+      creates: "{{ playbook_dir }}/../../apiserver.pem"
+    when: redeploy_certs | bool
+
+  - set_fact:
+      # base-64-encoded, pem CA cert for the ssl certs
+      l_serving_ca: "{{ lookup('file', playbook_dir + '/../../ca.pem') | b64encode }}"
+      # base-64-encoded, pem cert to use for ssl communication with the Cluster Operator API Server
+      l_serving_cert: "{{ lookup('file', playbook_dir + '/../../apiserver.pem') | b64encode }}"
+      # base-64-encoded, pem private key for the cert to use for ssl communication with the Cluster Operator API Server.
+      l_serving_key: "{{ lookup('file', playbook_dir + '/../../apiserver-key.pem') | b64encode }}"
+    when: redeploy_certs | bool
+
+  - name: create apiserver cert secret
+    k8s_raw:
+      state: present
+      definition:
+        # Secret to pass the SSL certs to the API Server
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: cluster-operator-apiserver-cert
+          namespace: "{{ cluster_operator_namespace }}"
+          labels:
+            app: cluster-operator-apiserver
+        type: Opaque
+        data:
+          tls.crt: "{{ l_serving_cert }}"
+          tls.key: "{{ l_serving_key }}"
+    when: redeploy_certs | bool
+
+  - name: create cluster cert secret
+    k8s_raw:
+      state: present
+      definition:
+        # Secret to pass the SSL certs to the API Server
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ssl-cert
+          namespace: "{{ cluster_operator_namespace }}"
+          labels:
+            app: cluster-operator-apiserver
+        type: Opaque
+        data:
+          server.crt: "{{ l_serving_cert }}"
+          server.key: "{{ l_serving_key }}"
+          ca.crt: "{{ l_serving_ca }}"
+    when: redeploy_certs | bool
+
+  - name: load serving CA from secret
+    command: "oc get secret -n {{ cluster_operator_namespace }} ssl-cert -o json"
+    register: cluster_cert_secret_reg
+
+  # Ensure l_serving_ca is set even if we did not regen certs, as it's needed for the apiserver aggregation:
+  - set_fact:
+      l_serving_ca: "{{ (cluster_cert_secret_reg.stdout | from_json)['data']['ca.crt'] }}"
+
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template
-    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p CLUSTER_OPERATOR_NAMESPACE={{ cluster_operator_namespace }} -p SERVING_CA={{ l_serving_ca }} -p SERVING_CERT={{ l_serving_cert }} -p SERVING_KEY={{ l_serving_key }} AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} | oc apply -f -"
+    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p CLUSTER_OPERATOR_NAMESPACE={{ cluster_operator_namespace }} -p SERVING_CA={{ l_serving_ca }}  AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} | oc apply -f -"
 
   - name: deploy playbook-mock for testing with fake-openshift-ansible
     shell: "oc apply -n {{ cluster_operator_namespace }} -f {{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"

--- a/contrib/examples/deploy.yaml
+++ b/contrib/examples/deploy.yaml
@@ -4,8 +4,6 @@
 #
 # Parameters:
 #   CLUSTER_OPERATOR_NAMESPACE: namespace to which to deploy the cluster operator. Defaults to "openshift-cluster-operator".
-#   SERVING_CERT: base-64-encoded, pem cert to use for ssl communication with the Cluster Operator API Server. Required.
-#   SERVING_KEY: base-64-encoded, pem private key for the cert to use for ssl communication with the Cluster Operator API Server. Required.
 #   SERVING_CA: base-64-encoded, pem CA cert for the ssl certs. Required.
 #
 ########
@@ -115,31 +113,6 @@ objects:
     kind: ServiceAccount
     name: cluster-operator-controller-manager
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
-
-# Secret to pass the SSL certs to the API Server
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: cluster-operator-apiserver-cert
-    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
-    labels:
-      app: cluster-operator-apiserver
-  type: Opaque
-  data:
-    tls.crt: ${SERVING_CERT}
-    tls.key: ${SERVING_KEY}
-
-# Default secret for cluster SSL
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: ssl-cert
-    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
-  type: Opaque
-  data:
-    server.crt: ${SERVING_CERT}
-    server.key: ${SERVING_KEY}
-    ca.crt: ${SERVING_CA}
 
 # Secret for AWS credentials to provision with.
 # NOTE: likely will be replaced by a set of credentials per cluster
@@ -409,10 +382,6 @@ parameters:
   value: kube-system
 # CA cert for API Server SSL cert
 - name: SERVING_CA
-# Private key for API Server SSL cert
-- name: SERVING_CERT
-# Public API Server SSL cert
-- name: SERVING_KEY
 - name: AWS_ACCESS_KEY_ID
 - name: AWS_SECRET_ACCESS_KEY
 - name: AWS_SSH_PRIVATE_KEY


### PR DESCRIPTION
If either the apiserver or cluster cert secrets do not exist, generate a
new local set of certs, and store as secrets.

etcd in the cluster itself will serve as the shared storage for these
across the team for a deployment.