### PR TITLE
Provide a means for adding custom validation

### DIFF
--- a/pkg/apis/clusterapi/validation/machine.go
+++ b/pkg/apis/clusterapi/validation/machine.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/golang/glog"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster"
+)
+
+// MachineStrategy is the strategy that the API server will use for Machine
+// resources.
+type MachineStrategy struct {
+	builders.StorageBuilder
+}
+
+// Validate checks that an instance of Machine is well formed
+func (m MachineStrategy) Validate(ctx request.Context, obj runtime.Object) field.ErrorList {
+	errors := field.ErrorList{}
+	errors = append(errors, m.StorageBuilder.Validate(ctx, obj)...)
+	machine := obj.(*cluster.Machine)
+	glog.Infof("Custom validation of Machine %s", machine.Name)
+	return errors
+}
+
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (m MachineStrategy) PrepareForCreate(ctx request.Context, obj runtime.Object) {
+	m.StorageBuilder.PrepareForCreate(ctx, obj)
+}
+
+// ReplaceMachineStorageBuilder replaces the storage builder used upstream for
+// Machine resources with a custom MachineStrategy builder.
+func ReplaceMachineStorageBuilder(storageBuilder builders.StorageBuilder) builders.StorageBuilder {
+	return &MachineStrategy{storageBuilder}
+}

--- a/pkg/apis/clusterapi/validation/validation.go
+++ b/pkg/apis/clusterapi/validation/validation.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
+	cav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// ReplaceStorageBuilder replaces the storage builder in the API group builder
+// for the specified resource builder.
+func ReplaceStorageBuilder(
+	apiGroupBuilder *builders.APIGroupBuilder,
+	builder builders.UnversionedResourceBuilder,
+	replaceBuilder func(builders.StorageBuilder) builders.StorageBuilder,
+) {
+	for _, version := range apiGroupBuilder.Versions {
+		if version.GroupVersion != cav1alpha1.SchemeGroupVersion {
+			continue
+		}
+		for _, kind := range version.Kinds {
+			if kind.Unversioned != builder {
+				continue
+			}
+			kind.StorageBuilder = replaceBuilder(kind.StorageBuilder)
+		}
+	}
+}

--- a/pkg/apiserver/etcd_config.go
+++ b/pkg/apiserver/etcd_config.go
@@ -24,7 +24,9 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/storage"
 
+	"github.com/openshift/cluster-operator/pkg/apis/clusterapi/validation"
 	ca_apis "sigs.k8s.io/cluster-api/pkg/apis"
+	ca "sigs.k8s.io/cluster-api/pkg/apis/cluster"
 )
 
 // EtcdConfig contains a generic API server Config along with config specific to
@@ -115,7 +117,9 @@ func (c completedEtcdConfig) NewServer(stopCh <-chan struct{}) (*ClusterOperator
 		groupInfos = append(groupInfos, groupInfo)
 	}
 
-	caGroupInfo := ca_apis.GetClusterAPIBuilder().Build(roFactory)
+	caAPIBuilder := ca_apis.GetClusterAPIBuilder()
+	validation.ReplaceStorageBuilder(caAPIBuilder, ca.InternalMachine, validation.ReplaceMachineStorageBuilder)
+	caGroupInfo := caAPIBuilder.Build(roFactory)
 	if caGroupInfo != nil {
 		groupInfos = append(groupInfos, caGroupInfo)
 	} else {


### PR DESCRIPTION
This is not super clean as supplementing the validation is not something that the apiserver-builder is designed to support. Nevertheless, it works without too much trouble.

* Adds sample validation to Machine that can be removed once some real validation of any of the cluster-api resources has been added.