### PR TITLE
Parameterize AWS SSH keypair name

### DIFF
--- a/contrib/ansible/create-cluster-playbook.yml
+++ b/contrib/ansible/create-cluster-playbook.yml
@@ -32,6 +32,9 @@
     # SSH key used for access to all VMs CO creates:
     ssh_priv_key: '~/.ssh/libra.pem'
 
+    # AWS keypair name to use for cluster machines
+    aws_ssh_keypair: "libra"
+
     # Force regeneration of cluster cert. Will happen regardless if one does not exist.
     redeploy_cluster_cert: False
 
@@ -139,6 +142,7 @@
         AWS_ACCESS_KEY_ID: "{{ l_aws_access_key_id }}"
         AWS_SECRET_ACCESS_KEY: "{{ l_aws_secret_access_key }}"
         SSH_KEY: "{{ l_aws_ssh_private_key }}"
+        SSH_KEYPAIR_NAME: "{{ aws_ssh_keypair }}"
     register: cluster_reg
 
   - name: create/update cluster

--- a/contrib/examples/cluster-template.yaml
+++ b/contrib/examples/cluster-template.yaml
@@ -36,6 +36,10 @@ parameters:
 - name: SSH_KEY
   required: true
   description: Base64 encoded SSH private key that can be used to access the provisioned servers.
+- name: SSH_KEYPAIR_NAME
+  required: true
+  value: libra
+  description: Name of AWS keypair to use for machines in this cluster.
 
 objects:
 
@@ -91,7 +95,7 @@ objects:
         sslSecret:
           name: ${CLUSTER_NAME}-certs
         region: "us-east-1"
-        keyPairName: "libra"
+        keyPairName: ${SSH_KEYPAIR_NAME}
     defaultHardwareSpec:
       aws:
         instanceType: "t2.xlarge"


### PR DESCRIPTION
This is needed to use an alternate keypair for CI