### PR TITLE
Cluster API cluster controller

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/options/options.go
+++ b/cmd/cluster-operator-controller-manager/app/options/options.go
@@ -58,26 +58,27 @@ const (
 func NewCMServer() *CMServer {
 	s := CMServer{
 		ControllerManagerConfiguration: componentconfig.ControllerManagerConfiguration{
-			Controllers:                     []string{"*"},
-			Address:                         defaultBindAddress,
-			Port:                            defaultPort,
-			ContentType:                     defaultContentType,
-			K8sKubeconfigPath:               defaultK8sKubeconfigPath,
-			ClusterOperatorKubeconfigPath:   defaultClusterOperatorKubeconfigPath,
-			MinResyncPeriod:                 metav1.Duration{Duration: 12 * time.Hour},
-			ConcurrentClusterSyncs:          defaultConcurrentSyncs,
-			ConcurrentMachineSetSyncs:       defaultConcurrentSyncs,
-			ConcurrentMachineSyncs:          defaultConcurrentSyncs,
-			ConcurrentMasterSyncs:           defaultConcurrentSyncs,
-			ConcurrentAcceptSyncs:           defaultConcurrentSyncs,
-			ConcurrentComponentSyncs:        defaultConcurrentSyncs,
-			ConcurrentNodeConfigSyncs:       defaultConcurrentSyncs,
-			ConcurrentDeployClusterAPISyncs: defaultConcurrentSyncs,
-			LeaderElection:                  leaderelectionconfig.DefaultLeaderElectionConfiguration(),
-			LeaderElectionNamespace:         defaultLeaderElectionNamespace,
-			ControllerStartInterval:         metav1.Duration{Duration: 0 * time.Second},
-			EnableProfiling:                 true,
-			EnableContentionProfiling:       false,
+			Controllers:                      []string{"*"},
+			Address:                          defaultBindAddress,
+			Port:                             defaultPort,
+			ContentType:                      defaultContentType,
+			K8sKubeconfigPath:                defaultK8sKubeconfigPath,
+			ClusterOperatorKubeconfigPath:    defaultClusterOperatorKubeconfigPath,
+			MinResyncPeriod:                  metav1.Duration{Duration: 12 * time.Hour},
+			ConcurrentClusterSyncs:           defaultConcurrentSyncs,
+			ConcurrentClusterAPIClusterSyncs: defaultConcurrentSyncs,
+			ConcurrentMachineSetSyncs:        defaultConcurrentSyncs,
+			ConcurrentMachineSyncs:           defaultConcurrentSyncs,
+			ConcurrentMasterSyncs:            defaultConcurrentSyncs,
+			ConcurrentAcceptSyncs:            defaultConcurrentSyncs,
+			ConcurrentComponentSyncs:         defaultConcurrentSyncs,
+			ConcurrentNodeConfigSyncs:        defaultConcurrentSyncs,
+			ConcurrentDeployClusterAPISyncs:  defaultConcurrentSyncs,
+			LeaderElection:                   leaderelectionconfig.DefaultLeaderElectionConfiguration(),
+			LeaderElectionNamespace:          defaultLeaderElectionNamespace,
+			ControllerStartInterval:          metav1.Duration{Duration: 0 * time.Second},
+			EnableProfiling:                  true,
+			EnableContentionProfiling:        false,
 		},
 	}
 	s.LeaderElection.LeaderElect = true
@@ -101,6 +102,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.BoolVar(&s.ClusterOperatorInsecureSkipVerify, "clusteroperator-insecure-skip-verify", s.ClusterOperatorInsecureSkipVerify, "Skip verification of the TLS certificate for the clusteroperator API server")
 	fs.DurationVar(&s.MinResyncPeriod.Duration, "min-resync-period", s.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod")
 	fs.Int32Var(&s.ConcurrentClusterSyncs, "concurrent-cluster-syncs", s.ConcurrentClusterSyncs, "The number of cluster objects that are allowed to sync concurrently. Larger number = more responsive clusters, but more CPU (and network) load")
+	fs.Int32Var(&s.ConcurrentClusterAPIClusterSyncs, "concurrent-clusterapi-cluster-syncs", s.ConcurrentClusterAPIClusterSyncs, "The number of cluster API cluster objects that are allowed to sync concurrently. Larger number = more responsive clusters, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentMachineSetSyncs, "concurrent-machine-set-syncs", s.ConcurrentMachineSetSyncs, "The number of machine set objects that are allowed to sync concurrently. Larger number = more responsive machine sets, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentMachineSyncs, "concurrent-machine-syncs", s.ConcurrentMachineSyncs, "The number of machine objects that are allowed to sync concurrently. Larger number = more responsive machines, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentMasterSyncs, "concurrent-master-syncs", s.ConcurrentMasterSyncs, "The number of master machine objects that are allowed to sync concurrently. Larger number = more responsive master machines, but more CPU (and network) load")

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -79,6 +79,11 @@ type ControllerManagerConfiguration struct {
 	// but more CPU (and network) load.
 	ConcurrentClusterSyncs int32
 
+	// concurrentClusterAPIClusterSyncs is the number of cluster objects that are
+	// allowed to sync concurrently. Larger number = more responsive clusters,
+	// but more CPU (and network) load.
+	ConcurrentClusterAPIClusterSyncs int32
+
 	// concurrentMachineSetSyncs is the number of machine set objects that are
 	// allowed to sync concurrently. Larger number = more responsive machine sets,
 	// but more CPU (and network) load.

--- a/pkg/controller/cluster/clusterapi_cluster_controller.go
+++ b/pkg/controller/cluster/clusterapi_cluster_controller.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
+
+	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clusterapiclient "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	informers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
+	listers "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
+
+	"github.com/openshift/cluster-operator/pkg/controller"
+	colog "github.com/openshift/cluster-operator/pkg/logging"
+)
+
+var clusterAPIControllerKind = clusterapi.SchemeGroupVersion.WithKind("Cluster")
+
+const (
+	clusterAPIControllerLogName = "clusterapi_cluster"
+	clusterAPIClusterNameLabel  = "clusteroperator.openshift.io/cluster"
+)
+
+// NewClusterAPIController returns a new controller.
+func NewClusterAPIController(clusterInformer informers.ClusterInformer, machineSetInformer informers.MachineSetInformer, kubeClient kubeclientset.Interface, clusterAPIClient clusterapiclient.Interface) *CAPIController {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	// TODO: remove the wrapper when every clients have moved to use the clientset.
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
+
+	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("clusterapi_cluster_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+	}
+
+	logger := log.WithField("controller", clusterAPIControllerLogName)
+	c := &CAPIController{
+		client:     clusterAPIClient,
+		kubeClient: kubeClient,
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterapi_cluster"),
+		logger:     logger,
+	}
+
+	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addCluster,
+		UpdateFunc: c.updateCluster,
+		DeleteFunc: c.deleteCluster,
+	})
+	c.clustersLister = clusterInformer.Lister()
+	c.clustersSynced = clusterInformer.Informer().HasSynced
+
+	machineSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addMachineSet,
+		UpdateFunc: c.updateMachineSet,
+	})
+	c.machineSetsLister = machineSetInformer.Lister()
+	c.machineSetsSynced = machineSetInformer.Informer().HasSynced
+
+	c.syncHandler = c.syncCluster
+	c.enqueueCluster = c.enqueue
+
+	return c
+}
+
+// CAPIController manages clusters.
+type CAPIController struct {
+	client     clusterapiclient.Interface
+	kubeClient kubeclientset.Interface
+
+	// To allow injection of syncCluster for testing.
+	syncHandler func(hKey string) error
+	// used for unit testing
+	enqueueCluster func(cluster *clusterapi.Cluster)
+
+	// clustersLister is able to list/get clusters and is populated by the shared informer passed to
+	// NewController.
+	clustersLister listers.ClusterLister
+	// clustersSynced returns true if the cluster shared informer has been synced at least once.
+	// Added as a member to the struct to allow injection for testing.
+	clustersSynced cache.InformerSynced
+
+	// machineSetsLister is able to list/get machine sets and is populated by the shared informer passed to
+	// NewController.
+	machineSetsLister listers.MachineSetLister
+	// machineSetsSynced returns true if the machine set shared informer has been synced at least once.
+	// Added as a member to the struct to allow injection for testing.
+	machineSetsSynced cache.InformerSynced
+
+	// Clusters that need to be synced
+	queue workqueue.RateLimitingInterface
+
+	logger log.FieldLogger
+}
+
+func (c *CAPIController) addCluster(obj interface{}) {
+	cluster := obj.(*clusterapi.Cluster)
+	colog.WithClusterAPICluster(c.logger, cluster).Debugf("adding cluster")
+	c.enqueueCluster(cluster)
+}
+
+func (c *CAPIController) updateCluster(old, cur interface{}) {
+	oldCluster := old.(*clusterapi.Cluster)
+	curCluster := cur.(*clusterapi.Cluster)
+	colog.WithClusterAPICluster(c.logger, oldCluster).Debugf("updating cluster")
+	c.enqueueCluster(curCluster)
+}
+
+func (c *CAPIController) deleteCluster(obj interface{}) {
+	cluster, ok := obj.(*clusterapi.Cluster)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			return
+		}
+		cluster, ok = tombstone.Obj.(*clusterapi.Cluster)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Cluster %#v", obj))
+			return
+		}
+	}
+	colog.WithClusterAPICluster(c.logger, cluster).Debugf("deleting cluster")
+	c.enqueueCluster(cluster)
+}
+
+// When a machine set is created, enqueue the cluster that
+func (c *CAPIController) addMachineSet(obj interface{}) {
+	machineSet := obj.(*clusterapi.MachineSet)
+
+	if machineSet.DeletionTimestamp != nil {
+		return
+	}
+
+	cluster, err := controller.ClusterForClusterAPIMachineSet(machineSet, c.clustersLister)
+	if err != nil {
+		glog.V(2).Infof("error retrieving cluster for machine set %q/%q: %v", machineSet.Namespace, machineSet.Name, err)
+		return
+	}
+	if cluster == nil {
+		// If the cluster owner reference is not set, attempt to retrieve the cluster by label
+		if machineSet.Labels != nil {
+			if clusterName, ok := machineSet.Labels[clusterAPIClusterNameLabel]; ok {
+				cluster, err = c.clustersLister.Clusters(machineSet.Namespace).Get(clusterName)
+				if err != nil {
+					glog.V(2).Infof("error retrieving cluster for machineset %s/%s: %v", machineSet.Namespace, machineSet.Name, err)
+					return
+				}
+			}
+		}
+		if cluster == nil {
+			return
+		}
+	}
+	colog.WithClusterAPIMachineSet(colog.WithClusterAPICluster(c.logger, cluster), machineSet).Debugln("machineset created")
+	c.enqueueCluster(cluster)
+}
+
+// When a machine set is updated, figure out what cluster manages it and wake it
+// up.
+func (c *CAPIController) updateMachineSet(old, cur interface{}) {
+	oldMachineSet := old.(*clusterapi.MachineSet)
+	curMachineSet := cur.(*clusterapi.MachineSet)
+	if curMachineSet.ResourceVersion == oldMachineSet.ResourceVersion {
+		// Periodic resync will send update events for all known machine sets.
+		// Two different versions of the same machine set will always have different RVs.
+		return
+	}
+
+	if curMachineSet.DeletionTimestamp != nil {
+		return
+	}
+
+	cluster, err := controller.ClusterForClusterAPIMachineSet(curMachineSet, c.clustersLister)
+	if err != nil {
+		glog.V(2).Infof("error retrieving cluster for machine set %s/%s: %v", curMachineSet.Namespace, curMachineSet.Name, err)
+		return
+	}
+	if cluster == nil {
+		// If the cluster owner reference is not set, attempt to retrieve the cluster by label
+		if curMachineSet.Labels != nil {
+			if clusterName, ok := curMachineSet.Labels[clusterAPIClusterNameLabel]; ok {
+				cluster, err = c.clustersLister.Clusters(curMachineSet.Namespace).Get(clusterName)
+				if err != nil {
+					glog.V(2).Infof("error retrieving cluster for machineset %s/%s: %v", curMachineSet.Namespace, curMachineSet.Name, err)
+					return
+				}
+			}
+		}
+		if cluster == nil {
+			return
+		}
+	}
+	colog.WithClusterAPIMachineSet(colog.WithClusterAPICluster(c.logger, cluster), curMachineSet).Debugln("machineset updated")
+	c.enqueueCluster(cluster)
+}
+
+// Run runs c; will not return until stopCh is closed. workers determines how
+// many clusters will be handled in parallel.
+func (c *CAPIController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("starting cluster controller")
+	defer c.logger.Info("shutting down cluster controller")
+
+	if !controller.WaitForCacheSync("clusterapi_cluster", stopCh, c.clustersSynced, c.machineSetsSynced) {
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *CAPIController) enqueue(cluster *clusterapi.Cluster) {
+	key, err := controller.KeyFunc(cluster)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", cluster, err))
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *CAPIController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *CAPIController) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncHandler(key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("Sync %q failed with %v", key, err))
+	c.queue.AddRateLimited(key)
+
+	return true
+}
+
+// syncCluster will sync the cluster with the given key.
+// This function is not meant to be invoked concurrently with the same key.
+func (c *CAPIController) syncCluster(key string) error {
+	startTime := time.Now()
+	c.logger.WithField("key", key).Debug("syncing cluster")
+	defer func() {
+		c.logger.WithFields(log.Fields{
+			"key":      key,
+			"duration": time.Now().Sub(startTime),
+		}).Debug("finished syncing cluster")
+	}()
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	cluster, err := c.clustersLister.Clusters(namespace).Get(name)
+	if errors.IsNotFound(err) {
+		c.logger.WithField("key", key).Debug("cluster has been deleted")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// List all active machine sets
+	allMachineSets, err := c.machineSetsLister.MachineSets(cluster.Namespace).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	r, err := labels.NewRequirement(clusterAPIClusterNameLabel, selection.Equals, []string{cluster.Name})
+	if err != nil {
+		return err
+	}
+	machineSetsSelector := labels.NewSelector().Add(*r)
+
+	// If any adoptions are attempted, we should first recheck for deletion with
+	// an uncached quorum read sometime after listing ReplicaSets (see #42639).
+	canAdoptFunc := RecheckDeletionTimestamp(func() (metav1.Object, error) {
+		fresh, err := c.client.ClusterV1alpha1().Clusters(cluster.Namespace).Get(cluster.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if fresh.UID != cluster.UID {
+			return nil, fmt.Errorf("original Cluster %s/%s is gone: got uid %v, wanted %v", cluster.Namespace, cluster.Name, fresh.UID, cluster.UID)
+		}
+		return fresh, nil
+	})
+	refManager := NewMachineSetControllerRefManager(c.client.ClusterV1alpha1(), cluster, machineSetsSelector, clusterAPIControllerKind, canAdoptFunc)
+	_, err = refManager.ClaimMachineSets(allMachineSets)
+	return err
+}

--- a/pkg/controller/cluster/machineset_refmgr.go
+++ b/pkg/controller/cluster/machineset_refmgr.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clusterapiclient "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+
+	controllerutil "github.com/openshift/cluster-operator/pkg/controller"
+)
+
+// MachineSetControllerRefManager is used to manage controller refs of MachineSets
+type MachineSetControllerRefManager struct {
+	controllerutil.BaseControllerRefManager
+	controllerKind   schema.GroupVersionKind
+	machineSetClient clusterapiclient.MachineSetsGetter
+}
+
+// NewMachineSetControllerRefManager returns a MachineSetControllerRefManager that exposes
+// methods to manage the controllerRef of MachineSets.
+//
+// The CanAdopt() function can be used to perform a potentially expensive check
+// (such as a live GET from the API server) prior to the first adoption.
+// It will only be called (at most once) if an adoption is actually attempted.
+// If CanAdopt() returns a non-nil error, all adoptions will fail.
+//
+// NOTE: Once CanAdopt() is called, it will not be called again by the same
+//       MachineSetControllerRefManager instance. Create a new instance if it
+//       makes sense to check CanAdopt() again (e.g. in a different sync pass).
+func NewMachineSetControllerRefManager(
+	machineSetClient clusterapiclient.MachineSetsGetter,
+	controller metav1.Object,
+	selector labels.Selector,
+	controllerKind schema.GroupVersionKind,
+	canAdopt func() error,
+) *MachineSetControllerRefManager {
+	return &MachineSetControllerRefManager{
+		BaseControllerRefManager: controllerutil.BaseControllerRefManager{
+			Controller:   controller,
+			Selector:     selector,
+			CanAdoptFunc: canAdopt,
+		},
+		controllerKind:   controllerKind,
+		machineSetClient: machineSetClient,
+	}
+}
+
+// ClaimMachineSets tries to take ownership of a list of MachineSets.
+//
+// It will reconcile the following:
+//   * Adopt orphans if the selector matches.
+//   * Release owned objects if the selector no longer matches.
+//
+// A non-nil error is returned if some form of reconciliation was attempted and
+// failed. Usually, controllers should try again later in case reconciliation
+// is still needed.
+//
+// If the error is nil, either the reconciliation succeeded, or no
+// reconciliation was necessary. The list of MachineSets that you now own is
+// returned.
+func (m *MachineSetControllerRefManager) ClaimMachineSets(sets []*capiv1.MachineSet) ([]*capiv1.MachineSet, error) {
+	var claimed []*capiv1.MachineSet
+	var errlist []error
+
+	match := func(obj metav1.Object) bool {
+		return m.Selector.Matches(labels.Set(obj.GetLabels()))
+	}
+	adopt := func(obj metav1.Object) error {
+		return m.AdoptMachineSet(obj.(*capiv1.MachineSet))
+	}
+	release := func(obj metav1.Object) error {
+		return m.ReleaseMachineSet(obj.(*capiv1.MachineSet))
+	}
+
+	for _, rs := range sets {
+		ok, err := m.ClaimObject(rs, match, adopt, release)
+		if err != nil {
+			errlist = append(errlist, err)
+			continue
+		}
+		if ok {
+			claimed = append(claimed, rs)
+		}
+	}
+	return claimed, utilerrors.NewAggregate(errlist)
+}
+
+// AdoptMachineSet sends a patch to take control of the MachineSet. It returns
+// the error if the patching fails.
+func (m *MachineSetControllerRefManager) AdoptMachineSet(rs *capiv1.MachineSet) error {
+	if err := m.CanAdopt(); err != nil {
+		return fmt.Errorf("can't adopt MachineSet %v/%v (%v): %v", rs.Namespace, rs.Name, rs.UID, err)
+	}
+	// Note that ValidateOwnerReferences() will reject this patch if another
+	// OwnerReference exists with controller=true.
+	addControllerPatch := fmt.Sprintf(
+		`{"metadata":{"ownerReferences":[{"apiVersion":"%s","kind":"%s","name":"%s","uid":"%s","controller":true,"blockOwnerDeletion":true}],"uid":"%s"}}`,
+		m.controllerKind.GroupVersion(), m.controllerKind.Kind,
+		m.Controller.GetName(), m.Controller.GetUID(), rs.UID)
+	_, err := m.machineSetClient.MachineSets(rs.Namespace).Patch(rs.Name, types.StrategicMergePatchType, []byte(addControllerPatch))
+	return err
+}
+
+// ReleaseMachineSet sends a patch to free the MachineSet from the control of the Deployment controller.
+// It returns the error if the patching fails. 404 and 422 errors are ignored.
+func (m *MachineSetControllerRefManager) ReleaseMachineSet(machineSet *capiv1.MachineSet) error {
+	glog.V(2).Infof("patching MachineSet %s_%s to remove its controllerRef to %s/%s:%s",
+		machineSet.Namespace, machineSet.Name, m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
+	deleteOwnerRefPatch := fmt.Sprintf(`{"metadata":{"ownerReferences":[{"$patch":"delete","uid":"%s"}],"uid":"%s"}}`, m.Controller.GetUID(), machineSet.UID)
+	_, err := m.machineSetClient.MachineSets(machineSet.Namespace).Patch(machineSet.Name, types.StrategicMergePatchType, []byte(deleteOwnerRefPatch))
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// If the MachineSet no longer exists, ignore it.
+			return nil
+		}
+		if errors.IsInvalid(err) {
+			// Invalid error will be returned in two cases: 1. the MachineSet
+			// has no owner reference, 2. the uid of the MachineSet doesn't
+			// match, which means the MachineSet is deleted and then recreated.
+			// In both cases, the error can be ignored.
+			return nil
+		}
+	}
+	return err
+}
+
+// RecheckDeletionTimestamp returns a CanAdopt() function to recheck deletion.
+//
+// The CanAdopt() function calls getObject() to fetch the latest value,
+// and denies adoption attempts if that object has a non-nil DeletionTimestamp.
+func RecheckDeletionTimestamp(getObject func() (metav1.Object, error)) func() error {
+	return func() error {
+		obj, err := getObject()
+		if err != nil {
+			return fmt.Errorf("can't recheck DeletionTimestamp: %v", err)
+		}
+		if obj.GetDeletionTimestamp() != nil {
+			return fmt.Errorf("%v/%v has just been deleted at %v", obj.GetNamespace(), obj.GetName(), obj.GetDeletionTimestamp())
+		}
+		return nil
+	}
+}

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// BaseControllerRefManager is the base for an controller/owner reference manager
+type BaseControllerRefManager struct {
+	Controller metav1.Object
+	Selector   labels.Selector
+
+	canAdoptErr  error
+	canAdoptOnce sync.Once
+	CanAdoptFunc func() error
+}
+
+// CanAdopt calls the canAdoptFunc exactly once and stores its
+// result in canAdoptErr. Subsequent calls to this function will
+// simply return the stored canAdoptErr value.
+func (m *BaseControllerRefManager) CanAdopt() error {
+	m.canAdoptOnce.Do(func() {
+		if m.CanAdoptFunc != nil {
+			m.canAdoptErr = m.CanAdoptFunc()
+		}
+	})
+	return m.canAdoptErr
+}
+
+// ClaimObject tries to take ownership of an object for this controller.
+//
+// It will reconcile the following:
+//   * Adopt orphans if the match function returns true.
+//   * Release owned objects if the match function returns false.
+//
+// A non-nil error is returned if some form of reconciliation was attempted and
+// failed. Usually, controllers should try again later in case reconciliation
+// is still needed.
+//
+// If the error is nil, either the reconciliation succeeded, or no
+// reconciliation was necessary. The returned boolean indicates whether you now
+// own the object.
+//
+// No reconciliation will be attempted if the controller is being deleted.
+func (m *BaseControllerRefManager) ClaimObject(obj metav1.Object, match func(metav1.Object) bool, adopt, release func(metav1.Object) error) (bool, error) {
+	controllerRef := metav1.GetControllerOf(obj)
+	if controllerRef != nil {
+		if controllerRef.UID != m.Controller.GetUID() {
+			// Owned by someone else. Ignore.
+			return false, nil
+		}
+		if match(obj) {
+			// We already own it and the selector matches.
+			// Return true (successfully claimed) before checking deletion timestamp.
+			// We're still allowed to claim things we already own while being deleted
+			// because doing so requires taking no actions.
+			return true, nil
+		}
+		// Owned by us but selector doesn't match.
+		// Try to release, unless we're being deleted.
+		if m.Controller.GetDeletionTimestamp() != nil {
+			return false, nil
+		}
+		if err := release(obj); err != nil {
+			// If the pod no longer exists, ignore the error.
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			// Either someone else released it, or there was a transient error.
+			// The controller should requeue and try again if it's still stale.
+			return false, err
+		}
+		// Successfully released.
+		return false, nil
+	}
+
+	// It's an orphan.
+	if m.Controller.GetDeletionTimestamp() != nil || !match(obj) {
+		// Ignore if we're being deleted or selector doesn't match.
+		return false, nil
+	}
+	if obj.GetDeletionTimestamp() != nil {
+		// Ignore if the object is being deleted
+		return false, nil
+	}
+	// Selector matches. Try to adopt.
+	if err := adopt(obj); err != nil {
+		// If the pod no longer exists, ignore the error.
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		// Either someone else claimed it first, or there was a transient error.
+		// The controller should requeue and try again if it's still orphaned.
+		return false, err
+	}
+	// Successfully adopted.
+	return true, nil
+}

