### PR TITLE
Create etcd pvc in cluster operator namespace

### DIFF
--- a/contrib/examples/deploy.yaml
+++ b/contrib/examples/deploy.yaml
@@ -118,6 +118,7 @@ objects:
   apiVersion: v1
   metadata:
     name: etcd-storage
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
   spec:
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
Deploying didn't work for me because the pvc got created in the current namespace instead of the cluster-operator-namespace