### PR TITLE
Integration tests using CAPI

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -575,6 +575,7 @@ func startClusterAPIInfraController(ctx ControllerContext) (bool, error) {
 	}
 	go infra.NewClusterAPIController(
 		ctx.ClusterAPIInformerFactory.Cluster().V1alpha1().Clusters(),
+		ctx.ClusterAPIInformerFactory.Cluster().V1alpha1().MachineSets(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-capi-infra-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-capi-infra-controller"),

--- a/pkg/ansible/generate_test.go
+++ b/pkg/ansible/generate_test.go
@@ -121,7 +121,7 @@ func testClusterVersion() *coapi.ClusterVersion {
 	}
 }
 
-func TestGenerateClusterVars(t *testing.T) {
+func TestGenerateClusterWideVars(t *testing.T) {
 	tests := []struct {
 		name             string
 		cluster          *coapi.Cluster
@@ -141,6 +141,7 @@ func TestGenerateClusterVars(t *testing.T) {
 				"openshift_aws_region: us-east-1",
 				"ansible_ssh_user: centos",
 				"openshift_deployment_type: origin",
+				"openshift_hosted_registry_replicas: 1",
 			},
 			shouldNotInclude: []string{
 				"openshift_release",
@@ -155,7 +156,7 @@ func TestGenerateClusterVars(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := GenerateClusterVars(tc.cluster.Name, &tc.cluster.Spec, &tc.clusterVersion.Spec)
+			result, err := GenerateClusterWideVars(tc.cluster.Name, &tc.cluster.Spec.Hardware, tc.clusterVersion, 2)
 			assert.Nil(t, err, "%s: unexpected: %v", tc.name, err)
 			for _, str := range tc.shouldInclude {
 				assert.Contains(t, result, str, "%s: result does not contain %q", tc.name, str)

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -23,9 +23,13 @@ import (
 
 // Annotation constants
 const (
-	// ClusterGenerationAnnotation contains the generation of a cluster spec used to create
-	// a provisioning job
-	ClusterGenerationAnnotation = GroupName + "/cluster.generation"
+	// OwnerGenerationAnnotation contains the generation of the spec of the
+	// owner of a job
+	OwnerGenerationAnnotation = GroupName + "/owner.generation"
+
+	// ClusterNameLabel is the label that a machineset must have to identify the
+	// cluster to which it belongs.
+	ClusterNameLabel = "clusteroperator.openshift.io/cluster"
 )
 
 // +genclient

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -28,6 +28,10 @@ const (
 	// OwnerGenerationAnnotation contains the generation of the spec of the
 	// owner of a job
 	OwnerGenerationAnnotation = GroupName + "/owner.generation"
+
+	// ClusterNameLabel is the label that a machineset must have to identify the
+	// cluster to which it belongs.
+	ClusterNameLabel = "clusteroperator.openshift.io/cluster"
 )
 
 // +genclient

--- a/pkg/controller/client_utils.go
+++ b/pkg/controller/client_utils.go
@@ -83,54 +83,11 @@ func preparePatchBytesforClusterStatus(oldCluster, newCluster *clusteroperator.C
 	return patchBytes, nil
 }
 
-// PatchClusterAPIStatus will patch the cluster with the difference
-// between original and cluster. If the patch request fails due to a
-// conflict, the request will be retried until it succeeds or fails for other
-// reasons.
-func PatchClusterAPIStatus(c clusterclientset.Interface, original, cluster *clusterv1.Cluster) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return patchClusterAPIStatus(c, original, cluster)
-	})
-}
-
-func patchClusterAPIStatus(c clusterclientset.Interface, oldCluster, newCluster *clusterv1.Cluster) error {
-	logger := log.WithField("cluster", fmt.Sprintf("%s/%s", oldCluster.Namespace, oldCluster.Name))
-	patchBytes, err := preparePatchBytesforClusterAPIStatus(oldCluster, newCluster)
-	if err != nil {
-		return err
-	}
-
-	// Do not send patch request if there is nothing to patch
-	if string(patchBytes) == "{}" {
-		return nil
-	}
-
-	logger.Debugf("about to patch cluster with %s", string(patchBytes))
-	_, err = c.ClusterV1alpha1().Clusters(newCluster.Namespace).Patch(newCluster.Name, types.StrategicMergePatchType, patchBytes, "status")
-	if err != nil {
-		logger.Warningf("Error patching cluster: %v", err)
-	}
+// UpdateClusterAPIStatus will update the cluster status. If the update request
+// fails due to a conflict, the request will NOT be retried.
+func UpdateClusterAPIStatus(c clusterclientset.Interface, cluster *clusterv1.Cluster) error {
+	_, err := c.ClusterV1alpha1().Clusters(cluster.Namespace).UpdateStatus(cluster)
 	return err
-}
-
-func preparePatchBytesforClusterAPIStatus(oldCluster, newCluster *clusterv1.Cluster) ([]byte, error) {
-	oldData, err := json.Marshal(oldCluster)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal oldData for cluster %s/%s: %v", oldCluster.Namespace, oldCluster.Name, err)
-	}
-
-	// Reset spec to make sure only patch for Status or ObjectMeta is generated.
-	newCluster.Spec = oldCluster.Spec
-	newData, err := json.Marshal(newCluster)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal newData for cluster %s/%s: %v", newCluster.Namespace, newCluster.Name, err)
-	}
-
-	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, clusteroperator.Cluster{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create two way merge patch for cluster %s/%s: %v", newCluster.Namespace, newCluster.Name, err)
-	}
-	return patchBytes, nil
 }
 
 // PatchMachineSetStatus will patch the machine set with the difference

--- a/pkg/controller/clusterapimachine/machine_controller.go
+++ b/pkg/controller/clusterapimachine/machine_controller.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
 
+	clustopv1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	clustopinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions/clusteroperator/v1alpha1"
 	clustoplisters "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
 	"github.com/openshift/cluster-operator/pkg/controller"
@@ -49,8 +50,6 @@ import (
 
 const (
 	controllerLogName = "capi-machine"
-
-	clusterNameLabel = "clusteroperator.openshift.io/cluster"
 )
 
 // NewController returns a new controller.
@@ -168,7 +167,7 @@ func (c *Controller) deleteMachine(obj interface{}) {
 // upstream convention soon.
 func (c *Controller) enqueueMachinesForCluster(cluster *capiv1.Cluster) {
 	nsMachines, err := c.machinesLister.Machines(cluster.Namespace).List(labels.SelectorFromSet(
-		labels.Set{clusterNameLabel: cluster.Name}))
+		labels.Set{clustopv1.ClusterNameLabel: cluster.Name}))
 	if err != nil {
 		utilruntime.HandleError(err)
 		return
@@ -297,7 +296,7 @@ func (c *Controller) syncMachine(key string) error {
 	mLog.Debugf("found machine")
 
 	// Lookup the cluster for this machine:
-	clusterName, ok := machine.Labels[clusterNameLabel]
+	clusterName, ok := machine.Labels[clustopv1.ClusterNameLabel]
 	if !ok {
 		return fmt.Errorf("no cluster label set on machine")
 	}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -24,20 +24,23 @@ import (
 	"github.com/golang/glog"
 	log "github.com/sirupsen/logrus"
 
-	lister "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/cluster-operator/pkg/api"
 	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	lister "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
+	capicommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capilister "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
 )
 
 var (
@@ -294,17 +297,31 @@ func ClusterForGenericMachineSet(
 	clusterKind schema.GroupVersionKind,
 	getCluster func(namespace, name string) (metav1.Object, error),
 ) (metav1.Object, error) {
-	controller, err := GetObjectController(
-		machineSet,
-		clusterKind,
-		func(name string) (metav1.Object, error) {
-			return getCluster(machineSet.GetNamespace(), name)
-		},
-	)
-	if err != nil {
-		return nil, err
+	switch ms := machineSet.(type) {
+	case *clusteroperator.MachineSet:
+		controller, err := GetObjectController(
+			machineSet,
+			clusterKind,
+			func(name string) (metav1.Object, error) {
+				return getCluster(machineSet.GetNamespace(), name)
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return controller, nil
+	case *clusterapi.MachineSet:
+		if ms.Labels == nil {
+			return nil, fmt.Errorf("missing %s label", clusteroperator.ClusterNameLabel)
+		}
+		clusterName, ok := ms.Labels[clusteroperator.ClusterNameLabel]
+		if !ok {
+			return nil, fmt.Errorf("missing %s label", clusteroperator.ClusterNameLabel)
+		}
+		return getCluster(ms.Namespace, clusterName)
+	default:
+		return nil, fmt.Errorf("unknown type of MachineSet: %T", ms)
 	}
-	return controller, nil
 }
 
 // MachineSetsForCluster retrieves the machinesets owned by a given cluster.
@@ -320,6 +337,16 @@ func MachineSetsForCluster(cluster *clusteroperator.Cluster, machineSetsLister l
 		}
 	}
 	return clusterMachineSets, nil
+}
+
+// CAPIMachineSetsForCluster retrieves the machinesets associated with the
+// specified cluster name.
+func CAPIMachineSetsForCluster(namespace string, clusterName string, machineSetsLister capilister.MachineSetLister) ([]*clusterapi.MachineSet, error) {
+	requirement, err := labels.NewRequirement(clusteroperator.ClusterNameLabel, selection.Equals, []string{clusterName})
+	if err != nil {
+		return nil, err
+	}
+	return machineSetsLister.MachineSets(namespace).List(labels.NewSelector().Add(*requirement))
 }
 
 // MachineSetLabels returns the labels to apply to a machine set belonging to the
@@ -378,7 +405,7 @@ func ClusterSpecFromClusterAPI(cluster *clusterapi.Cluster) (*clusteroperator.Cl
 	}
 	obj, gvk, err := api.Codecs.UniversalDecoder(clusteroperator.SchemeGroupVersion).Decode([]byte(cluster.Spec.ProviderConfig.Value.Raw), nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not decode ProviderConfig: %v", err)
 	}
 	spec, ok := obj.(*clusteroperator.ClusterProviderConfigSpec)
 	if !ok {
@@ -395,7 +422,7 @@ func ClusterStatusFromClusterAPI(cluster *clusterapi.Cluster) (*clusteroperator.
 	}
 	obj, gvk, err := api.Codecs.UniversalDecoder(clusteroperator.SchemeGroupVersion).Decode([]byte(cluster.Status.ProviderStatus.Raw), nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not decode ProviderStatus: %v", err)
 	}
 	status, ok := obj.(*clusteroperator.ClusterProviderStatus)
 	if !ok {
@@ -550,4 +577,61 @@ func ApplyDefaultMachineSetHardwareSpec(machineSetHardwareSpec, defaultHardwareS
 		return nil, err
 	}
 	return mergedSpec, nil
+}
+
+// GetClustopInfraSize gets the size of the infra machine set for the cluster.
+func GetClustopInfraSize(cluster *clusteroperator.CombinedCluster) (int, error) {
+	for _, ms := range cluster.ClusterOperatorSpec.MachineSets {
+		if ms.Infra {
+			return ms.Size, nil
+		}
+	}
+	return 0, fmt.Errorf("no machineset of type Infra found")
+}
+
+// GetCAPIInfraSize gets the size of the infra machine set for the cluster.
+func GetCAPIInfraSize(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (int, error) {
+	machineSet, err := GetCAPIInfraMachineSet(cluster, machineSetLister)
+	if err != nil {
+		return 0, err
+	}
+	size := machineSet.Spec.Replicas
+	if size == nil {
+		return 1, nil
+	}
+	return int(*size), nil
+}
+
+// GetCAPIInfraMachineSet gets the infra machine set for the cluster.
+func GetCAPIInfraMachineSet(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (*clusterapi.MachineSet, error) {
+	machineSets, err := CAPIMachineSetsForCluster(cluster.Namespace, cluster.Name, machineSetLister)
+	if err != nil {
+		return nil, err
+	}
+	for _, ms := range machineSets {
+		clustopSpec, err := MachineSetSpecFromClusterAPIMachineSpec(&ms.Spec.Template.Spec)
+		if err != nil {
+			continue
+		}
+		if clustopSpec.Infra {
+			return ms, nil
+		}
+	}
+	return nil, fmt.Errorf("no infra machineset found")
+}
+
+// GetCAPIMasterMachineSet gets the master machine set for the cluster.
+func GetCAPIMasterMachineSet(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (*clusterapi.MachineSet, error) {
+	machineSets, err := CAPIMachineSetsForCluster(cluster.Namespace, cluster.Name, machineSetLister)
+	if err != nil {
+		return nil, err
+	}
+	for _, ms := range machineSets {
+		for _, role := range ms.Spec.Template.Spec.Roles {
+			if role == capicommon.MasterRole {
+				return ms, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no master machineset found")
 }

--- a/pkg/controller/syncmachineset/syncmachineset_controller.go
+++ b/pkg/controller/syncmachineset/syncmachineset_controller.go
@@ -107,7 +107,7 @@ func NewController(
 
 	c.syncHandler = c.syncMachineSet
 	c.enqueueMachineSet = c.enqueue
-	c.buildClients = c.buildRemoteClusterClients
+	c.BuildRemoteClient = c.buildRemoteClusterClients
 
 	return c
 }
@@ -124,7 +124,7 @@ type Controller struct {
 	// Used for unit testing
 	enqueueMachineSet func(machineSet *cov1.MachineSet)
 
-	buildClients func(*cov1.Cluster) (clusterapiclient.Interface, error)
+	BuildRemoteClient func(*cov1.Cluster) (clusterapiclient.Interface, error)
 
 	// machineSetsLister is able to list/get machine sets and is
 	// populated by the shared informer passed to NewController.
@@ -377,7 +377,7 @@ func (c *Controller) syncMasterMachineSet(ms *cov1.MachineSet) error {
 	}
 
 	// Create the Cluster object if it does not already exist:
-	remoteClusterAPIClient, err := c.buildClients(coCluster)
+	remoteClusterAPIClient, err := c.BuildRemoteClient(coCluster)
 	if err != nil {
 		return err
 	}
@@ -425,7 +425,7 @@ func (c *Controller) syncComputeMachineSet(ms *cov1.MachineSet) error {
 		return nil
 	}
 
-	remoteClusterAPIClient, err := c.buildClients(coCluster)
+	remoteClusterAPIClient, err := c.BuildRemoteClient(coCluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/syncmachineset/syncmachineset_controller_test.go
+++ b/pkg/controller/syncmachineset/syncmachineset_controller_test.go
@@ -171,7 +171,7 @@ func TestMasterMachineSets(t *testing.T) {
 			}
 			cStore.Add(cluster)
 
-			c.buildClients = func(*cov1.Cluster) (clusterapiclient.Interface, error) {
+			c.BuildRemoteClient = func(*cov1.Cluster) (clusterapiclient.Interface, error) {
 				return remoteClusterAPIClient, nil
 			}
 			if tc.clusterAPIExists {


### PR DESCRIPTION
* Added integration tests using the cluster-api resources.
* Fixed flake where integration tests were occasionally failing due to missing deprovision job. See https://trello.com/c/cdGM9KVt.
* Use UPDATE to update cluster status since we cannot do a strategic merge of the ProviderStatus.
* Fixed a number of bugs with capi controllers.
* Moved cluster name label used on MachineSets to a common location.