### PR TITLE
Deploy AWS actuator from source in root CO cluster.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ define build-and-tag # (service, image, mutable_image, prefix)
 	$(eval build_path := "$(4)build/$(1)")
 	$(eval tmp_build_path := "$(build_path)/tmp")
 	mkdir -p $(tmp_build_path)
-	cp $(BINDIR)/$(1) $(tmp_build_path)
+	cp -r $(BINDIR)/* $(tmp_build_path)
 	cp $(build_path)/Dockerfile $(tmp_build_path)
 	# -i.bak is required for cross-platform compat: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
 	sed -i.bak "s|BASEIMAGE|$(BASEIMAGE)|g" $(tmp_build_path)/Dockerfile

--- a/build/cluster-operator/Dockerfile
+++ b/build/cluster-operator/Dockerfile
@@ -20,5 +20,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/*
 
 ADD cluster-operator opt/services/
+ADD aws-machine-controller opt/services/
 
 ENTRYPOINT ["/opt/services/cluster-operator"]

--- a/contrib/examples/cluster-api-controllers-template.yaml
+++ b/contrib/examples/cluster-api-controllers-template.yaml
@@ -10,8 +10,8 @@ objects:
     name: cluster-api-controller-manager
     namespace: ${CLUSTER_API_NAMESPACE}
 
-- apiVersion: apps/v1beta1
-  kind: Deployment
+- kind: DeploymentConfig
+  apiVersion: apps.openshift.io/v1
   metadata:
     name: aws-machine-controller
     namespace: ${CLUSTER_API_NAMESPACE}
@@ -19,9 +19,20 @@ objects:
       app: aws-machine-controller
   spec:
     selector:
-      matchLabels:
-        app: aws-machine-controller
+      app: aws-machine-controller
+    triggers:
+      - type: "ConfigChange"
+      - type: "ImageChange"
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - "machine-controller"
+          from:
+            # Uses the same ImageStream as our main controllers:
+            kind: "ImageStreamTag"
+            name: "cluster-operator:latest"
     replicas: 1
+    revisionHistoryLimit: 4
     template:
       metadata:
         labels:
@@ -30,8 +41,10 @@ objects:
         serviceAccountName: cluster-api-controller-manager
         containers:
         - name: machine-controller
-          image: ${MACHINE_CONTROLLER_IMAGE}
-          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          image: cluster-operator:latest
+          imagePullPolicy: Never
+          command:
+          - /opt/services/aws-machine-controller
           args:
           - --log-level=debug
           - --default-availability-zone=${DEFAULT_AVAILABILITY_ZONE}
@@ -54,6 +67,7 @@ objects:
         - name: bootstrap-kubeconfig
           secret:
             secretName: bootstrap-kubeconfig
+
 - apiVersion: apps/v1beta1
   kind: Deployment
   metadata:
@@ -106,8 +120,6 @@ parameters:
 - name: CLUSTER_API_IMAGE
   value: quay.io/openshift/kubernetes-cluster-api:latest
 # machine controller image
-- name: MACHINE_CONTROLLER_IMAGE
-  value: quay.io/csrwng/aws-machine-controller:latest
 - name: DEFAULT_AVAILABILITY_ZONE
   value: us-east-1c
 # pull policy (for testing)


### PR DESCRIPTION
Previously was using an image from quay.io, meaning we couldn't make
local changes and run them in the root cluster. Now bundles the actuator
with our main cluster operator image, and uses the same ImageStream our
other deployment configs use.