### PR TITLE
Update image for cluster API controllers in root cluster.

### DIFF
--- a/contrib/ansible/deploy-playbook.yml
+++ b/contrib/ansible/deploy-playbook.yml
@@ -30,6 +30,9 @@
     # Cluster operator git repository to build:
     cluster_operator_git_repo: "https://github.com/openshift/cluster-operator"
     cluster_operator_git_ref: master
+    # Cluster API controller image to deploy on root cluster
+    cluster_api_image: "registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest"
+    cluster_api_image_pull_policy: "Always"
 
   tasks:
   - import_role:
@@ -154,6 +157,8 @@
       template_file: "{{ playbook_dir }}/../examples/cluster-api-controllers-template.yaml"
       parameters:
         CLUSTER_API_NAMESPACE: "{{ cluster_operator_namespace }}"
+        CLUSTER_API_IMAGE: "{{ cluster_api_image }}"
+        IMAGE_PULL_POLICY: "{{ cluster_api_image_pull_policy }}"
     register: cluster_api_controllers
 
   - name: deploy cluster api controllers

--- a/contrib/examples/cluster-api-controllers-template.yaml
+++ b/contrib/examples/cluster-api-controllers-template.yaml
@@ -118,7 +118,7 @@ parameters:
   value: openshift-cluster-operator
 # location of cluster-api container image
 - name: CLUSTER_API_IMAGE
-  value: quay.io/openshift/kubernetes-cluster-api:latest
+  value: registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest
 # machine controller image
 - name: DEFAULT_AVAILABILITY_ZONE
   value: us-east-1c


### PR DESCRIPTION
Root cluster was still deploying the old quay.io image, this should match what was done for the target cluster recently.