### PR TITLE
Temporarily allow infra deprovision without deleting remote machinesets.

### DIFF
--- a/pkg/controller/infra/infra_controller.go
+++ b/pkg/controller/infra/infra_controller.go
@@ -408,11 +408,13 @@ func (s *jobSyncStrategy) UpdateOwnerStatus(original, owner metav1.Object) error
 }
 
 func (s *jobSyncStrategy) CanUndo(owner metav1.Object) bool {
-	cluster, ok := owner.(*clusteroperator.CombinedCluster)
+	_, ok := owner.(*clusteroperator.CombinedCluster)
 	if !ok {
 		return false
 	}
-	return cluster.ClusterDeploymentStatus.DeprovisionedComputeMachinesets
+	// TODO: re-enable as soon as remote machine sets are operational again.
+	// return cluster.ClusterDeploymentStatus.DeprovisionedComputeMachinesets
+	return true
 }
 
 func convertJobSyncConditionType(conditionType controller.JobSyncConditionType) clusteroperator.ClusterConditionType {


### PR DESCRIPTION
These machinesets are not currently being created and nothing sets this
required status boolean as a result. As such capi.Clusters cannot be
deleted right now, as they are blocked by the infra deprovision
finalizer which never gets removed.

Until we are creating remote machinesets again this check should just
return true.