### PR TITLE
Add cluster API and machine controller image refs to ClusterVersion

### DIFF
--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -104,6 +104,26 @@ type ClusterVersionSpec struct {
 	// Defaults to IfNotPreset.
 	// +optional
 	OpenshiftAnsibleImagePullPolicy *corev1.PullPolicy
+
+	// ClusterAPIImage is the name of the image to use on the target
+	// cluster to run Cluster API
+	// +optional
+	ClusterAPIImage *string
+
+	// ClusterAPIImagePullPolicy is the pull policy to use for the
+	// ClusterAPIImage
+	// +optional
+	ClusterAPIImagePullPolicy *corev1.PullPolicy
+
+	// MachineControllerImage is the name of the image to use on the
+	// target cluster to run the machine controller
+	// +optional
+	MachineControllerImage *string
+
+	// MachineControllerImagePullPolicy is the pull policy to use for
+	// the MachineControllerImagePullPolicy
+	// +optional
+	MachineControllerImagePullPolicy *corev1.PullPolicy
 }
 
 // ClusterVersionStatus is the status of a ClusterVersion. It may be used to indicate if the

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -106,6 +106,26 @@ type ClusterVersionSpec struct {
 	// Defaults to IfNotPreset.
 	// +optional
 	OpenshiftAnsibleImagePullPolicy *corev1.PullPolicy `json:"openshiftAnsibleImagePullPolicy,omitempty"`
+
+	// ClusterAPIImage is the name of the image to use on the target
+	// cluster to run Cluster API
+	// +optional
+	ClusterAPIImage *string `json:"clusterAPIImage,omitempty"`
+
+	// ClusterAPIImagePullPolicy is the pull policy to use for the
+	// ClusterAPIImage
+	// +optional
+	ClusterAPIImagePullPolicy *corev1.PullPolicy `json:"clusterAPIImagePullPolicy,omitempty"`
+
+	// MachineControllerImage is the name of the image to use on the
+	// target cluster to run the machine controller
+	// +optional
+	MachineControllerImage *string `json:"machineControllerImage,omitempty"`
+
+	// MachineControllerImagePullPolicy is the pull policy to use for
+	// the MachineControllerImagePullPolicy
+	// +optional
+	MachineControllerImagePullPolicy *corev1.PullPolicy `json:"machineControllerImagePullPolicy,omitempty"`
 }
 
 // ClusterVersionStatus is the status of a ClusterVersion. It may be used to indicate if the

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -553,6 +553,10 @@ func autoConvert_v1alpha1_ClusterVersionSpec_To_clusteroperator_ClusterVersionSp
 	out.Version = in.Version
 	out.OpenshiftAnsibleImage = (*string)(unsafe.Pointer(in.OpenshiftAnsibleImage))
 	out.OpenshiftAnsibleImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.OpenshiftAnsibleImagePullPolicy))
+	out.ClusterAPIImage = (*string)(unsafe.Pointer(in.ClusterAPIImage))
+	out.ClusterAPIImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.ClusterAPIImagePullPolicy))
+	out.MachineControllerImage = (*string)(unsafe.Pointer(in.MachineControllerImage))
+	out.MachineControllerImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.MachineControllerImagePullPolicy))
 	return nil
 }
 
@@ -570,6 +574,10 @@ func autoConvert_clusteroperator_ClusterVersionSpec_To_v1alpha1_ClusterVersionSp
 	out.Version = in.Version
 	out.OpenshiftAnsibleImage = (*string)(unsafe.Pointer(in.OpenshiftAnsibleImage))
 	out.OpenshiftAnsibleImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.OpenshiftAnsibleImagePullPolicy))
+	out.ClusterAPIImage = (*string)(unsafe.Pointer(in.ClusterAPIImage))
+	out.ClusterAPIImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.ClusterAPIImagePullPolicy))
+	out.MachineControllerImage = (*string)(unsafe.Pointer(in.MachineControllerImage))
+	out.MachineControllerImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.MachineControllerImagePullPolicy))
 	return nil
 }
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -466,6 +466,42 @@ func (in *ClusterVersionSpec) DeepCopyInto(out *ClusterVersionSpec) {
 			**out = **in
 		}
 	}
+	if in.ClusterAPIImage != nil {
+		in, out := &in.ClusterAPIImage, &out.ClusterAPIImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.ClusterAPIImagePullPolicy != nil {
+		in, out := &in.ClusterAPIImagePullPolicy, &out.ClusterAPIImagePullPolicy
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.PullPolicy)
+			**out = **in
+		}
+	}
+	if in.MachineControllerImage != nil {
+		in, out := &in.MachineControllerImage, &out.MachineControllerImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.MachineControllerImagePullPolicy != nil {
+		in, out := &in.MachineControllerImagePullPolicy, &out.MachineControllerImagePullPolicy
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.PullPolicy)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -465,6 +465,42 @@ func (in *ClusterVersionSpec) DeepCopyInto(out *ClusterVersionSpec) {
 			**out = **in
 		}
 	}
+	if in.ClusterAPIImage != nil {
+		in, out := &in.ClusterAPIImage, &out.ClusterAPIImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.ClusterAPIImagePullPolicy != nil {
+		in, out := &in.ClusterAPIImagePullPolicy, &out.ClusterAPIImagePullPolicy
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.PullPolicy)
+			**out = **in
+		}
+	}
+	if in.MachineControllerImage != nil {
+		in, out := &in.MachineControllerImage, &out.MachineControllerImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.MachineControllerImagePullPolicy != nil {
+		in, out := &in.MachineControllerImagePullPolicy, &out.MachineControllerImagePullPolicy
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.PullPolicy)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -853,6 +853,34 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"clusterAPIImage": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterAPIImage is the name of the image to use on the target cluster to run Cluster API",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"clusterAPIImagePullPolicy": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ClusterAPIImagePullPolicy is the pull policy to use for the ClusterAPIImage",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"machineControllerImage": {
+							SchemaProps: spec.SchemaProps{
+								Description: "MachineControllerImage is the name of the image to use on the target cluster to run the machine controller",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"machineControllerImagePullPolicy": {
+							SchemaProps: spec.SchemaProps{
+								Description: "MachineControllerImagePullPolicy is the pull policy to use for the MachineControllerImagePullPolicy",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"imageFormat", "vmImages", "deploymentType", "version"},
 				},


### PR DESCRIPTION
The original reason for this is so we can specify which images to use in CI. However, it also makes sense that we track these images per version.