### PR TITLE
Create a fake cluster operator environment by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@
 
 ## Deploy / Re-deploy Cluster Operator
 
+| **WARNING** |
+| ---- |
+| By default when using `deploy-devel-playbook.yml` to deploy cluster operator, fake images will be used. This means that no actual cluster will be created. If you want to create a real cluster, pass `-e fake_deployment=false` to the playbook invocation. |
+
   * Deploy cluster operator to the OpenShift cluster you are currently logged into. (see above for oc login instructions above)
     * `ansible-playbook contrib/ansible/deploy-devel-playbook.yml`
     * This creates an OpenShift BuildConfig and ImageStream for the cluster-operator image. (which does not yet exist)
@@ -64,7 +68,6 @@
 
   * `ansible-playbook contrib/ansible/create-cluster-playbook.yml`
     * This will create a cluster named after your username in your current context's namespace, using a fake ClusterVersion. (no actual resources will be provisioned, the Ansible image used will just verify the playbook called exists, and return indicating success)
-    * Specify `-e cluster_version` to use a real cluster version and provision an actual cluster in AWS. (see `oc get clusterversions -n openshift-cluster-operator` for list of the defaults we create)
     * Specify `-e cluster_name`, `-e cluster_namespace`, or other variables you can override as defined at the top of the playbook.
     * This command can be re-run to update the definition of the cluster and test how the cluster operator will respond to the change. (WARNING: do not try to change the name/namespace, as this will create a new cluster)
 

--- a/build/fake-machine-controller/Dockerfile
+++ b/build/fake-machine-controller/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install ca-certificates -y && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY fake-machine-controller opt/services/fake-machine-controller
+
+ENTRYPOINT ["/opt/services/fake-machine-controller"]

--- a/cmd/fake-machine-controller/machine-controller.go
+++ b/cmd/fake-machine-controller/machine-controller.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/apiserver/pkg/util/logs"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
+
+	"sigs.k8s.io/cluster-api/pkg/controller/config"
+	"sigs.k8s.io/cluster-api/pkg/controller/machine"
+	"sigs.k8s.io/cluster-api/pkg/controller/sharedinformers"
+
+	"github.com/openshift/cluster-operator/pkg/clusterapi/fake"
+)
+
+var (
+	defaultAvailabilityZone string
+	logLevel                string
+)
+
+const (
+	controllerLogName = "fakeMachine"
+	defaultLogLevel   = "info"
+)
+
+func init() {
+	config.ControllerConfig.AddFlags(pflag.CommandLine)
+	pflag.CommandLine.StringVar(&defaultAvailabilityZone, "default-availability-zone", "us-east-1c", "Default availability zone for machines created by this controller.")
+	pflag.CommandLine.StringVar(&logLevel, "log-level", defaultLogLevel, "Log level (debug,info,warn,error,fatal)")
+}
+
+func main() {
+	pflag.Parse()
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	config, err := controller.GetConfig(config.ControllerConfig.Kubeconfig)
+	if err != nil {
+		glog.Fatalf("Could not create Config for talking to the apiserver: %v", err)
+	}
+
+	log.SetOutput(os.Stdout)
+	if lvl, err := log.ParseLevel(logLevel); err != nil {
+		log.Panic(err)
+	} else {
+		log.SetLevel(lvl)
+	}
+
+	logger := log.WithField("controller", controllerLogName)
+	actuator := fake.NewActuator(logger)
+	shutdown := make(chan struct{})
+	si := sharedinformers.NewSharedInformers(config, shutdown)
+	c := machine.NewMachineController(config, si, actuator)
+	c.Run(shutdown)
+	select {}
+}

--- a/contrib/ansible/create-cluster-playbook.yml
+++ b/contrib/ansible/create-cluster-playbook.yml
@@ -15,9 +15,8 @@
     # ID for your cluster, defaults to current username:
     cluster_name: "{{ lookup ('env', 'USER') }}"
 
-    # ClusterVersion to use, default to fake so we don't actually create a cluster unless user
-    # explicitly opts-in:
-    cluster_version: origin-v3-10-fake
+    # ClusterVersion to use
+    cluster_version: origin-v3-10
 
     # Namespace where we expect cluster version to exist, does not have to match the cluster namespace
     # and generally this can be left as is:
@@ -163,5 +162,4 @@
     kubectl_apply:
       definition: "{{ new_cluster_reg.result | to_json }}"
     when: new_cluster_api