--- a/pkg/controller/mockjobsyncstrategy_generated_test.go
+++ b/pkg/controller/mockjobsyncstrategy_generated_test.go
@@ -141,3 +141,38 @@ func (m *MockJobSyncStrategy) GetLastJobSuccess(owner v11.Object) *time.Time {
 func (mr *MockJobSyncStrategyMockRecorder) GetLastJobSuccess(owner interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastJobSuccess", reflect.TypeOf((*MockJobSyncStrategy)(nil).GetLastJobSuccess), owner)
 }
+
+// MockCheckBeforeUndo is a mock of CheckBeforeUndo interface
+type MockCheckBeforeUndo struct {
+	ctrl     *gomock.Controller
+	recorder *MockCheckBeforeUndoMockRecorder
+}
+
+// MockCheckBeforeUndoMockRecorder is the mock recorder for MockCheckBeforeUndo
+type MockCheckBeforeUndoMockRecorder struct {
+	mock *MockCheckBeforeUndo
+}
+
+// NewMockCheckBeforeUndo creates a new mock instance
+func NewMockCheckBeforeUndo(ctrl *gomock.Controller) *MockCheckBeforeUndo {
+	mock := &MockCheckBeforeUndo{ctrl: ctrl}
+	mock.recorder = &MockCheckBeforeUndoMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockCheckBeforeUndo) EXPECT() *MockCheckBeforeUndoMockRecorder {
+	return m.recorder
+}
+
+// CanUndo mocks base method
+func (m *MockCheckBeforeUndo) CanUndo(owner v11.Object) bool {
+	ret := m.ctrl.Call(m, "CanUndo", owner)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanUndo indicates an expected call of CanUndo
+func (mr *MockCheckBeforeUndoMockRecorder) CanUndo(owner interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanUndo", reflect.TypeOf((*MockCheckBeforeUndo)(nil).CanUndo), owner)
+}


### PR DESCRIPTION
This controller adds owner references to machinesets that are labeled
with the cluster's name. It uses the same owner reference manager
used in Kube to set owner references on PodSets based on a label
selector.