### PR TITLE
Kubectl apply module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
   * Install required packages:
     * Fedora: `sudo dnf install golang make docker ansible`
     * Mac OSX:
-      * [Go](https://golang.org/doc/install#osx) 
+      * [Go](https://golang.org/doc/install#osx)
       * [Ansible](http://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-pip)
-    * NOTE: Ansible 2.5+ is required to run our deployment playbooks.
   * Change docker to allow insecure pulls (required for `oc cluster up`):
     * Edit `/etc/sysconfig/docker`
     * Change `OPTIONS=` to include `--insecure-registry 172.30.0.0/16`

--- a/README.md
+++ b/README.md
@@ -95,3 +95,20 @@ You can then run ansible with the above inventory file and your cluster ID:
 
 `ansible-playbook -i ec2-hosts build/cluster-operator-ansible/playbooks/cluster-operator/node-config-daemonset.yml -e openshift_aws_clusterid=dgoodwin-cluster`
 
+## Maintenance
+
+We're using the Cluster Operator deployment Ansible as a testing ground for the
+kubectl-ansible modules that wrap apply and oc process. These roles are
+vendored in similar to how golang works using a tool called
+[gogitit](https://github.com/dgoodwin/gogitit/). The required gogitit manifest
+and cache are committed, but only the person updating the vendored code needs
+to install the tool or worry about the manifest. For everyone else the roles
+are just available normally and this allows us to not require developers to
+periodically re-run ansible-galaxy install.
+
+Updating the vendored code can be done with:
+
+```
+$ cd contrib/ansible/
+$ gogitit sync
+```

--- a/contrib/ansible/create-cluster-playbook.yaml
+++ b/contrib/ansible/create-cluster-playbook.yaml
@@ -15,7 +15,7 @@
     # ID for your cluster, defaults to current username:
     cluster_name: "{{ lookup ('env', 'USER') }}"
 
-    # ClusterVersion to install, default to fake so we don't actually create a cluster unless user
+    # ClusterVersion to use, default to fake so we don't actually create a cluster unless user
     # explicitly opts-in:
     cluster_version: origin-v3-10-fake
 
@@ -43,6 +43,9 @@
     # in the cert dir defined above.
     cluster_ca_name: ca
 
+  roles:
+    - kubectl-ansible
+
   tasks:
 
   # If no cluster_namespace was defined on the CLI, we want to create the cluster in the current:
@@ -62,11 +65,12 @@
     changed_when: false
 
   - name: create cluster namespace
-    k8s_raw:
-      name: "{{ cluster_namespace }}"
-      api_version: v1
-      kind: Namespace
-      state: present
+    kubectl_apply:
+      definition:
+        kind: "Namespace"
+        apiVersion: v1
+        metadata:
+          name: "{{ cluster_namespace }}"
 
   - name: check for password-protected ssh key
     command: "grep ENCRYPTED {{ ssh_priv_key }}"
@@ -111,5 +115,21 @@
       l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_creds_section + ' file=' + aws_creds_file) | b64encode }}"
       l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
 
-  - name: create the cluster
-    shell: "oc process -f {{ playbook_dir }}/../examples/cluster-template.yaml -p CLUSTER_NAME={{ cluster_name }} -p CLUSTER_NAMESPACE={{ cluster_namespace }} -p CLUSTER_VERSION={{ cluster_version }} -p CLUSTER_VERSION_NAMESPACE={{ cluster_version_namespace }} -p CLUSTER_CERT={{ l_cluster_cert }} -p CLUSTER_PRIVATE_KEY={{ l_cluster_cert_key }} -p AWS_ACCESS_KEY_ID={{ l_aws_access_key_id }} -p AWS_SECRET_ACCESS_KEY={{ l_aws_secret_access_key }} -p SSH_KEY={{ l_aws_ssh_private_key }} -o yaml | oc apply -f -"
+  - name: process cluster template
+    oc_process:
+      template_file: "{{ playbook_dir }}/../examples/cluster-template.yaml"
+      parameters:
+        CLUSTER_NAME: "{{ cluster_name }}"
+        CLUSTER_NAMESPACE: "{{ cluster_namespace }}"
+        CLUSTER_VERSION: "{{ cluster_version }}"
+        CLUSTER_VERSION_NAMESPACE: "{{ cluster_version_namespace }}"
+        CLUSTER_CERT: "{{ l_cluster_cert }}"
+        CLUSTER_PRIVATE_KEY: "{{ l_cluster_cert_key }}"
+        AWS_ACCESS_KEY_ID: "{{ l_aws_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ l_aws_secret_access_key }}"
+        SSH_KEY: "{{ l_aws_ssh_private_key }}"
+    register: cluster_reg
+
+  - name: create/update cluster
+    kubectl_apply:
+      definition: "{{ cluster_reg.result | to_json }}"

--- a/contrib/ansible/create-cluster-playbook.yaml
+++ b/contrib/ansible/create-cluster-playbook.yaml
@@ -43,10 +43,10 @@
     # in the cert dir defined above.
     cluster_ca_name: ca
 
-  roles:
-    - kubectl-ansible
-
   tasks:
+
+  - import_role:
+      name: kubectl-ansible
 
   # If no cluster_namespace was defined on the CLI, we want to create the cluster in the current:
   - name: lookup current namespace if none defined

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -12,12 +12,13 @@
 - hosts: localhost
   connection: local
   gather_facts: no
-  roles:
-    - kubectl-ansible
   vars:
     # Namespace to deploy CO to:
     cluster_operator_namespace: "openshift-cluster-operator"
   tasks:
+
+  - import_role:
+      name: kubectl-ansible
 
   - name: process cluster versions template
     oc_process:

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -12,18 +12,28 @@
 - hosts: localhost
   connection: local
   gather_facts: no
+  roles:
+    - kubectl-ansible
   vars:
     # Namespace to deploy CO to:
     cluster_operator_namespace: "openshift-cluster-operator"
   tasks:
 
-  - name: deploy development cluster versions once our apiserver is up
-    shell: "oc process -f {{ playbook_dir }}/../examples/cluster-versions-template.yaml -o yaml | oc apply -f -"
-    # Wait up to 2 minutes for our apiserver to be accepting our types:
+  - name: process cluster versions template
+    oc_process:
+      template_file: "{{ playbook_dir }}/../examples/cluster-versions-template.yaml"
+    register: cluster_versions_reg
+
+  - name: wait for our apiserver and create/update cluster versions
+    kubectl_apply:
+      definition: "{{ cluster_versions_reg.result | to_json }}"
     register: result
-    until: result.rc == 0
+    # Wait up to 2 minutes for our apiserver to be accepting our types:
+    until: result.failed == false
     retries: 24
     delay: 5
 
-  - name: deploy playbook-mock for testing with fake-openshift-ansible
-    shell: "oc apply -n {{ cluster_operator_namespace }} -f {{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"
+  - name: create/update playbook mock deployment
+    kubectl_apply:
+      namespace: "{{ cluster_operator_namespace }}"
+      src: "{{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"

--- a/contrib/ansible/deploy-playbook.yaml
+++ b/contrib/ansible/deploy-playbook.yaml
@@ -28,9 +28,9 @@
     # in the cert dir defined above.
     apiserver_ca_name: ca
 
-  roles:
-    - kubectl-ansible
   tasks:
+  - import_role:
+      name: kubectl-ansible
   - set_fact:
       cluster_operator_namespace: "{{ cli_cluster_operator_namespace }}"
     when: cli_cluster_operator_namespace is defined

--- a/contrib/ansible/deploy-playbook.yaml
+++ b/contrib/ansible/deploy-playbook.yaml
@@ -28,17 +28,20 @@
     # in the cert dir defined above.
     apiserver_ca_name: ca
 
+  roles:
+    - kubectl-ansible
   tasks:
   - set_fact:
       cluster_operator_namespace: "{{ cli_cluster_operator_namespace }}"
     when: cli_cluster_operator_namespace is defined
 
-  - name: create cluster-operator namespace
-    k8s_raw:
-      name: "{{ cluster_operator_namespace }}"
-      api_version: v1
-      kind: Namespace
-      state: present
+  - name: create the cluster operator namespace
+    kubectl_apply:
+      definition:
+        kind: "Namespace"
+        apiVersion: v1
+        metadata:
+          name: "{{ cluster_operator_namespace }}"
 
   - name: check if apiserver cert secret exists
     command: "oc get secret cluster-operator-apiserver-cert -n {{ cluster_operator_namespace }}"
@@ -82,8 +85,7 @@
     when: redeploy_apiserver_cert | bool
 
   - name: create apiserver cert secret
-    k8s_raw:
-      state: present
+    kubectl_apply:
       definition:
         # Secret to pass the SSL certs to the API Server
         apiVersion: v1
@@ -109,10 +111,27 @@
   - set_fact:
       l_serving_ca: "{{ (cluster_cert_secret_reg.stdout | from_json)['data']['ca.crt'] }}"
 
-  - name: deploy cluster operator service accounts, roles and bindings
-    shell: "oc process -f {{ playbook_dir }}/../examples/cluster-operator-roles-template.yaml -o yaml -p CLUSTER_OPERATOR_NAMESPACE={{ cluster_operator_namespace }} | oc apply -f -"
+  - name: process authentication template
+    oc_process:
+      template_file: "{{ playbook_dir }}/../examples/cluster-operator-roles-template.yaml"
+      parameters:
+        CLUSTER_OPERATOR_NAMESPACE: "{{ cluster_operator_namespace }}"
+    register: auth_reg
     when: deploy_roles | bool
 
-  - name: deploy application template
-    shell: "oc process -f {{ playbook_dir }}/../examples/cluster-operator-template.yaml -o yaml -p CLUSTER_OPERATOR_NAMESPACE={{ cluster_operator_namespace }} -p SERVING_CA={{ l_serving_ca }} | oc apply -f -"
+  - name: deploy authentication objects
+    kubectl_apply:
+      definition: "{{ auth_reg.result | to_json }}"
+    when: deploy_roles | bool
 
+  - name: process cluster operator application template
+    oc_process:
+      template_file: "{{ playbook_dir }}/../examples/cluster-operator-template.yaml"
+      parameters:
+        CLUSTER_OPERATOR_NAMESPACE: "{{ cluster_operator_namespace }}"
+        SERVING_CA: "{{ l_serving_ca }}"
+    register: cluster_app_reg
+
+  - name: deploy cluster operator
+    kubectl_apply:
+      definition: "{{ cluster_app_reg.result | to_json }}"


### PR DESCRIPTION
These commits switch us from using shell commands / k8s_raw to my in-progress kubectl_apply and oc_process wrapper modules. Per discussion last week we're going to use our deployment Ansible as a testbed for these and see where they go. The path back to k8s_raw once it's more production ready should be quite straightforward.

With this change Ansible 2.5 is no longer required.

The roles are vendored using another tool I wrote (gogitit), but this is only relevant to the person doing the vendoring. None the less the metadata files are available if anyone else needed to do this, and the README is updated with details on how.