### PR TITLE
Add check that controller-manager can use to verify that cluster-api resources are available

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -452,7 +452,7 @@ func StartControllers(ctx ControllerContext, controllers map[string]InitFunc) er
 }
 
 func startClusterController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go cluster.NewController(
@@ -466,7 +466,7 @@ func startClusterController(ctx ControllerContext) (bool, error) {
 }
 
 func startInfraController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go infra.NewController(
@@ -479,7 +479,7 @@ func startInfraController(ctx ControllerContext) (bool, error) {
 }
 
 func startMachineSetController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go machineset.NewController(
@@ -493,7 +493,7 @@ func startMachineSetController(ctx ControllerContext) (bool, error) {
 }
 
 func startMachineController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go machine.NewController(
@@ -505,7 +505,7 @@ func startMachineController(ctx ControllerContext) (bool, error) {
 }
 
 func startMasterController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go master.NewController(
@@ -518,7 +518,7 @@ func startMasterController(ctx ControllerContext) (bool, error) {
 }
 
 func startAcceptController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go accept.NewController(
@@ -531,7 +531,7 @@ func startAcceptController(ctx ControllerContext) (bool, error) {
 }
 
 func startComponentsController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go components.NewController(
@@ -544,7 +544,7 @@ func startComponentsController(ctx ControllerContext) (bool, error) {
 }
 
 func startNodeConfigController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go nodeconfig.NewController(
@@ -557,7 +557,7 @@ func startNodeConfigController(ctx ControllerContext) (bool, error) {
 }
 
 func startDeployClusterAPIController(ctx ControllerContext) (bool, error) {
-	if !resourcesAvailable(ctx) {
+	if !clusterOperatorResourcesAvailable(ctx) {
 		return false, nil
 	}
 	go deployclusterapi.NewController(
@@ -569,14 +569,23 @@ func startDeployClusterAPIController(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func resourcesAvailable(ctx ControllerContext) bool {
-	gvrs := []schema.GroupVersionResource{
-		{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "clusters"},
-		{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machinesets"},
-	}
+func clusterOperatorResourcesAvailable(ctx ControllerContext) bool {
+	return resourcesAvailable(ctx,
+		schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "clusters"},
+		schema.GroupVersionResource{Group: "clusteroperator.openshift.io", Version: "v1alpha1", Resource: "machinesets"},
+	)
+}
 
-	for _, gvr := range gvrs {
-		if !ctx.AvailableResources[gvr] {
+func clusterAPIResourcesAvailable(ctx ControllerContext) bool {
+	return resourcesAvailable(ctx,
+		schema.GroupVersionResource{Group: "cluster.k8s.io", Version: "v1alpha1", Resource: "clusters"},
+		schema.GroupVersionResource{Group: "cluster.k8s.io", Version: "v1alpha1", Resource: "machinesets"},
+	)
+}
+
+func resourcesAvailable(ctx ControllerContext, resources ...schema.GroupVersionResource) bool {
+	for _, resource := range resources {
+		if !ctx.AvailableResources[resource] {
 			return false
 		}
 	}


### PR DESCRIPTION
This will be used by controller-manager when deciding whether to start the new cluster-api controllers that will be added.