### PR TITLE
Ensure cluster API binaries are executable in image

### DIFF
--- a/build/clusterapi-image/Dockerfile
+++ b/build/clusterapi-image/Dockerfile
@@ -19,3 +19,5 @@ RUN apt-get install -y ca-certificates
 
 ADD apiserver .
 ADD controller-manager .
+
+RUN chmod +x apiserver controller-manager


### PR DESCRIPTION
When the cluster-api image is built in CI, the binaries don't get the executable permission. Ensure that the binaries are executable.