### PR TITLE
Register cluster api types

### DIFF
--- a/contrib/examples/cluster-operator-template.yaml
+++ b/contrib/examples/cluster-operator-template.yaml
@@ -323,3 +323,19 @@ objects:
     caBundle: ${SERVING_CA}
     groupPriorityMinimum: 10000
     versionPriority: 20
+
+# Registration of the cluster-api API with the aggregator
+- apiVersion: apiregistration.k8s.io/v1beta1
+  kind: APIService
+  metadata:
+    name: v1alpha1.cluster.k8s.io
+    namespace: ${KUBE_SYSTEM_NAMESPACE}
+  spec:
+    group: cluster.k8s.io
+    version: v1alpha1
+    service:
+      namespace: ${CLUSTER_OPERATOR_NAMESPACE}
+      name: cluster-operator-apiserver
+    caBundle: ${SERVING_CA}
+    groupPriorityMinimum: 10000
+    versionPriority: 20

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -17,30 +17,32 @@ limitations under the License.
 package api
 
 import (
-	"k8s.io/apimachinery/pkg/apimachinery/announced"
-	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/install"
+	co_install "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/install"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
+	ca_install "sigs.k8s.io/cluster-api/pkg/apis/cluster/install"
 )
 
 var (
-	groupFactoryRegistry = make(announced.APIGroupFactoryRegistry)
+	groupFactoryRegistry = builders.GroupFactoryRegistry
 	// Registry is an instance of an API registry.
-	Registry = registered.NewOrDie("")
+	Registry = builders.Registry
 	// Scheme for API object types
-	Scheme = runtime.NewScheme()
+	Scheme = builders.Scheme
 	// ParameterCodec handles versioning of objects that are converted to query parameters.
 	ParameterCodec = runtime.NewParameterCodec(Scheme)
 	// Codecs for creating a server config
-	Codecs = serializer.NewCodecFactory(Scheme)
+	Codecs = builders.Codecs
 )
 
 func init() {
-	install.Install(groupFactoryRegistry, Registry, Scheme)
+	co_install.Install(groupFactoryRegistry, Registry, Scheme)
+
+	ca_install.Install(groupFactoryRegistry, Registry, Scheme)
 
 	// we need to add the options to empty v1
 	// TODO fix the server code to avoid this

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -20,6 +20,7 @@ import (
 	cov1alpha1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	cav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // ClusterOperatorAPIServer contains the base GenericAPIServer along with other
@@ -38,6 +39,7 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 	ret := serverstorage.NewResourceConfig()
 	ret.EnableVersions(
 		cov1alpha1.SchemeGroupVersion,
+		cav1alpha1.SchemeGroupVersion,
 	)
 
 	return ret


### PR DESCRIPTION
Include both the original cluster-operator resources and the upstream cluster-api resources in the API server.