### PR TITLE
set registry count to the number of infra nodes (max 2)

### DIFF
--- a/pkg/ansible/generate_test.go
+++ b/pkg/ansible/generate_test.go
@@ -66,6 +66,32 @@ func testMachineSet() *coapi.MachineSet {
 	}
 }
 
+func testClusterMachineSetBuilder(name string, nodeType coapi.NodeType, infra bool, size int,
+	cluster *coapi.Cluster) *coapi.ClusterMachineSet {
+	return &coapi.ClusterMachineSet{
+		ShortName: name,
+		MachineSetConfig: coapi.MachineSetConfig{
+			NodeType: nodeType,
+			Infra:    infra,
+			Size:     size,
+			Hardware: &coapi.MachineSetHardwareSpec{
+				AWS: &coapi.MachineSetAWSHardwareSpec{
+					InstanceType: "x9large",
+				},
+			},
+		},
+	}
+}
+
+func testClusterWithInfra() *coapi.Cluster {
+	cluster := testCluster()
+	cluster.Spec.MachineSets = []coapi.ClusterMachineSet{
+		*testClusterMachineSetBuilder("master", coapi.NodeTypeMaster, false, 3, cluster),
+		*testClusterMachineSetBuilder("infra", coapi.NodeTypeCompute, true, 2, cluster),
+	}
+	return cluster
+}
+
 func testClusterVersion() *coapi.ClusterVersion {
 	masterAMI := "master-AMI-west"
 	return &coapi.ClusterVersion{
@@ -105,7 +131,7 @@ func TestGenerateClusterVars(t *testing.T) {
 	}{
 		{
 			name:           "cluster",
-			cluster:        testCluster(),
+			cluster:        testClusterWithInfra(),
 			clusterVersion: testClusterVersion(),
 			shouldInclude: []string{
 				"openshift_aws_clusterid: testcluster",


### PR DESCRIPTION
provide the number of infra nodes when generating ansible variables so that we can do things like set the number of replicas for some components based on that size.
    
as a temporary measure, keep registy replicas hardcoded to 1 for now while we wait for a move to S3-backed storage as running more than 1 registry with non-shared storage (separate PVs in the current setup) will result in problems

update tests so that we have clusters with a machineset having infra: true