### PR TITLE
Fix infinitely stalled devel deployment.

### DIFF
--- a/contrib/ansible/create-cluster-playbook.yml
+++ b/contrib/ansible/create-cluster-playbook.yml
@@ -51,17 +51,6 @@
   - import_role:
       name: kubectl-ansible
 
-  - name: process cluster versions template
-    oc_process:
-      template_file: "{{ playbook_dir }}/../examples/cluster-versions-template.yaml"
-    parameters:
-      CLUSTER_VERSION_NS: "{{ cluster_version_namespace }}"
-    register: cluster_versions_reg
-
-  - name: create/update cluster versions
-    kubectl_apply:
-      definition: "{{ cluster_versions_reg.result | to_json }}"
-
   # If no cluster_namespace was defined on the CLI, we want to create the cluster in the current:
   - name: lookup current namespace if none defined
     command: "oc project -q"

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -58,4 +58,18 @@
   - name: create/update cluster versions
     kubectl_apply:
       definition: "{{ cluster_versions_reg.result | to_json }}"
+    # Even with waiting for the apiserver deployment, there are still a few seconds before the apiserver responds:
+    retries: 5
+    delay: 5
+    register: create_versions_result
+    until: create_versions_result is succeeded
+    ignore_errors: yes
+
+  - debug: var=create_versions_result
+    when: not create_versions_result is succeeded
+
+  - name: report error if unable to create cluster versions
+    fail:
+      msg: 'Unable to create cluster versions'
+    when: not create_versions_result is succeeded
 

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -15,7 +15,23 @@
   vars:
     # Namespace to deploy CO to:
     cluster_operator_namespace: "openshift-cluster-operator"
+
+    # Normally we assume to build and push images for devel deployments:
+    push_images: True
   tasks:
+
+  - name: build images off latest source
+    command: make images
+    args:
+      chdir: "{{ playbook_dir }}/../../"
+    when: push_images | bool
+
+  - name: push devel images to integrated registry
+    command: make integrated-registry-push
+    args:
+      chdir: "{{ playbook_dir }}/../../"
+    when: push_images | bool
+
   - name: wait for apiserver deployment to finish
     command: |-
       oc rollout status deploymentconfig/cluster-operator-apiserver -n {{ cluster_operator_namespace | quote }}
@@ -32,4 +48,14 @@
       namespace: "{{ cluster_operator_namespace }}"
       src: "{{ playbook_dir }}/../examples/deploy-playbook-mock.yaml"
 
-  - debug: msg="Deployment complete, you may need to push images to the registry or start a build before the Cluster Operator will deploy. (see README.md)"
+  - name: process cluster versions template
+    oc_process:
+      template_file: "{{ playbook_dir }}/../examples/cluster-versions-template.yaml"
+    parameters:
+      CLUSTER_VERSION_NS: "{{ cluster_version_namespace }}"
+    register: cluster_versions_reg
+
+  - name: create/update cluster versions
+    kubectl_apply:
+      definition: "{{ cluster_versions_reg.result | to_json }}"
+


### PR DESCRIPTION
Due to the order in which things merged, master currently will stall on
a devel deployment waiting for it to complete, when we expect you to
make a decision on how to get images. (make push-integrated registry, or
oc start-build)

With this change devel deployments now assume to run make images, and
make integrated-registry-push, then wait for the deployment to roll out.
You no longer need to choose a deployment method.

This makes a devel deployment playbook run much slower, but this should
not be part of normal workflow, typically you just run make images push
yourself, or run your controller externally when working.

With this change creation of the default cluster versions can move back
to it's more logical location.