### PR TITLE
Add utility to extract e2e test container logs

### DIFF
--- a/contrib/cmd/extract-co-jenkins-logs/main.go
+++ b/contrib/cmd/extract-co-jenkins-logs/main.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/openshift/cluster-operator/contrib/cmd/extract-co-jenkins-logs/util"
+)
+
+// Given a Jenkins URL, extracts logs of relevant containers to current or specified
+// directory
+
+// NewExtractLogsCommand returns a command that will extract logs
+func NewExtractLogsCommand(outputDir, containersLog, dockerInfoLog string) *cobra.Command {
+	return &cobra.Command{
+		Use: "extract-co-jenkins-logs JENKINS_BUILD_URL",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 && (len(containersLog) == 0 || len(dockerInfoLog) == 0) {
+				cmd.Usage()
+				return
+			}
+			var jenkinsURL string
+			if len(args) > 0 {
+				jenkinsURL = args[0]
+			}
+			err := extractLogs(jenkinsURL, outputDir, containersLog, dockerInfoLog)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+}
+
+func main() {
+	log.SetOutput(os.Stdout)
+	var logLevel,
+		outputDir,
+		containersLog,
+		dockerInfoLog string
+
+	pflag.CommandLine.StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warning, error, fatal, panic")
+	pflag.CommandLine.StringVar(&outputDir, "output-dir", "", "Output directory")
+	pflag.CommandLine.StringVar(&containersLog, "containers-log", "", "File containing containers log")
+	pflag.CommandLine.StringVar(&dockerInfoLog, "docker-info", "", "File containing docker.info")
+
+	pflag.Parse()
+	level, err := log.ParseLevel(logLevel)
+	if err == nil {
+		log.SetLevel(level)
+	} else {
+		log.Warningf("Invalid log level: %s. Defaulting to 'info'.\n", logLevel)
+	}
+	cmd := NewExtractLogsCommand(outputDir, containersLog, dockerInfoLog)
+	cmd.Execute()
+}
+
+func extractLogs(jobURLString, outputDir, containersLog, dockerInfo string) error {
+	// Download containers.log and docker.info artifacts
+	var err error
+	if len(containersLog) == 0 {
+		containersLog, err = util.DownloadFile(jobURLString, "s3/download/generated/containers.log")
+		if err != nil {
+			return err
+		}
+	}
+	if len(dockerInfo) == 0 {
+		dockerInfo, err = util.DownloadFile(jobURLString, "s3/download/generated/docker.info")
+		if err != nil {
+			return err
+		}
+	}
+
+	containers, err := util.ParseDockerInfo(dockerInfo)
+	if err != nil {
+		return err
+	}
+
+	if len(outputDir) == 0 {
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		ts := time.Now().Format("01-02-2006_15-04-05")
+		outputDir = filepath.Join(wd, fmt.Sprintf("logs-%s", ts))
+		if err = os.MkdirAll(outputDir, 0777); err != nil {
+			return err
+		}
+	}
+
+	err = util.ExtractContainerLogs(containers, containersLog, outputDir)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Logs extracted to %s", outputDir)
+	return nil
+}

--- a/contrib/cmd/extract-co-jenkins-logs/util/dockerinfo.go
+++ b/contrib/cmd/extract-co-jenkins-logs/util/dockerinfo.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func ParseDockerInfo(fileName string) (map[string]string, error) {
+	log.Debugf("Parsing docker.info file %s", fileName)
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	result := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	inContainers := false
+	var nameIndex int
+	for scanner.Scan() {
+		line := scanner.Text()
+		if isContainersHeader(line) {
+			nameIndex = getNameColumnIndex(line)
+			inContainers = true
+			continue
+		}
+		if inContainers {
+			id, name := parseContainerLine(nameIndex, line)
+			if len(id) > 0 {
+				log.Debugf("Adding container id %s: %s", id, name)
+				result[id] = name
+			}
+		}
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func isContainersHeader(str string) bool {
+	return strings.HasPrefix(str, "CONTAINER ID")
+}
+
+func getNameColumnIndex(str string) int {
+	return strings.Index(str, "NAMES")
+}
+
+func parseContainerLine(nameIndex int, line string) (string, string) {
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	id := parts[0]
+	name := line[nameIndex:]
+	return id, name
+}

--- a/contrib/cmd/extract-co-jenkins-logs/util/download.go
+++ b/contrib/cmd/extract-co-jenkins-logs/util/download.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func joinURL(base, suffix string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	u.Path = path.Join(u.Path, suffix)
+	return u.String(), nil
+}
+
+func downloadURL(urlString string, out io.Writer) error {
+	log.Debugf("downloading %s\n", urlString)
+	resp, err := http.Get(urlString)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("error downloading %s: %s", urlString, resp.Status)
+	}
+	defer resp.Body.Close()
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+func DownloadFile(base, suffix string) (string, error) {
+	u, err := joinURL(base, suffix)
+	if err != nil {
+		return "", err
+	}
+
+	tmp, err := ioutil.TempFile("", "co-logs-")
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+	log.Debugf("Created temp file %s", tmp.Name())
+
+	err = downloadURL(u, tmp)
+	if err != nil {
+		return "", err
+	}
+
+	return tmp.Name(), nil
+}

--- a/contrib/cmd/extract-co-jenkins-logs/util/extractlogs.go
+++ b/contrib/cmd/extract-co-jenkins-logs/util/extractlogs.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func ExtractContainerLogs(containers map[string]string, logFilename, outputDir string) error {
+	log.Debugf("Extracting container logs from %s. Output directory: %s\n", logFilename, outputDir)
+	file, err := os.Open(logFilename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	inFile := false
+	var currentFile io.WriteCloser
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "==>"):
+			if inFile {
+				currentFile.Close()
+				currentFile = nil
+			}
+			fileName := parseFileLine(line, containers)
+			if len(fileName) > 0 {
+				currentFile, err = os.Create(filepath.Join(outputDir, fileName))
+				if err != nil {
+					return err
+				}
+				inFile = true
+			}
+		case len(line) == 0:
+			if inFile {
+				currentFile.Close()
+				currentFile = nil
+				inFile = false
+			}
+		default:
+			if inFile {
+				logLine := parseLogLine(line)
+				if len(logLine) > 0 {
+					fmt.Fprintf(currentFile, "%s", logLine)
+				}
+			}
+		}
+	}
+	if currentFile != nil {
+		currentFile.Close()
+	}
+	if err = scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+var containerIdRE = regexp.MustCompile("\\/containers\\/([^/]+)\\/")
+
+func parseFileLine(line string, containers map[string]string) string {
+	parts := containerIdRE.FindStringSubmatch(line)
+	if len(parts) < 2 {
+		return ""
+	}
+	containerId := parts[1][:12]
+	log.Debugf("Found start of container log for container id: %s", containerId)
+	containerName, ok := containers[containerId]
+	if !ok {
+		log.Debugf("Did not find container id %s in containers map", containerId)
+		return ""
+	}
+	// split the containerName in its parts
+	parts = strings.Split(containerName, "_")
+	// skip non-k8s containers
+	if parts[0] != "k8s" {
+		log.Debugf("Skipping container %s because it's not run by Kubernetes", containerName)
+		return ""
+	}
+	// skip pause containers
+	if parts[1] == "POD" {
+		log.Debugf("Skipping container %s because it's a pause pod", containerName)
+		return ""
+	}
+	container := parts[1]
+	pod := parts[2]
+	namespace := parts[3]
+
+	log.Debugf("Found container with ns: %s, pod: %s, container: %s", namespace, pod, container)
+
+	return fmt.Sprintf("%s_%s_%s.log", namespace, pod, container)
+}
+
+type LogLine struct {
+	Log string `json:"log"`
+}
+
+func parseLogLine(line string) string {
+	logLine := LogLine{}
+	json.Unmarshal([]byte(line), &logLine)
+	return logLine.Log
+}


### PR DESCRIPTION
Adds command that will extract container logs from a given Jenkins job. It will create a separate file for each container log either in the current directory or a directory specified by `--output-dir`