### PR TITLE
Extract AWS creds secret from template.

### DIFF
--- a/contrib/ansible/deploy-devel.yaml
+++ b/contrib/ansible/deploy-devel.yaml
@@ -49,6 +49,31 @@
       l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_creds_section + ' file=~/.aws/credentials') | b64encode }}"
       l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
 
+  - name: check if AWS credentials secret exists
+    command: "oc get secret aws-credentials -n {{ cluster_operator_namespace }}"
+    failed_when: false
+    changed_when: false
+    register: aws_creds_secret_exists_reg
+
+  # If the aws credentials secret does not already exist, try to create it:
+  - name: create AWS credentials secret
+    k8s_raw:
+      state: present
+      definition:
+
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-credentials
+          namespace: "{{ cluster_operator_namespace }}"
+          labels:
+            app: cluster-operator
+        type: Opaque
+        data:
+          awsAccessKeyId: "{{ l_aws_access_key_id }}"
+          awsSecretAccessKey: "{{ l_aws_secret_access_key }}"
+    when: aws_creds_secret_exists_reg.rc > 0 and "NotFound" in aws_creds_secret_exists_reg.stderr
+
   - name: check if apiserver cert secret exists
     command: "oc get secret cluster-operator-apiserver-cert -n {{ cluster_operator_namespace }}"
     failed_when: false
@@ -133,7 +158,7 @@
 
   # TODO: not accurately reflecting 'changed' status as apply doesn't report until upstream PRs merge.
   - name: deploy application template
-    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p CLUSTER_OPERATOR_NAMESPACE={{ cluster_operator_namespace }} -p SERVING_CA={{ l_serving_ca }}  AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} | oc apply -f -"
+    shell: "oc process -f {{ playbook_dir }}/../examples/deploy.yaml -o yaml -p CLUSTER_OPERATOR_NAMESPACE={{ cluster_operator_namespace }} -p SERVING_CA={{ l_serving_ca }} AWS_SSH_PRIVATE_KEY={{ l_aws_ssh_private_key }} | oc apply -f -"
 
   - name: deploy playbook-mock for testing with fake-openshift-ansible
     shell: "oc apply -n {{ cluster_operator_namespace }} -f {{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"

--- a/contrib/examples/deploy.yaml
+++ b/contrib/examples/deploy.yaml
@@ -114,20 +114,6 @@ objects:
     name: cluster-operator-controller-manager
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
 
-# Secret for AWS credentials to provision with.
-# NOTE: likely will be replaced by a set of credentials per cluster
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: aws-credentials
-    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
-    labels:
-      app: cluster-operator
-  type: Opaque
-  data:
-    aws_access_key_id: ${AWS_ACCESS_KEY_ID}
-    aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-
 # Secret for AWS SSH private key
 - apiVersion: v1
   kind: Secret
@@ -382,6 +368,4 @@ parameters:
   value: kube-system
 # CA cert for API Server SSL cert
 - name: SERVING_CA
-- name: AWS_ACCESS_KEY_ID
-- name: AWS_SECRET_ACCESS_KEY
 - name: AWS_SSH_PRIVATE_KEY

--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -218,7 +218,7 @@ func (r *jobGenerator) GeneratePlaybooksJobWithServiceAccount(
 				ValueFrom: &kapi.EnvVarSource{
 					SecretKeyRef: &kapi.SecretKeySelector{
 						LocalObjectReference: hardware.AWS.AccountSecret,
-						Key:                  "aws_access_key_id",
+						Key:                  "awsAccessKeyId",
 					},
 				},
 			},
@@ -227,7 +227,7 @@ func (r *jobGenerator) GeneratePlaybooksJobWithServiceAccount(
 				ValueFrom: &kapi.EnvVarSource{
 					SecretKeyRef: &kapi.SecretKeySelector{
 						LocalObjectReference: hardware.AWS.AccountSecret,
-						Key:                  "aws_secret_access_key",
+						Key:                  "awsSecretAccessKey",
 					},
 				},
 			},


### PR DESCRIPTION
This is not actually used in the template, rather an assumed set of
credentials we use in the job generator. (will probably eventually
be configmap driven)

Renamed the secret keys to work around a bug in the k8s_raw module.