### PR TITLE
AWS actuator: remove finalizer on successful delete

### DIFF
--- a/contrib/cmd/aws-actuator-test/main.go
+++ b/contrib/cmd/aws-actuator-test/main.go
@@ -68,7 +68,7 @@ func deleteClusterMachine(instanceId string) error {
 		instanceIDAnnotation: instanceId,
 	}
 	actuator := aws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
-	err := actuator.Delete(machine)
+	err := actuator.DeleteMachine(machine)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On successful AWS instance delete, updates the machine resource to remove the finalizer. This allows the machine resource to go away.

Follows pattern in upstream GCP actuator:
https://github.com/kubernetes-sigs/cluster-api/blob/029f15be7c227663cdd99f80ec4bca499b66ae57/cloud/google/machineactuator.go#L387-L388