### PR TITLE
Verify that generated mocks are up-to-date

### DIFF
--- a/build/generate-mocks.sh
+++ b/build/generate-mocks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script verifies that the generated code for the client matches
+# what would be generated currently. It will error out and print the
+# first difference found.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+go generate ./pkg/controller


### PR DESCRIPTION
Fail CI when the generated mocks are not up-to-date, built with the latest version of gomock and mockgen.