### PR TITLE
document need for python2-libselinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
     * `sudo systemctl start docker`
   * Install the OpenShift and Kubernetes Python clients:
     * `sudo pip install kubernetes openshift`
+  * Install python SELinux libraries
+    * `dnf install python2-libselinux`
   * Clone this repo to `$HOME/go/src/github.com/openshift/cluster-operator`
   * Get cfssl:
     * `go get -u github.com/cloudflare/cfssl/cmd/...`


### PR DESCRIPTION
noticed it was needed while setting up a new machine to run cluster-operator locally