### PR TITLE
Include "undo" in the name of undo jobs

### DIFF
--- a/pkg/controller/jobsync.go
+++ b/pkg/controller/jobsync.go
@@ -144,8 +144,13 @@ func (s *jobSync) Sync(key string) error {
 		lastJobSuccess = reprocessStrategy.GetLastJobSuccess(owner)
 	}
 
-	jobControlResult, job, err := s.jobControl.ControlJobs(key, owner, needsProcessing,
-		reprocessInterval, lastJobSuccess, jobFactory)
+	extraJobIdentifier := ""
+	if deleting {
+		extraJobIdentifier = "undo"
+	}
+
+	jobControlResult, job, err := s.jobControl.ControlJobs(key, owner, extraJobIdentifier,
+		needsProcessing, reprocessInterval, lastJobSuccess, jobFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobsync_test.go
+++ b/pkg/controller/jobsync_test.go
@@ -150,7 +150,7 @@ func TestJobSyncForDeletedOwner(t *testing.T) {
 			if tc.expectControl {
 				mockJobSyncStrategy.EXPECT().GetJobFactory(owner, true).
 					Return(mockJobFactory, nil)
-				mockJobControl.EXPECT().ControlJobs(testKey, owner, true, nil, nil, mockJobFactory).
+				mockJobControl.EXPECT().ControlJobs(testKey, owner, "undo", true, nil, nil, mockJobFactory).
 					Return(JobControlNoWork, nil, nil)
 			}
 
@@ -214,7 +214,7 @@ func TestJobSyncWithErrorControllingJobs(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlResult(""), nil, fmt.Errorf("error controlling jobs"))
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -246,7 +246,7 @@ func TestJobSyncWithPendingExpectationsResult(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlPendingExpectations, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -278,7 +278,7 @@ func TestJobSyncWithNoWorkResult(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlNoWork, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -369,7 +369,11 @@ func TestJobSyncForCompletedJob(t *testing.T) {
 			}
 			mockJobSyncStrategy.EXPECT().GetJobFactory(owner, tc.deleting).
 				Return(mockJobFactory, nil)
-			mockJobControl.EXPECT().ControlJobs(testKey, owner, true, nil, nil, mockJobFactory).
+			extraJobIdentifier := ""
+			if tc.deleting {
+				extraJobIdentifier = "undo"
+			}
+			mockJobControl.EXPECT().ControlJobs(testKey, owner, extraJobIdentifier, true, nil, nil, mockJobFactory).
 				Return(JobControlJobSucceeded, job, nil)
 
 			// Update owner status to reflect completed job
@@ -480,7 +484,11 @@ func TestJobSyncForFailedJob(t *testing.T) {
 			}
 			mockJobSyncStrategy.EXPECT().GetJobFactory(owner, tc.deleting).
 				Return(mockJobFactory, nil)
-			mockJobControl.EXPECT().ControlJobs(testKey, owner, true, nil, nil, mockJobFactory).
+			extraJobIdentifier := ""
+			if tc.deleting {
+				extraJobIdentifier = "undo"
+			}
+			mockJobControl.EXPECT().ControlJobs(testKey, owner, extraJobIdentifier, true, nil, nil, mockJobFactory).
 				Return(JobControlJobFailed, job, nil)
 
 			// Update owner status to reflect failed job
@@ -536,7 +544,7 @@ func TestJobSyncForInProgressJob(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlJobWorking, job, nil)
 
 	// Update owner status to reflect in-progress job
@@ -574,7 +582,7 @@ func TestJobSyncWithJobWorkingResultButNoJobReturned(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlJobWorking, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -606,7 +614,7 @@ func TestJobSyncWithCreatingJobResult(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlCreatingJob, nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)
@@ -638,7 +646,7 @@ func TestJobSyncWithUnkownJobsResult(t *testing.T) {
 		Return(needsProcessing)
 	mockJobSyncStrategy.EXPECT().GetJobFactory(owner, false).
 		Return(mockJobFactory, nil)
-	mockJobControl.EXPECT().ControlJobs(testKey, owner, needsProcessing, nil, nil, mockJobFactory).
+	mockJobControl.EXPECT().ControlJobs(testKey, owner, "", needsProcessing, nil, nil, mockJobFactory).
 		Return(JobControlResult("other-result"), nil, nil)
 
 	jobSync := NewJobSync(mockJobControl, mockJobSyncStrategy, false, logger)

--- a/pkg/controller/mockjobcontrol_generated_test.go
+++ b/pkg/controller/mockjobcontrol_generated_test.go
@@ -67,8 +67,8 @@ func (mr *MockJobControlMockRecorder) OnDelete(obj interface{}) *gomock.Call {
 }
 
 // ControlJobs mocks base method
-func (m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, buildNewJob bool, reprocessInterval *time.Duration, lastJobSuccess *time.Time, jobFactory JobFactory) (JobControlResult, *v1.Job, error) {
-	ret := m.ctrl.Call(m, "ControlJobs", ownerKey, owner, buildNewJob, reprocessInterval, lastJobSuccess, jobFactory)
+func (m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, extraJobIdentifier string, buildNewJob bool, reprocessInterval *time.Duration, lastJobSuccess *time.Time, jobFactory JobFactory) (JobControlResult, *v1.Job, error) {
+	ret := m.ctrl.Call(m, "ControlJobs", ownerKey, owner, extraJobIdentifier, buildNewJob, reprocessInterval, lastJobSuccess, jobFactory)
 	ret0, _ := ret[0].(JobControlResult)
 	ret1, _ := ret[1].(*v1.Job)
 	ret2, _ := ret[2].(error)
@@ -76,8 +76,8 @@ func (m *MockJobControl) ControlJobs(ownerKey string, owner v11.Object, buildNew
 }
 
 // ControlJobs indicates an expected call of ControlJobs
-func (mr *MockJobControlMockRecorder) ControlJobs(ownerKey, owner, buildNewJob, reprocessInterval, lastJobSuccess, jobFactory interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlJobs", reflect.TypeOf((*MockJobControl)(nil).ControlJobs), ownerKey, owner, buildNewJob, reprocessInterval, lastJobSuccess, jobFactory)
+func (mr *MockJobControlMockRecorder) ControlJobs(ownerKey, owner, extraJobIdentifier, buildNewJob, reprocessInterval, lastJobSuccess, jobFactory interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlJobs", reflect.TypeOf((*MockJobControl)(nil).ControlJobs), ownerKey, owner, extraJobIdentifier, buildNewJob, reprocessInterval, lastJobSuccess, jobFactory)
 }
 
 // ObserveOwnerDeletion mocks base method


### PR DESCRIPTION
Undo jobs will have "undo" in their names. For example, the undo infra job will have a name like `infra-undo-test-cluster-6r9tl`.