### PR TITLE
Fix verify-mocks refusing to run due to untracked files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,10 +242,10 @@ verify-client-gen: .init .generate_exes
 
 verify-mocks:
 	@echo Running verify mocks generation
-	@[ `git status -s | head -c1 | wc -c` -eq 0 ] || \
-	    (echo "Cannot vefify mocks while there are uncommited changes" && false)
+	@git diff --quiet && git diff --cached --quiet || \
+	    (echo "Cannot verify mocks while there are uncommited changes" && false)
 	@$(DOCKER_CMD) $(BUILD_DIR)/generate-mocks.sh
-	@[ `git status -s | head -c1 | wc -c` -eq 0 ] || \
+	@git diff --quiet && git diff --cached --quiet || \
 	    (echo "Please run \"make .generate_mocks\"" && false)
 
 format: .init


### PR DESCRIPTION
Common to have temporary files, logs, and patches laying around
a git repo, verify-mocks was refusing to run despite these files not
being tracked by git.

Switch to a more forgiving method of checking for local changes.