### PR TITLE
Parameterize images to deploy on target cluster

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml
@@ -93,7 +93,17 @@
       dest: "{{ temp_file.path }}"
 
   - name: process template
-    shell: "oc process -f {{ temp_file.path }} -p CLUSTER_API_NAMESPACE={{ cluster_api_namespace }} -p SERVING_CA={{ cluster_api_ca_bundle }} -p SERVING_CERT={{ cluster_api_cert }} -p SERVING_KEY={{ cluster_api_key }} -p BOOTSTRAP_KUBECONFIG='{{ bootstrap_kubeconfig.content }}' | oc apply -f -"
+    shell: |-
+      oc process -f {{ temp_file.path }} \
+         -p CLUSTER_API_NAMESPACE={{ cluster_api_namespace }} \
+         -p SERVING_CA={{ cluster_api_ca_bundle }} \
+         -p SERVING_CERT={{ cluster_api_cert }} \
+         -p SERVING_KEY={{ cluster_api_key }} \
+         -p BOOTSTRAP_KUBECONFIG='{{ bootstrap_kubeconfig.content }}' \
+         -p CLUSTER_API_IMAGE='{{ cluster_api_image }}' \
+         -p CLUSTER_API_IMAGE_PULL_POLICY='{{ cluster_api_image_pull_policy }}' \
+         -p MACHINE_CONTROLLER_IMAGE='{{ machine_controller_image }}' \
+         -p MACHINE_CONTROLLER_IMAGE_PULL_POLICY='{{ machine_controller_image_pull_policy }}' | oc apply -f -
 
   - name: remove template file
     file:

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
@@ -7,8 +7,10 @@
 #   SERVING_CERT: base-64-encoded, pem cert to use for ssl communication with the Cluster API Server. Required.
 #   SERVING_KEY: base-64-encoded, pem private key for the cert to use for ssl communication with the Cluster API Server. Required.
 #   SERVING_CA: base-64-encoded, pem CA cert for the ssl certs. Required.
-#   IMAGE: clusterapi container image location
-#   IMAGE_PULL_POLICY: control image pull policy for clusterapi containers
+#   CLUSTER_API_IMAGE: clusterapi container image location
+#   CLUSTER_API_IMAGE_PULL_POLICY: control image pull policy for clusterapi containers
+#   MACHINE_CONTROLLER_IMAGE: machine controller image reference
+#   MACHINE_CONTROLLER_IMAGE_PULL_POLICY: pull policy for machine controller image
 #
 ########
 
@@ -82,8 +84,8 @@ objects:
         serviceAccountName: cluster-api-apiserver
         containers:
         - name: apiserver
-          image: ${IMAGE}
-          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          image: ${CLUSTER_API_IMAGE}
+          imagePullPolicy: ${CLUSTER_API_IMAGE_PULL_POLICY}
           volumeMounts:
           - name: cluster-apiserver-certs
             mountPath: /var/run/cluster-api-apiserver
@@ -203,7 +205,9 @@ objects:
         containers:
         - name: machine-controller
           image: ${MACHINE_CONTROLLER_IMAGE}
-          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          imagePullPolicy: ${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}
+          command:
+          - /opt/services/aws-machine-controller
           args:
           - --log-level=debug
           - --default-availability-zone=${DEFAULT_AVAILABILITY_ZONE}
@@ -249,8 +253,8 @@ objects:
           node-role.kubernetes.io/master: "true"
         containers:
         - name: controller-manager
-          image: ${IMAGE}
-          imagePullPolicy: ${IMAGE_PULL_POLICY}
+          image: ${CLUSTER_API_IMAGE}
+          imagePullPolicy: ${CLUSTER_API_IMAGE_PULL_POLICY}
           command:
           - "./controller-manager"
           resources:
@@ -371,7 +375,7 @@ parameters:
 - name: KUBE_SYSTEM_NAMESPACE
   value: kube-system
 # pull policy (for testing)
-- name: IMAGE_PULL_POLICY
+- name: CLUSTER_API_IMAGE_PULL_POLICY
   value: Always
 # CA cert for API Server SSL cert
 - name: SERVING_CA
@@ -380,11 +384,11 @@ parameters:
 # Public API Server SSL cert
 - name: SERVING_KEY
 # location of container image
-- name: IMAGE
-  value: quay.io/openshift/kubernetes-cluster-api:latest
+- name: CLUSTER_API_IMAGE
 # machine controller image
 - name: MACHINE_CONTROLLER_IMAGE
