### PR TITLE
save kubeconfig after install

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-operator/aws/install_masters.yml
+++ b/build/cluster-operator-ansible/playbooks/cluster-operator/aws/install_masters.yml
@@ -1,0 +1,54 @@
+---
+# call openshift-ansible's master provisioning
+- import_playbook: ../../aws/openshift-cluster/install.yml
+
+# The below piece of ansible would be needed if we wanted to only
+# do the save-kubeconfig-from-target-cluster steps that follow.
+# This playbook can one day be extended to handle a workflow of
+# just-get-me-an-updated-kubeconfig by enabling/conditionalizing
+# the commented out piece below.
+#- name: setup master ansible hosts
+#  hosts: localhost
+#  gather_facts: false
+#  tasks:
+#  - name: setup the master node group
+#    import_role:
+#      name: openshift_aws
+#      tasks_from: setup_master_group.yml
+
+- name: save kubeconfig into secret
+  hosts: masters[0]
+  gather_facts: false
+  remote_user: root
+  tasks:
+  - name: slurp kubeconfig
+    slurp:
+      src: /etc/origin/master/admin.kubeconfig
+    register: kubeconfig
+
+  - name: temp file to hold kubeconfig
+    tempfile:
+      state: file
+    register: temp_file
+    delegate_to: localhost
+
+  - name: save kubeconfig into temp file
+    copy:
+      content: "{{ kubeconfig.content | b64decode }}"
+      dest: "{{ temp_file.path }}"
+    delegate_to: localhost
+
+  - name: delete any existing secret
+    shell: "oc delete secret {{ openshift_aws_clusterid }}-kubeconfig"
+    ignore_errors: true
+    delegate_to: localhost
+
+  - name: save secret
+    shell: "oc secret new {{ openshift_aws_clusterid }}-kubeconfig kubeconfig={{ temp_file.path }}"
+    delegate_to: localhost
+
+  - name: delete temp file
+    file:
+      state: absent
+      path: "{{ temp_file.path }}"
+    delegate_to: localhost

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -56,7 +56,7 @@ const (
 
 	controllerLogName = "master"
 
-	masterPlaybook = "playbooks/aws/openshift-cluster/install.yml"
+	masterPlaybook = "playbooks/cluster-operator/aws/install_masters.yml"
 	// jobType is the type of job run by this controller.
 	jobType = "master"
 


### PR DESCRIPTION
introduce playbooks/cluster-operator/aws/install_masters.yml. this will call the original playbook/aws/openshift-cluster/install.yml and then save the kubeconfig from one of the masters into a secret for custer operator

update the master controller installation playbook to use the new entrypoint

note: this now means that any and all clusterversion objects will need to reference cluster-operator-ansible as the container image