### PR TITLE
Add controller to add masters to internal/external ELB.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ verify: .init .generate_exes verify-generated verify-client-gen verify-mocks
 	@echo Running gofmt:
 	@$(DOCKER_CMD) gofmt -l -s $(TOP_SRC_DIRS)>.out 2>&1||true
 	@[ ! -s .out ] || \
-	  (echo && echo "*** Please 'gofmt' the following:" && \
+	  (echo && echo "*** Please 'gofmt -s -d' on the following:" && \
 	  cat .out && echo && rm .out && false)
 	@rm .out
 	@#

--- a/cmd/cluster-operator-controller-manager/app/options/options.go
+++ b/cmd/cluster-operator-controller-manager/app/options/options.go
@@ -70,6 +70,7 @@ func NewCMServer() *CMServer {
 			ConcurrentComponentSyncs:         defaultConcurrentSyncs,
 			ConcurrentNodeConfigSyncs:        defaultConcurrentSyncs,
 			ConcurrentDeployClusterAPISyncs:  defaultConcurrentSyncs,
+			ConcurrentELBMachineSyncs:        defaultConcurrentSyncs,
 			ConcurrentClusterDeploymentSyncs: defaultConcurrentSyncs,
 			LeaderElection:                   leaderelectionconfig.DefaultLeaderElectionConfiguration(),
 			LeaderElectionNamespace:          defaultLeaderElectionNamespace,
@@ -104,6 +105,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.Int32Var(&s.ConcurrentNodeConfigSyncs, "concurrent-nodeconfig-syncs", s.ConcurrentNodeConfigSyncs, "The number of clusters that are allowed to configure the node config daemonset concurrently. Larger number = more responsive node config jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentDeployClusterAPISyncs, "concurrent-deploy-cluster-api-syncs", s.ConcurrentDeployClusterAPISyncs, "The number of master machine set objects that are allowed to install the upstream cluster API controllers concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentClusterDeploymentSyncs, "concurrent-cluster-deployment-syncs", s.ConcurrentClusterDeploymentSyncs, "The number of cluster deployment objects that are allowed to sync concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
+	fs.Int32Var(&s.ConcurrentELBMachineSyncs, "concurrent-elb-machine-syncs", s.ConcurrentELBMachineSyncs, "The number of master machine objects that are allowed to be added to the internal/external AWS ELB concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.BoolVar(&s.EnableProfiling, "profiling", s.EnableProfiling, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.BoolVar(&s.EnableContentionProfiling, "contention-profiling", s.EnableContentionProfiling, "Enable lock contention profiling, if profiling is enabled")
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -103,6 +103,11 @@ type ControllerManagerConfiguration struct {
 	// sync concurrently. Larger number = more responsive processing but more CPU (and network) load.
 	ConcurrentClusterDeploymentSyncs int32
 
+	// ConcurrentELBMachineSyncs is the number of master machine objects that are
+	// allowed to sync concurrently in the controller which adds them to the internal/external master ELBs.
+	// Larger number = more responsive master machines, but more CPU (and network) load.
+	ConcurrentELBMachineSyncs int32
+
 	// leaderElection defines the configuration of leader election client.
 	LeaderElection componentconfig.LeaderElectionConfiguration
 

--- a/pkg/clusterapi/aws/actuator.go
+++ b/pkg/clusterapi/aws/actuator.go
@@ -390,16 +390,15 @@ func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 		// but instance could be deleted between the two calls.
 		return fmt.Errorf("attempted to update machine but no instances found")
 	}
-	SortInstances(instances)
+	newestInstance, terminateInstances := SortInstances(instances)
 
 	// In very unusual circumstances, there could be more than one machine running matching this
 	// machine name and cluster ID. In this scenario we will keep the newest, and delete all others.
-	newestInstance := instances[0]
 	mLog = mLog.WithField("instanceID", *newestInstance.InstanceId)
 	mLog.Debug("instance found")
 
 	if len(instances) > 1 {
-		err = TerminateInstances(client, instances[1:], mLog)
+		err = TerminateInstances(client, terminateInstances, mLog)
 		if err != nil {
 			return err
 		}

--- a/pkg/clusterapi/aws/utils.go
+++ b/pkg/clusterapi/aws/utils.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+)
+
+// SortInstances sorts the given slice of instances based on their launch time. The first item in the
+// slice after sorting will be the most recently launched, and can be considered the definitive instance
+// for the machine, a caller may wish to terminate all others. This function should only be called with
+// running instances, not those which are stopped or terminated.
+func SortInstances(instances []*ec2.Instance) {
+	sort.Slice(instances, func(i, j int) bool {
+		if instances[i].LaunchTime == nil && instances[j].LaunchTime == nil {
+			// No idea what to do here, should not be possible, just return the first.
+			return false
+		}
+		if instances[i].LaunchTime != nil && instances[j].LaunchTime == nil {
+			return true
+		}
+		if instances[i].LaunchTime == nil && instances[j].LaunchTime != nil {
+			return false
+		}
+		if (*instances[i].LaunchTime).After(*instances[j].LaunchTime) {
+			return true
+		}
+		return false
+	})
+}
+
+// GetInstance returns the AWS instance for a given machine. If multiple instances match our machine,
+// the most recently launched will be returned. If no instance exists, an error will be returned.
+func GetInstance(machine *clusterv1.Machine, client ec2iface.EC2API) (*ec2.Instance, error) {
+	instances, err := GetRunningInstances(machine, client)
+	if err != nil {
+		return nil, err
+	}
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("no instance found for machine: %s", machine.Name)
+	}
+
+	SortInstances(instances)
+	return instances[0], nil
+}
+
+// GetRunningInstances returns all running instances that have a tag matching our machine name,
+// and cluster ID.
+func GetRunningInstances(machine *clusterv1.Machine, client ec2iface.EC2API) ([]*ec2.Instance, error) {
+
+	machineName := machine.Name
+
+	clusterID, ok := getClusterID(machine)
+	if !ok {
+		return []*ec2.Instance{}, fmt.Errorf("unable to get cluster ID for machine: %s", machine.Name)
+	}
+
+	// Query instances with our machine's name, and in running/pending state.
+	request := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []*string{&machineName},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []*string{aws.String("running"), aws.String("pending")},
+			},
+			{
+				Name:   aws.String("tag:clusterid"),
+				Values: []*string{&clusterID},
+			},
+		},
+	}
+	result, err := client.DescribeInstances(request)
+	if err != nil {
+		return []*ec2.Instance{}, err
+	}
+
+	instances := make([]*ec2.Instance, 0, len(result.Reservations))
+	for _, reservation := range result.Reservations {
+		for _, instance := range reservation.Instances {
+			instances = append(instances, instance)
+		}
+	}
+
+	return instances, nil
+}
+
+// CreateAWSClients creates clients for the AWS services we use, using either the cluster AWS credentials secret
+// if defined (i.e. in the root cluster), otherwise the IAM profile of the master where the
+// actuator will run. (target clusters)
+func CreateAWSClients(kubeClient kubernetes.Interface, mSpec *cov1.MachineSetSpec, namespace, region string) (ec2iface.EC2API, elbiface.ELBAPI, error) {
+	awsConfig := &aws.Config{Region: aws.String(region)}
+
+	if mSpec.ClusterHardware.AWS == nil {
+		return nil, nil, fmt.Errorf("no AWS cluster hardware set on machine spec")
+	}
+
+	// If the cluster specifies an AWS credentials secret and it exists, use it for our client credentials:
+	if mSpec.ClusterHardware.AWS.AccountSecret.Name != "" {
+		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(
+			mSpec.ClusterHardware.AWS.AccountSecret.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+		accessKeyID, ok := secret.Data[awsCredsSecretIDKey]
+		if !ok {
+			return nil, nil, fmt.Errorf("AWS credentials secret %v did not contain key %v",
+				mSpec.ClusterHardware.AWS.AccountSecret.Name, awsCredsSecretIDKey)
+		}
+		secretAccessKey, ok := secret.Data[awsCredsSecretAccessKey]
+		if !ok {
+			return nil, nil, fmt.Errorf("AWS credentials secret %v did not contain key %v",
+				mSpec.ClusterHardware.AWS.AccountSecret.Name, awsCredsSecretAccessKey)
+		}
+
+		awsConfig.Credentials = credentials.NewStaticCredentials(
+			string(accessKeyID), string(secretAccessKey), "")
+	}
+
+	// Otherwise default to relying on the IAM role of the masters where the actuator is running:
+	s, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ec2.New(s), elb.New(s), nil
+}
+
+// TerminateInstances terminates all provided instances with a single EC2 request.
+func TerminateInstances(client ec2iface.EC2API, instances []*ec2.Instance, mLog log.FieldLogger) error {
+	instanceIDs := []*string{}
+	// Cleanup all older instances:
+	for _, instance := range instances[1:] {
+		mLog.WithFields(log.Fields{
+			"instanceID": *instance.InstanceId,
+			"state":      *instance.State.Name,
+			"launchTime": *instance.LaunchTime,
+		}).Warn("cleaning up extraneous instance for machine")
+		instanceIDs = append(instanceIDs, instance.InstanceId)
+	}
+	for _, instanceID := range instanceIDs {
+		mLog.WithField("instanceID", *instanceID).Info("terminating instance")
+	}
+
+	terminateInstancesRequest := &ec2.TerminateInstancesInput{
+		InstanceIds: instanceIDs,
+	}
+	_, err := client.TerminateInstances(terminateInstancesRequest)
+	if err != nil {
+		mLog.Errorf("error terminating instances: %v", err)
+		return fmt.Errorf("error terminating instances: %v", err)
+	}
+	return nil
+}

--- a/pkg/clusterapi/aws/utils_test.go
+++ b/pkg/clusterapi/aws/utils_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func TestSortInstances(t *testing.T) {
+	cases := []struct {
+		name                    string
+		instances               []*ec2.Instance
+		expectedFirstInstanceID string
+	}{
+		{
+			name: "only one",
+			instances: []*ec2.Instance{
+				buildInstance("i1", time.Now().Add(time.Minute*60)),
+			},
+			expectedFirstInstanceID: "i1",
+		},
+		{
+			name: "multiple running instances",
+			instances: []*ec2.Instance{
+				buildInstance("i1", time.Now().Add(-time.Minute*60)),
+				buildInstance("i2", time.Now().Add(-time.Minute*10)),
+				buildInstance("i3", time.Now().Add(-time.Minute*30)),
+				buildInstance("i4", time.Now().Add(-time.Minute*90)),
+			},
+			expectedFirstInstanceID: "i2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SortInstances(tc.instances)
+			assert.Equal(t, tc.expectedFirstInstanceID, *tc.instances[0].InstanceId)
+		})
+	}
+}
+
+func buildInstance(instanceID string, launchTime time.Time) *ec2.Instance {
+	return &ec2.Instance{
+		InstanceId: &instanceID,
+		LaunchTime: &launchTime,
+	}
+}