-  value: quay.io/csrwng/aws-machine-controller:latest
+- name: MACHINE_CONTROLLER_IMAGE_PULL_POLICY
+  value: Always
 - name: DEFAULT_AVAILABILITY_ZONE
   value: us-east-1c
 - name: BOOTSTRAP_KUBECONFIG

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -16,6 +16,15 @@
     # Namespace to deploy CO to:
     cluster_operator_namespace: "openshift-cluster-operator"
 
+    # Namespace for cluster versions:
+    cluster_version_namespace: "openshift-cluster-operator"
+
+    # Images to deploy on target cluster
+    cluster_api_image: "registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest"
+    cluster_api_image_pull_policy: "Always"
+    machine_controller_image: "registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest"
+    machine_controller_image_pull_policy: "Always"
+
     # Normally we assume to build and push images for devel deployments:
     push_images: True
   tasks:
@@ -51,8 +60,12 @@
   - name: process cluster versions template
     oc_process:
       template_file: "{{ playbook_dir }}/../examples/cluster-versions-template.yaml"
-    parameters:
-      CLUSTER_VERSION_NS: "{{ cluster_version_namespace }}"
+      parameters:
+        CLUSTER_VERSION_NS: "{{ cluster_version_namespace }}"
+        CLUSTER_API_IMAGE: "{{ cluster_api_image }}"
+        CLUSTER_API_IMAGE_PULL_POLICY: "{{ cluster_api_image_pull_policy }}"
+        MACHINE_CONTROLLER_IMAGE: "{{ machine_controller_image }}"
+        MACHINE_CONTROLLER_IMAGE_PULL_POLICY: "{{ machine_controller_image_pull_policy }}"
     register: cluster_versions_reg
 
   - name: create/update cluster versions

--- a/contrib/examples/cluster-versions-template.yaml
+++ b/contrib/examples/cluster-versions-template.yaml
@@ -17,6 +17,20 @@ parameters:
   displayName: Openshift Ansible Image Pull Policy
   description: Policy to use when pulling the Openshift Ansible image
   value: "Always"
+- name: CLUSTER_API_IMAGE
+  displayName: Cluster API Image
+  description: Name and tag of the image to use for the Cluster API on the target cluster
+- name: CLUSTER_API_IMAGE_PULL_POLICY
+  displayName: Cluster API Image Pull Policy
+  descrition: Policy to use when pulling the Cluster API image on the target cluster
+  value: Always
+- name: MACHINE_CONTROLLER_IMAGE
+  displayName: Machine Controller Image 
+  descrition: Name and tag of the image to use for the machine controller on the target cluster
+- name: MACHINE_CONTROLLER_IMAGE_PULL_POLICY
+  displayName: Cluster API Image Pull Policy
+  descrition: Policy to use when pulling the machine controller image on the target cluster
+  value: Always
 
 objects:
 
@@ -37,6 +51,11 @@ objects:
     # TODO: Update after jdiaz incoming work is merged:
     openshiftAnsibleImage: cluster-operator-ansible:canary
     openshiftAnsibleImagePullPolicy: Never
+    clusterAPIImage: "${CLUSTER_API_IMAGE}"
+    clusterAPIImagePullPolicy: "${CLUSTER_API_IMAGE_PULL_POLICY}"
+    machineControllerImage: "${MACHINE_CONTROLLER_IMAGE}"
+    machineControllerImagePullPolicy: "${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}"
+
 
 - apiVersion: clusteroperator.openshift.io/v1alpha1
   kind: ClusterVersion
@@ -54,3 +73,7 @@ objects:
     version: "v3.10.0"
     openshiftAnsibleImage: fake-openshift-ansible:canary
     openshiftAnsibleImagePullPolicy: Never
+    clusterAPIImage: "${CLUSTER_API_IMAGE}"
+    clusterAPIImagePullPolicy: "${CLUSTER_API_IMAGE_PULL_POLICY}"
+    machineControllerImage: "${MACHINE_CONTROLLER_IMAGE}"
+    machineControllerImagePullPolicy: "${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}"


### PR DESCRIPTION
Allows passing variables to the deploy-cluster-api playbook to point to alternate images for the machine controller and cluster-api.

For now, the default location of these images will be the registry on api.ci where we'll update the latest tag every time we merge to master.

For PRs we will push to the same registry with a pr-specific tag and tell the target cluster to use that.