### PR TITLE
Bump test cluster instance type to t2.xlarge.

### DIFF
--- a/contrib/examples/cluster.yaml
+++ b/contrib/examples/cluster.yaml
@@ -41,7 +41,7 @@ objects:
         keyPairName: "libra"
     defaultHardwareSpec:
       aws:
-        instanceType: "t2.medium"
+        instanceType: "t2.xlarge"
     machineSets:
     - shortName: master
       nodeType: Master


### PR DESCRIPTION
We're really struggling with performance and stability on t2.medium.