### PR TITLE
Use AWS credentials for actuator EC2 client when defined.

### DIFF
--- a/pkg/controller/clusterapimachine/machine_controller.go
+++ b/pkg/controller/clusterapimachine/machine_controller.go
@@ -337,7 +337,7 @@ func (c *Controller) syncMachine(key string) error {
 	}
 
 	if !apiequality.Semantic.DeepEqual(machine, newMachine) {
-		_, err = c.capiClient.ClusterV1alpha1().Machines(cluster.Namespace).Update(machine)
+		_, err = c.capiClient.ClusterV1alpha1().Machines(cluster.Namespace).Update(newMachine)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -465,7 +465,7 @@ func PopulateMachineSpec(machineSpec *clusterapi.MachineSpec, clusterSpec *clust
 			return err
 		}
 		msSpec.VMImage = *vmImage
-		mLog.Debugf("machine spec VMImage set to: %s", *vmImage)
+		mLog.Debugf("machine spec VMImage set to: %s", *vmImage.AWSImage)
 	}
 
 	// use cluster defaults for hardware spec if unset:
@@ -474,11 +474,10 @@ func PopulateMachineSpec(machineSpec *clusterapi.MachineSpec, clusterSpec *clust
 		return err
 	}
 	msSpec.Hardware = hwSpec
-	mLog.Debugf("machine spec hardware set to: %v", msSpec.Hardware.AWS)
 
 	// Copy cluster hardware onto the provider config as well. Needed when deleting a cluster in the actuator.
 	if (msSpec.ClusterHardware == clusteroperator.ClusterHardwareSpec{}) {
-		mLog.Debugf("cluster hardware not set, copying: %v", clusterSpec.Hardware)
+		mLog.Debugf("cluster hardware not set, copying")
 		msSpec.ClusterHardware = clusterSpec.Hardware
 	}
 


### PR DESCRIPTION
With this change the control plane masters will now be created for a new
cluster API. Their machineset will need to manually be deleted for time
being.

Fixes an error in logs where we were double deleting the finalizer now
that upstream implemented it as well.