### PR TITLE
Fix infra controller lookup of infra machineset size.

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -588,37 +588,6 @@ func GetClustopInfraSize(cluster *clusteroperator.CombinedCluster) (int, error) 
 	return 0, fmt.Errorf("no machineset of type Infra found")
 }
 
-// GetCAPIInfraSize gets the size of the infra machine set for the cluster.
-func GetCAPIInfraSize(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (int, error) {
-	machineSet, err := GetCAPIInfraMachineSet(cluster, machineSetLister)
-	if err != nil {
-		return 0, err
-	}
-	size := machineSet.Spec.Replicas
-	if size == nil {
-		return 1, nil
-	}
-	return int(*size), nil
-}
-
-// GetCAPIInfraMachineSet gets the infra machine set for the cluster.
-func GetCAPIInfraMachineSet(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (*clusterapi.MachineSet, error) {
-	machineSets, err := CAPIMachineSetsForCluster(cluster.Namespace, cluster.Name, machineSetLister)
-	if err != nil {
-		return nil, err
-	}
-	for _, ms := range machineSets {
-		clustopSpec, err := MachineSetSpecFromClusterAPIMachineSpec(&ms.Spec.Template.Spec)
-		if err != nil {
-			continue
-		}
-		if clustopSpec.Infra {
-			return ms, nil
-		}
-	}
-	return nil, fmt.Errorf("no infra machineset found")
-}
-
 // GetCAPIMasterMachineSet gets the master machine set for the cluster.
 func GetCAPIMasterMachineSet(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (*clusterapi.MachineSet, error) {
 	machineSets, err := CAPIMachineSetsForCluster(cluster.Namespace, cluster.Name, machineSetLister)

--- a/pkg/controller/infra/infra_controller_test.go
+++ b/pkg/controller/infra/infra_controller_test.go
@@ -173,10 +173,9 @@ apiVersion: "clusteroperator.openshift.io/v1alpha1"
 kind: "ClusterProviderConfigSpec"
 machineSets:
 - shortName: master
-  masterSetConfig:
-    nodeType: master
-    infra: true
-    size: 3
+  nodeType: master
+  infra: true
+  size: 3
 `
 	cluster := &clusterapi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This was set up to look for a infra capi.MachineSet to get the size,
however we do not create this in the root cluster, so the infra job was
not spawning.

Instead it should use the co.Cluster.Spec.MachineSets just as we did
previously.