--- a/pkg/controller/awselb/aws_elb_controller.go
+++ b/pkg/controller/awselb/aws_elb_controller.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awselb
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+
+	capicommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	informers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
+	lister "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
+
+	clustopv1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	clustopclient "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	clustopaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+	"github.com/openshift/cluster-operator/pkg/controller"
+	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
+	clustoplog "github.com/openshift/cluster-operator/pkg/logging"
+)
+
+const (
+	// maxRetries is the number of times a service will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuings of a service.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
+	maxRetries     = 15
+	controllerName = "awselb"
+)
+
+// NewController returns a new *Controller.
+func NewController(machineInformer informers.MachineInformer, kubeClient kubeclientset.Interface, clustopClient clustopclient.Interface) *Controller {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	// TODO: remove the wrapper when every clients have moved to use the clientset.
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
+
+	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("clusteroperator_awselb_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+	}
+
+	c := &Controller{
+		client:     clustopClient,
+		kubeClient: kubeClient,
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "awselb"),
+	}
+
+	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addMachine,
+		UpdateFunc: c.updateMachine,
+		DeleteFunc: c.deleteMachine,
+	})
+	c.machinesLister = machineInformer.Lister()
+	c.machinesSynced = machineInformer.Informer().HasSynced
+
+	c.syncHandler = c.syncMachine
+	c.enqueueMachine = c.enqueue
+	c.logger = log.WithField("controller", controllerName)
+
+	return c
+}
+
+// Controller monitors master machines and adds to ELBs as appropriate.
+type Controller struct {
+	client     clustopclient.Interface
+	kubeClient kubeclientset.Interface
+
+	// To allow injection of syncMachine for testing.
+	syncHandler func(hKey string) error
+	// used for unit testing
+	enqueueMachine func(machine *capiv1.Machine)
+
+	// machinesLister is able to list/get machines and is populated by the shared informer passed to
+	// NewController.
+	machinesLister lister.MachineLister
+	// machinesSynced returns true if the machine shared informer has been synced at least once.
+	// Added as a member to the struct to allow injection for testing.
+	machinesSynced cache.InformerSynced
+
+	// Machines that need to be synced
+	queue workqueue.RateLimitingInterface
+
+	logger log.FieldLogger
+}
+
+func (c *Controller) addMachine(obj interface{}) {
+	machine := obj.(*capiv1.Machine)
+
+	if !controller.MachineHasRole(machine, capicommon.MasterRole) {
+		clustoplog.WithMachine(c.logger, machine).Debug("skipping non-master machine")
+		return
+	}
+
+	clustoplog.WithMachine(c.logger, machine).Debug("adding machine")
+	c.enqueueMachine(machine)
+}
+
+func (c *Controller) updateMachine(old, cur interface{}) {
+	oldMachine := old.(*capiv1.Machine)
+	curMachine := cur.(*capiv1.Machine)
+
+	if !controller.MachineHasRole(curMachine, capicommon.MasterRole) {
+		clustoplog.WithMachine(c.logger, curMachine).Debug("skipping non-master machine")
+		return
+	}
+
+	clustoplog.WithMachine(c.logger, oldMachine).Infof("updating machine")
+	c.enqueueMachine(curMachine)
+}
+
+func (c *Controller) deleteMachine(obj interface{}) {
+
+	machine, ok := obj.(*capiv1.Machine)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			return
+		}
+		machine, ok = tombstone.Obj.(*capiv1.Machine)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Machine %#v", obj))
+			return
+		}
+	}
+
+	if !controller.MachineHasRole(machine, capicommon.MasterRole) {
+		clustoplog.WithMachine(c.logger, machine).Debug("skipping non-master machine")
+		return
+	}
+
+	clustoplog.WithMachine(c.logger, machine).Infof("deleting machine")
+	c.enqueueMachine(machine)
+}
+
+// Run runs c; will not return until stopCh is closed. workers determines how
+// many machines will be handled in parallel.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	log.Infof("Starting awselb controller")
+	defer log.Infof("Shutting down awselb controller")
+
+	if !controller.WaitForCacheSync("machine", stopCh, c.machinesSynced) {
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *Controller) enqueue(machine *capiv1.Machine) {
+	key, err := controller.KeyFunc(machine)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", machine, err))
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncHandler(key.(string))
+	c.handleErr(err, key)
+
+	return true
+}
+
+func (c *Controller) handleErr(err error, key interface{}) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	if c.queue.NumRequeues(key) < maxRetries {
+		c.logger.Infof("Error syncing machine %v: %v", key, err)
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	utilruntime.HandleError(err)
+	c.logger.Infof("Dropping machine %q out of the queue: %v", key, err)
+	c.queue.Forget(key)
+}
+
+// syncMachine will sync the machine with the given key.
+// This function is not meant to be invoked concurrently with the same key.
+func (c *Controller) syncMachine(key string) error {
+	startTime := time.Now()
+	c.logger.WithField("key", key).Debug("syncing machine")
+	defer func() {
+		c.logger.WithFields(log.Fields{
+			"key":      key,
+			"duration": time.Now().Sub(startTime),
+		}).Debug("finished syncing machine")
+	}()
+
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	machine, err := c.machinesLister.Machines(ns).Get(name)
+	if errors.IsNotFound(err) {
+		c.logger.WithField("key", key).Info("machine has been deleted")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	mLog := clustoplog.WithMachine(c.logger, machine)
+
+	clusterID, ok := machine.Labels[clustopv1.ClusterNameLabel]
+	if !ok {
+		return fmt.Errorf("unable to lookup cluster for machine: %s", machine.Name)
+	}
+
+	coMachineSetSpec, err := controller.MachineSetSpecFromClusterAPIMachineSpec(&machine.Spec)
+	if err != nil {
+		return err
+	}
+
+	region := coMachineSetSpec.ClusterHardware.AWS.Region
+	mLog.Debugf("Obtaining AWS clients for region %q", region)
+	ec2Client, elbClient, err := clustopaws.CreateAWSClients(c.kubeClient, coMachineSetSpec, machine.Namespace, region)
+	if err != nil {
+		return err
+	}
+
+	instance, err := clustopaws.GetInstance(machine, ec2Client)
+	if err != nil {
+		return err
+	}
+	mLog = mLog.WithField("instanceID", *instance.InstanceId)
+
+	err = c.addInstanceToELB(instance, fmt.Sprintf("%s-master-external", clusterID), elbClient, mLog)
+	if err != nil {
+		return err
+	}
+	err = c.addInstanceToELB(instance, fmt.Sprintf("%s-master-internal", clusterID), elbClient, mLog)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) addInstanceToELB(
+	instance *ec2.Instance,
+	elbName string,
+	elbClient elbiface.ELBAPI,
+	mLog log.FieldLogger) error {
+
+	registerInput := elb.RegisterInstancesWithLoadBalancerInput{
+		Instances:        []*elb.Instance{{InstanceId: instance.InstanceId}},
+		LoadBalancerName: aws.String(elbName),
+	}
+
+	// This API call appears to be idempotent, so for now no need to check if the instance is
+	// registered first, we can just request that it be added.
+	_, err := elbClient.RegisterInstancesWithLoadBalancer(&registerInput)
+	if err != nil {
+		return err
+	}
+	mLog.WithField("elb", elbName).Infof("instance added to ELB")
+	return nil
+}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -46,6 +46,7 @@ import (
 	clustopclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
 	clustopinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions"
 	"github.com/openshift/cluster-operator/pkg/controller"
+	"github.com/openshift/cluster-operator/pkg/controller/awselb"
 	componentscontroller "github.com/openshift/cluster-operator/pkg/controller/components"
 	deployclusterapicontroller "github.com/openshift/cluster-operator/pkg/controller/deployclusterapi"
 	infracontroller "github.com/openshift/cluster-operator/pkg/controller/infra"
@@ -481,6 +482,15 @@ func startServerAndControllers(t *testing.T) (
 				fakeKubeClient,
 				clustopClient,
 				capiClient,
+			)
+			return func() { controller.Run(1, stopCh) }
+		}(),
+		// awselb
+		func() func() {
+			controller := awselb.NewController(
+				capiSharedInformers.Machines(),
+				fakeKubeClient,
+				clustopClient,
 			)
 			return func() { controller.Run(1, stopCh) }
 		}(),


### PR DESCRIPTION
Watches machines, and if they're masters adds them to internal/external ELB. This happens on every machine sync, the API call appears idempotent, however if we feel this is too much chatter I could modify to only re-try adding to the ELB after a certain amount of time has elapsed since successfully being added.

Also disables the check for deprovisioning remote machinesets as we do not
currently create them, and this blocks the infra deprovision job and
thus cluster deletion.