### PR TITLE
Set the current context of the cluster kubeconfig to the external one

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-operator/aws/install_masters.yml
+++ b/build/cluster-operator-ansible/playbooks/cluster-operator/aws/install_masters.yml
@@ -38,6 +38,10 @@
       dest: "{{ temp_file.path }}"
     delegate_to: localhost
 
+  - name: set kubeconfig external context
+    shell: "CONTEXT=$(KUBECONFIG={{ temp_file.path }} oc config get-contexts -o name | grep -v internal) && KUBECONFIG={{ temp_file.path }} oc config use-context $CONTEXT"
+    delegate_to: localhost
+
   - name: delete any existing secret
     shell: "oc delete secret {{ openshift_aws_clusterid }}-kubeconfig"
     ignore_errors: true


### PR DESCRIPTION
Before creating the kubeconfig secret, set the current context in the kubeconfig to the one that will allow external access.