### PR TITLE
Convert to builds, image streams and deployment configs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile to perform a full cluster-operator build from source.
+#
+# This Dockerfile is intended for performing in-cluster OpenShift builds. It differs
+# from those in build/ in that it does not expect to compile the binary externally
+# and add to the container, everything is built internally during docker build.
+FROM golang:1.9
+
+ENV PATH=/go/bin:$PATH GOPATH=/go
+
+ADD . /go/src/github.com/openshift/cluster-operator
+
+WORKDIR /go/src/github.com/openshift/cluster-operator
+RUN NO_DOCKER=1 make build
+ENTRYPOINT ["bin/cluster-operator"]
+

--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,17 @@ aws-machine-controller-image: build/aws-machine-controller/Dockerfile $(BINDIR)/
 	docker tag $(AWS_MACHINE_CONTROLLER_IMAGE) $(AWS_MACHINE_CONTROLLER_MUTABLE_IMAGE)
 	docker tag $(AWS_MACHINE_CONTROLLER_IMAGE) $(AWS_MACHINE_CONTROLLER_PUBLIC_IMAGE)
 
+# Push our Docker Images to the integrated registry:
+INTEGRATED_REGISTRY                         ?= 172.30.1.1
+integrated-registry-push:
+	# WARNING: this will fail if logged in as system:admin, see README for creating an "admin" account
+	# you can use separately that will work here:
+	 $(eval OPENSHIFT_TOKEN := $(shell oc whoami -t))
+	docker login -u admin -p $(OPENSHIFT_TOKEN) $(INTEGRATED_REGISTRY):5000
+	# NOTE: the in-cluster ImageStream tag we use is latest:
+	docker tag cluster-operator:$(MUTABLE_TAG) $(INTEGRATED_REGISTRY):5000/openshift-cluster-operator/cluster-operator:latest
+	docker push $(INTEGRATED_REGISTRY):5000/openshift-cluster-operator/cluster-operator:latest
+
 
 # Push our Docker Images to a registry
 ######################################

--- a/contrib/ansible/create-cluster-playbook.yaml
+++ b/contrib/ansible/create-cluster-playbook.yaml
@@ -48,6 +48,17 @@
   - import_role:
       name: kubectl-ansible
 
+  - name: process cluster versions template
+    oc_process:
+      template_file: "{{ playbook_dir }}/../examples/cluster-versions-template.yaml"
+    parameters:
+      CLUSTER_VERSION_NS: "{{ cluster_version_namespace }}"
+    register: cluster_versions_reg
+
+  - name: create/update cluster versions
+    kubectl_apply:
+      definition: "{{ cluster_versions_reg.result | to_json }}"
+
   # If no cluster_namespace was defined on the CLI, we want to create the cluster in the current:
   - name: lookup current namespace if none defined
     command: "oc project -q"

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -20,21 +20,9 @@
   - import_role:
       name: kubectl-ansible
 
-  - name: process cluster versions template
-    oc_process:
-      template_file: "{{ playbook_dir }}/../examples/cluster-versions-template.yaml"
-    register: cluster_versions_reg
-
-  - name: wait for our apiserver and create/update cluster versions
-    kubectl_apply:
-      definition: "{{ cluster_versions_reg.result | to_json }}"
-    register: result
-    # Wait up to 2 minutes for our apiserver to be accepting our types:
-    until: result.failed == false
-    retries: 24
-    delay: 5
-
   - name: create/update playbook mock deployment
     kubectl_apply:
       namespace: "{{ cluster_operator_namespace }}"
       src: "{{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"
+
+  - debug: msg="Deployment complete, you may need to push images to the registry or start a build before the Cluster Operator will deploy. (see README.md)"

--- a/contrib/ansible/deploy-playbook.yaml
+++ b/contrib/ansible/deploy-playbook.yaml
@@ -27,6 +27,9 @@
     # This CA will be generated once and then re-used for all certs. Will be created
     # in the cert dir defined above.
     apiserver_ca_name: ca