-
 

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -6,28 +6,43 @@
 # devel specific tasks.
 ---
 
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: set default variable values
+    set_fact:
+      # Namespace to deploy CO to:
+      cluster_operator_namespace: "{{ cluster_operator_namespace | default('openshift-cluster-operator') }}"
+
+      # Namespace for cluster versions:
+      cluster_version_namespace: "{{ cluster_version_namespace | default('openshift-cluster-operator') }}"
+
+      # Images to deploy on target cluster
+      cluster_api_image: "{{ cluster_api_image | default('registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest') }}"
+      cluster_api_image_pull_policy: "{{ cluster_api_image_pull_policy | default('Always') }}"
+      machine_controller_image: "{{ machine_controller_image | default('registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest') }}"
+      machine_controller_image_pull_policy: "{{ machine_controller_image_pull_policy | default('Always') }}"
+
+      fake_deployment: "{{ fake_deployment | default(True) }}"
+      ansible_image: "{{ ansible_image | default('cluster-operator-ansible:canary') }}"
+      ansible_image_pull_policy: "{{ ansible_image_pull_policy | default('Never') }}"
+
+      # Normally we assume to build and push images for devel deployments:
+      push_images: "{{ push_images | default(True) }}"
+
 # Perform a normal deployment:
 - import_playbook: deploy-playbook.yml
+
 
 - hosts: localhost
   connection: local
   gather_facts: no
-  vars:
-    # Namespace to deploy CO to:
-    cluster_operator_namespace: "openshift-cluster-operator"
-
-    # Namespace for cluster versions:
-    cluster_version_namespace: "openshift-cluster-operator"
-
-    # Images to deploy on target cluster
-    cluster_api_image: "registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest"
-    cluster_api_image_pull_policy: "Always"
-    machine_controller_image: "registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest"
-    machine_controller_image_pull_policy: "Always"
-
-    # Normally we assume to build and push images for devel deployments:
-    push_images: True
   tasks:
+  - name: set ansible image name
+    set_fact:
+      ansible_image: "fake-openshift-ansible:canary"
+    when: fake_deployment | bool
 
   - name: build images off latest source
     shell: make images
@@ -66,6 +81,8 @@
         CLUSTER_API_IMAGE_PULL_POLICY: "{{ cluster_api_image_pull_policy }}"
         MACHINE_CONTROLLER_IMAGE: "{{ machine_controller_image }}"
         MACHINE_CONTROLLER_IMAGE_PULL_POLICY: "{{ machine_controller_image_pull_policy }}"
+        ANSIBLE_IMAGE: "{{ ansible_image }}"
+        ANSIBLE_IMAGE_PULL_POLICY: "{{ ansible_image_pull_policy }}"
     register: cluster_versions_reg
 
   - name: create/update cluster versions
@@ -86,3 +103,12 @@
       msg: 'Unable to create cluster versions'
     when: not create_versions_result is succeeded
 
+  - name: describe deployment
+    debug:
+      msg: "WARNING: You have created a cluster operator deployment with fake images. Clusters will not be created on your cloud provider."
+    when: fake_deployment | bool
+
+  - name: describe deployment
+    debug:
+      msg: "WARNING: You have created a cluster operator deployment with real images. Creating a cluster will result in artifacts provisioned to your cloud provider."
+    when: not (fake_deployment | bool)

--- a/contrib/ansible/deploy-playbook.yml
+++ b/contrib/ansible/deploy-playbook.yml
@@ -34,12 +34,22 @@
     cluster_api_image: "registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest"
     cluster_api_image_pull_policy: "Always"
 
+    fake_deployment: False
+    machine_controller_imagestream: "cluster-operator"
+    machine_controller_entrypoint: "/opt/services/aws-machine-controller"
+
   tasks:
   - import_role:
       name: kubectl-ansible
   - set_fact:
       cluster_operator_namespace: "{{ cli_cluster_operator_namespace }}"
     when: cli_cluster_operator_namespace is defined
+
+  - name: set AWS machine controller image
+    set_fact:
+      machine_controller_imagestream: "fake-machine-controller"
+      machine_controller_entrypoint: "/opt/services/fake-machine-controller"
+    when: fake_deployment | bool
 
   - name: check if cluster operator namespace exists
     command: "oc get namespace {{ cluster_operator_namespace }}"
@@ -158,6 +168,8 @@
       parameters:
         CLUSTER_API_NAMESPACE: "{{ cluster_operator_namespace }}"
         CLUSTER_API_IMAGE: "{{ cluster_api_image }}"
+        MACHINE_CONTROLLER_IMAGESTREAM: "{{ machine_controller_imagestream }}"
+        MACHINE_CONTROLLER_ENTRYPOINT: "{{ machine_controller_entrypoint }}"
         IMAGE_PULL_POLICY: "{{ cluster_api_image_pull_policy }}"
     register: cluster_api_controllers
 

--- a/contrib/examples/cluster-api-controllers-template.yaml
+++ b/contrib/examples/cluster-api-controllers-template.yaml
@@ -30,7 +30,7 @@ objects:
           from:
             # Uses the same ImageStream as our main controllers:
             kind: "ImageStreamTag"
-            name: "cluster-operator:latest"
+            name: "${MACHINE_CONTROLLER_IMAGESTREAM}:latest"
     replicas: 1
     revisionHistoryLimit: 4
     template:
