### PR TITLE
Fixes to cluster-api deployment and export

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
@@ -253,8 +253,6 @@ objects:
           imagePullPolicy: ${IMAGE_PULL_POLICY}
           command:
           - "./controller-manager"
-          args:
-          - --cloud=aws
           resources:
             requests:
               cpu: 100m

--- a/contrib/cmd/cluster-api-export/export.go
+++ b/contrib/cmd/cluster-api-export/export.go
@@ -94,6 +94,9 @@ func exportCluster(clusterName string, out io.Writer) error {
 	capiCluster.Spec.ProviderConfig.Value = &runtime.RawExtension{
 		Raw: []byte(serializeCOResource(cluster)),
 	}
+	capiCluster.Spec.ClusterNetwork.ServiceDomain = "cluster-api.k8s.io"
+	capiCluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"10.10.0.0/16"}
+	capiCluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"172.30.0.0/16"}
 	result.Items = append(result.Items, runtime.RawExtension{
 		Raw: []byte(serializeClusterAPIResource(capiCluster)),
 	})


### PR DESCRIPTION
In the latest version of cluster API, the controller manager no longer takes a --cloud flag, and some fields in Spec.ClusterNetwork are now required.