+    # Cluster operator git repository to build:
+    cluster_operator_git_repo: "https://github.com/openshift/cluster-operator"
+    cluster_operator_git_ref: master
 
   tasks:
   - import_role:
@@ -130,6 +133,8 @@
       parameters:
         CLUSTER_OPERATOR_NAMESPACE: "{{ cluster_operator_namespace }}"
         SERVING_CA: "{{ l_serving_ca }}"
+        GIT_REPO: "{{ cluster_operator_git_repo }}"
+        GIT_REF: "{{ cluster_operator_git_ref }}"
     register: cluster_app_reg
 
   - name: deploy cluster operator

--- a/contrib/examples/cluster-operator-roles-template.yaml
+++ b/contrib/examples/cluster-operator-roles-template.yaml
@@ -53,6 +53,62 @@ objects:
     name: cluster-operator-apiserver
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
 
+# We have to create our openshift-cluster-operator namespace outside of "oc new-project"
+# due to restrictions on project names starting with "openshift-". This results in the default
+# service accounts (namely "deployer") being unable to view ReplicationControllers in the
+# namespace, and thus unable to actually deploy. A controller is incoming to monitor for this.
+#
+# NOTE: may not be required in 3.10, a controller was added to maintain these bindings.
+#
+# Until then we manually bind the deployer/builder service accounts to appropriate roles:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: "system:deployers"
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:deployer
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: deployer
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  #userNames:
+  #- system:serviceaccount:${CLUSTER_OPERATOR_NAMESPACE}:deployer
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: "system:image-builders"
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-builder
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: builder
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  #userNames:
+  #- system:serviceaccount:${CLUSTER_OPERATOR_NAMESPACE}:builder
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: "system:image-pullers"
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-puller
+  subjects:
+  - apiGroup: ""
+    kind: Group
+    name: system:serviceaccounts:${CLUSTER_OPERATOR_NAMESPACE}
+  #userNames:
+  #- system:serviceaccount:${CLUSTER_OPERATOR_NAMESPACE}:deployer
+
 # API Server gets the ability to read authentication. This allows it to
 # read the specific configmap that has the requestheader-* entries to
 # enable api aggregation
@@ -121,3 +177,14 @@ objects:
     name: cluster-operator-controller-manager
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
 
+# Create a role for the master installer to save a kubeconfig
+# from a managed cluster
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: "clusteroperator.openshift.io:master-controller"
+  rules:
+  # CRUD secrets with kubeconfig data
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:     ["create", "delete", "get", "list", "update"]

--- a/contrib/examples/cluster-operator-template.yaml
+++ b/contrib/examples/cluster-operator-template.yaml
@@ -22,7 +22,12 @@ parameters:
 # Namespace of kube-system. Do not change. Required due to oc process behavior.
 - name: KUBE_SYSTEM_NAMESPACE
   value: kube-system
-
+- name: GIT_REPO
+  description: Cluster Operator git repository the BuildConfig will use.
+  value: https://github.com/openshift/cluster-operator
+- name: GIT_REF
+  description: Cluster Operator git repository branch/tag/commit the BuildConfig will use.
+  value: master
 objects:
 - kind: PersistentVolumeClaim
   apiVersion: v1
@@ -37,9 +42,45 @@ objects:
       requests:
         storage: 1Gi
 
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: cluster-operator
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  spec: {}
+
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: cluster-operator
+    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+  spec:
+    source:
+      type: "Git"
+      git:
+        uri: ${GIT_REPO}
+        ref: ${GIT_REF}
+    strategy:
+      type: "Docker"
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: golang:1.9
+        dockerfilePath:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: cluster-operator:latest
+    triggers: []
+    nodeSelector: {}
+    successfulBuildsHistoryLimit: 3
+    failedBuildsHistoryLimit: 3
+  status:
+    lastVersion: 0
+
 # Deployment of the API Server pod
