### PR TITLE
Start cluster-api informers in controller-manager

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -154,6 +154,7 @@ func Run(s *options.CMServer) error {
 		}
 
 		ctx.InformerFactory.Start(ctx.Stop)
+		ctx.ClusterAPIInformerFactory.Start(ctx.Stop)
 		ctx.KubeInformerFactory.Start(ctx.Stop)
 		close(ctx.InformersStarted)
 

--- a/contrib/examples/cluster-operator-roles-template.yaml
+++ b/contrib/examples/cluster-operator-roles-template.yaml
@@ -150,6 +150,10 @@ objects:
   - apiGroups: ["clusteroperator.openshift.io"]
     resources: ["*"]
     verbs:     ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # allow all operations on all resources in the cluster-api API group
+  - apiGroups: ["cluster.k8s.io"]
+    resources: ["*"]
+    verbs:     ["create", "get", "list", "watch", "update", "patch", "delete"]
   # allow operations on required resources in any namespace a cluster is created
   - apiGroups:     [""]
     resources:     ["configmaps", "pods", "secrets", "serviceaccounts"]


### PR DESCRIPTION
* Start the shared informers for the cluster-api in controller-manager.
* Give controller-manager user full permissions to the cluster-api resources.