@@ -41,10 +41,10 @@ objects:
         serviceAccountName: cluster-api-controller-manager
         containers:
         - name: machine-controller
-          image: cluster-operator:latest
+          image: " "
           imagePullPolicy: ${IMAGE_PULL_POLICY}
           command:
-          - /opt/services/aws-machine-controller
+          - ${MACHINE_CONTROLLER_ENTRYPOINT}
           args:
           - --log-level=debug
           - --default-availability-zone=${DEFAULT_AVAILABILITY_ZONE}
@@ -129,3 +129,7 @@ parameters:
   value: Always
 - name: BOOTSTRAP_KUBECONFIG
   value: ""
+- name: MACHINE_CONTROLLER_IMAGESTREAM
+  value: cluster-operator
+- name: MACHINE_CONTROLLER_ENTRYPOINT
+  value: /opt/services/aws-machine-controller

--- a/contrib/examples/cluster-versions-template.yaml
+++ b/contrib/examples/cluster-versions-template.yaml
@@ -12,11 +12,9 @@ parameters:
 - name: ANSIBLE_IMAGE
   displayName: Openshift Ansible Image
   description: Name and tag of the Openshift Ansible image to use to run the ansible jobs
-  value: "cluster-operator-ansible:canary"
 - name: ANSIBLE_IMAGE_PULL_POLICY
   displayName: Openshift Ansible Image Pull Policy
   description: Policy to use when pulling the Openshift Ansible image
-  value: "Always"
 - name: CLUSTER_API_IMAGE
   displayName: Cluster API Image
   description: Name and tag of the image to use for the Cluster API on the target cluster
@@ -49,30 +47,8 @@ objects:
     deploymentType: origin
     version: "v3.10.0"
     # TODO: Update after jdiaz incoming work is merged:
-    openshiftAnsibleImage: cluster-operator-ansible:canary
-    openshiftAnsibleImagePullPolicy: Never
-    clusterAPIImage: "${CLUSTER_API_IMAGE}"
-    clusterAPIImagePullPolicy: "${CLUSTER_API_IMAGE_PULL_POLICY}"
-    machineControllerImage: "${MACHINE_CONTROLLER_IMAGE}"
-    machineControllerImagePullPolicy: "${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}"
-
-
-- apiVersion: clusteroperator.openshift.io/v1alpha1
-  kind: ClusterVersion
-  metadata:
-    name: origin-v3-10-fake
-    namespace: ${CLUSTER_VERSION_NS}
-  spec:
-    imageFormat: "openshift/origin-${component}:v3.10.0"
-    vmImages:
-      awsVMImages:
-        regionAMIs:
-        - region: us-east-1
-          ami: ami-0e8468df91f4e8b6c
-    deploymentType: origin
-    version: "v3.10.0"
-    openshiftAnsibleImage: fake-openshift-ansible:canary
-    openshiftAnsibleImagePullPolicy: Never
+    openshiftAnsibleImage: "${ANSIBLE_IMAGE}"
+    openshiftAnsibleImagePullPolicy: "${ANSIBLE_IMAGE_PULL_POLICY}"
     clusterAPIImage: "${CLUSTER_API_IMAGE}"
     clusterAPIImagePullPolicy: "${CLUSTER_API_IMAGE_PULL_POLICY}"
     machineControllerImage: "${MACHINE_CONTROLLER_IMAGE}"

--- a/pkg/clusterapi/fake/actuator.go
+++ b/pkg/clusterapi/fake/actuator.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	clustoplog "github.com/openshift/cluster-operator/pkg/logging"
+)
+
+// Actuator is a fake actuator
+type Actuator struct {
+	logger   *log.Entry
+	machines sync.Map
+}
+
+// NewActuator returns a new fake Actuator
+func NewActuator(logger *log.Entry) *Actuator {
+	actuator := &Actuator{
+		logger: logger,
+	}
+	return actuator
+}
+
+// Create logs a create call
+func (a *Actuator) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("creating machine %#v", machine)
+	a.machines.LoadOrStore(machineKey(machine), true)
+	return nil
+}
+
+// Delete logs a delete call
+func (a *Actuator) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("deleting machine %#v", machine)
+	a.machines.Delete(machineKey(machine))
+	return nil
+}
+
+// Update logs an update call
+func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("updating machine %#v", machine)
+	if _, ok := a.machines.Load(machineKey(machine)); !ok {
+		return fmt.Errorf("machine not found")
+	}
+	return nil
+}
+
+// Exists logs the exists call and returns true
+func (a *Actuator) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
+	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("checking if machine exists")
+	_, ok := a.machines.Load(machineKey(machine))
+	return ok, nil
+}
+
+func machineKey(machine *clusterv1.Machine) string {
+	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
+}


### PR DESCRIPTION
Adds a fake machine controller and introduces a variable that can be set on deployment to either use real or fake images.

Whether you use a real or fake cluster now depends on the `use_real_images` variable passed to the deploy-devel-playbook and not on which cluster_version is used to create the cluster.