-- apiVersion: apps/v1beta1
-  kind: Deployment
+- kind: DeploymentConfig
+  apiVersion: apps.openshift.io/v1
   metadata:
     name: cluster-operator-apiserver
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
@@ -47,8 +88,23 @@ objects:
       app: cluster-operator-apiserver
   spec:
     selector:
-      matchLabels:
-        app: cluster-operator-apiserver
+      app: cluster-operator-apiserver
+    replicas: 1
+    revisionHistoryLimit: 4
+    # NOTE: can't do Rolling here yet, the new etcd container can't come up due to a lock on the snap/db
+    # in the persistent volume which is held by the running deployment.
+    strategy:
+      type: Recreate
+    triggers:
+      - type: "ConfigChange"
+      - type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "apiserver"
+          from:
+            kind: "ImageStreamTag"
+            name: "cluster-operator:latest"
     template:
       metadata:
         labels:
@@ -65,14 +121,12 @@ objects:
           - http://localhost:2379
           - -v
           - "10"
-          image: cluster-operator:canary
-          command: ["/opt/services/cluster-operator"]
+          image: cluster-operator:latest
           imagePullPolicy: Never
           name: apiserver
           ports:
           - containerPort: 6443
             protocol: TCP
-          resources: {}
           terminationMessagePath: /dev/termination-log
           volumeMounts:
           - mountPath: /var/run/openshift-cluster-operator
@@ -99,6 +153,7 @@ objects:
             successThreshold: 1
             timeoutSeconds: 2
         - name: etcd
+          # TODO: fixed tag here?
           image: quay.io/coreos/etcd:latest
           imagePullPolicy: Always
           resources:
@@ -142,7 +197,6 @@ objects:
             timeoutSeconds: 2
         dnsPolicy: ClusterFirst
         restartPolicy: Always
-        securityContext: {}
         terminationGracePeriodSeconds: 30
         volumes:
         - name: apiserver-ssl
@@ -159,8 +213,8 @@ objects:
             claimName: etcd-storage
 
 # Deployment of the Controller Manager pod
-- kind: Deployment
-  apiVersion: extensions/v1beta1
+- kind: DeploymentConfig
+  apiVersion: apps.openshift.io/v1
   metadata:
     name: cluster-operator-controller-manager
     namespace: ${CLUSTER_OPERATOR_NAMESPACE}
@@ -168,8 +222,19 @@ objects:
       app: cluster-operator-controller-manager
   spec:
     selector:
-      matchLabels:
-        app: cluster-operator-controller-manager
+      app: cluster-operator-controller-manager
+    triggers:
+      - type: "ConfigChange"
+      - type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "controller-manager"
+          from:
+            kind: "ImageStreamTag"
+            name: "cluster-operator:latest"
+    replicas: 1
+    revisionHistoryLimit: 4
     template:
       metadata:
         labels:
@@ -178,7 +243,7 @@ objects:
         serviceAccountName: cluster-operator-controller-manager
         containers:
         - name: controller-manager
-          image: cluster-operator:canary
+          image: cluster-operator:latest
           imagePullPolicy: Never
           resources:
             requests:
@@ -258,15 +323,3 @@ objects:
     caBundle: ${SERVING_CA}
     groupPriorityMinimum: 10000
     versionPriority: 20
-
-# Create a role for the master installer to save a kubeconfig
-# from a managed cluster
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: "clusteroperator.openshift.io:master-controller"
-  rules:
-  # CRUD secrets with kubeconfig data
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs:     ["create", "delete", "get", "list", "update"]


### PR DESCRIPTION
Deploying will now create a BuildConfig, ImageStream, and
DeploymentConfig. However until you push images there's nothing for the
DeploymentConfig to run.

You can push images in two ways, either start-build to build the latest
git master, or a make target to push your locally built images.
(development)


May want to actually test this one.