### PR TITLE
WIP: Run master install whenever new machines need it

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-operator/aws/install_masters.yml
+++ b/build/cluster-operator-ansible/playbooks/cluster-operator/aws/install_masters.yml
@@ -1,6 +1,22 @@
 ---
 # call openshift-ansible's master provisioning
-- import_playbook: ../../aws/openshift-cluster/install.yml
+# Skip setting up the master group
+- name: set the master facts for hostname to elb
+  hosts: masters
+  gather_facts: no
+  remote_user: root
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: master_facts.yml
+
+- name: run the init
+  import_playbook: ../../init/main.yml
+
+- import_playbook: ../../openshift-checks/private/install.yml
+
+- name: configure the control plane
+  import_playbook: ../../common/private/control_plane.yml
 
 # The below piece of ansible would be needed if we wanted to only
 # do the save-kubeconfig-from-target-cluster steps that follow.

--- a/cmd/cluster-operator-controller-manager/app/controllermanager.go
+++ b/cmd/cluster-operator-controller-manager/app/controllermanager.go
@@ -539,6 +539,7 @@ func startMasterController(ctx ControllerContext) (bool, error) {
 	go master.NewController(
 		ctx.ClusterAPIInformerFactory.Cluster().V1alpha1().Clusters(),
 		ctx.ClusterAPIInformerFactory.Cluster().V1alpha1().MachineSets(),
+		ctx.ClusterAPIInformerFactory.Cluster().V1alpha1().Machines(),
 		ctx.KubeInformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.KubeClientOrDie("clusteroperator-master-controller"),
 		ctx.ClientBuilder.ClientOrDie("clusteroperator-master-controller"),

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -322,10 +322,15 @@ etcd
 
 [OSEv3:vars]
 ansible_become=true
-[[ $machines := .MachineNames ]]
-[[ $sections := makeSlice "masters" "etcd" "nodes" ]][[ range $sections ]][[ . | printf "[%s]" ]]
-[[ range $machines ]][[ . ]]
+
+[masters]
+[[ range .MachineNames ]][[ . ]]
 [[ end ]]
+[etcd]
+[[ range .MachineNames ]][[ . ]]
+[[ end ]]
+[nodes]
+[[ range .MachineNames ]][[ . ]]
 [[ end ]]
 `
 )
@@ -498,13 +503,9 @@ func GenerateClusterWideVarsForMachineSetWithInfraSize(
 	return buf.String(), nil
 }
 
+// GenerateInventoryForMasterMachines generates an inventory for the given master machines
 func GenerateInventoryForMasterMachines(machines []*capi.Machine) (string, error) {
-
-	makeSlice := func(args ...interface{}) []interface{} {
-		return args
-	}
-	funcMap := map[string]interface{}{"makeSlice": makeSlice}
-	t, err := template.New("inventory").Delims("[[", "]]").Funcs(template.FuncMap(funcMap)).Parse(masterMachinesInventory)
+	t, err := template.New("inventory").Delims("[[", "]]").Parse(masterMachinesInventory)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -24,6 +24,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	capi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
 	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	"github.com/openshift/cluster-operator/pkg/controller"
 )
@@ -312,6 +314,20 @@ ansible_become=true
 
 [nodes]
 `
+	masterMachinesInventory = `
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+ansible_become=true
+[[ $machines := .MachineNames ]]
+[[ $sections := makeSlice "masters" "etcd" "nodes" ]][[ range $sections ]][[ . | printf "[%s]" ]]
+[[ range $machines ]][[ . ]]
+[[ end ]]
+[[ end ]]
+`
 )
 
 type clusterParams struct {
@@ -342,6 +358,10 @@ type clusterVersionParams struct {
 	Release     string
 	AMI         string
 	ImageFormat string
+}
+
+type inventoryParams struct {
+	MachineNames []string
 }
 
 // GenerateClusterWideVars generates the vars to pass to the ansible playbook
@@ -476,4 +496,50 @@ func GenerateClusterWideVarsForMachineSetWithInfraSize(
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func GenerateInventoryForMasterMachines(machines []*capi.Machine) (string, error) {
+
+	makeSlice := func(args ...interface{}) []interface{} {
+		return args
+	}
+	funcMap := map[string]interface{}{"makeSlice": makeSlice}
+	t, err := template.New("inventory").Delims("[[", "]]").Funcs(template.FuncMap(funcMap)).Parse(masterMachinesInventory)
+	if err != nil {
+		return "", err
+	}
+
+	machinePublicNames, err := getMachinePublicNames(machines)
+	if err != nil {
+		return "", err
+	}
+
+	params := &inventoryParams{
+		MachineNames: machinePublicNames,
+	}
+
+	var buf bytes.Buffer
+	err = t.Execute(&buf, params)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func getMachinePublicNames(machines []*capi.Machine) ([]string, error) {
+	result := []string{}
+	for _, m := range machines {
+		providerStatus, err := controller.AWSMachineProviderStatusFromClusterAPIMachine(m)
+		if err != nil {
+			return nil, err
+		}
+		if providerStatus == nil {
+			return nil, fmt.Errorf("no AWS provider status in machine %s/%s", m.Namespace, m.Name)
+		}
+		if providerStatus.PublicDNS == nil {
+			return nil, fmt.Errorf("no public DNS name is set for %s/%s", m.Namespace, m.Name)
+		}
+		result = append(result, *providerStatus.PublicDNS)
+	}
+	return result, nil
 }

--- a/pkg/ansible/jobgeneratorexecutor.go
+++ b/pkg/ansible/jobgeneratorexecutor.go
@@ -170,19 +170,23 @@ func (e *JobGeneratorExecutor) WithServiceAccount(serviceAccount *kapi.ServiceAc
 	return e
 }
 
+// WithMasterMachines sets a set of master machines so that the job will run
+// with an inventory generated from those machines. It also annotates the job
+// with the list of machines used.
 func (e *JobGeneratorExecutor) WithMasterMachines(machines []*capi.Machine) *JobGeneratorExecutor {
 	e.masterMachines = machines
 	return e
 }
 
 func serializeMachineKeys(machines []*capi.Machine) string {
-	keys := []string{}
-	for _, m := range machines {
-		keys = append(keys, fmt.Sprintf("%s/%s", m.Namespace, m.Name))
+	keys := make([]string, len(machines))
+	for i, m := range machines {
+		keys[i] = fmt.Sprintf("%s/%s", m.Namespace, m.Name)
 	}
 	return strings.Join(keys, ",")
 }
 
+// SetJobMachineKeys sets an annotation on the job that contains a comma-separated list of machine keys
 func SetJobMachineKeys(job *kbatch.Job, machines []*capi.Machine) {
 	if job.Annotations == nil {
 		job.Annotations = map[string]string{}
@@ -190,6 +194,7 @@ func SetJobMachineKeys(job *kbatch.Job, machines []*capi.Machine) {
 	job.Annotations[machineKeysAnnotation] = serializeMachineKeys(machines)
 }
 
+// GetJobMachineKeys retrieves a list of machine keys from an annotation on the job
 func GetJobMachineKeys(job *kbatch.Job) []string {
 	result := []string{}
 	value, ok := job.Annotations[machineKeysAnnotation]

--- a/pkg/ansible/jobgeneratorexecutor.go
+++ b/pkg/ansible/jobgeneratorexecutor.go
@@ -17,11 +17,18 @@ limitations under the License.
 package ansible
 
 import (
+	"fmt"
+	"strings"
+
 	kbatch "k8s.io/api/batch/v1"
 	kapi "k8s.io/api/core/v1"
 
+	capi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
 	clustop "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
+
+const machineKeysAnnotation = "clusteroperator.openshift.io/machines"
 
 // JobGeneratorExecutor is used to execute a JobGenerator to create a job for
 // a cluster.
@@ -34,6 +41,7 @@ type JobGeneratorExecutor struct {
 	forMasterMachineSet bool
 	infraSize           *int
 	serviceAccount      *kapi.ServiceAccount
+	masterMachines      []*capi.Machine
 }
 
 // NewJobGeneratorExecutorForCluster creates a JobGeneratorExecutor
@@ -111,12 +119,20 @@ func (e *JobGeneratorExecutor) Execute(name string) (*kbatch.Job, *kapi.ConfigMa
 		job       *kbatch.Job
 		configMap *kapi.ConfigMap
 	)
+	inventory := DefaultInventory
+	if e.masterMachines != nil {
+		inventory, err = GenerateInventoryForMasterMachines(e.masterMachines)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	if e.serviceAccount == nil {
 		job, configMap = e.jobGenerator.GeneratePlaybooksJob(
 			name,
 			&e.cluster.ClusterDeploymentSpec.Hardware,
 			e.playbooks,
-			DefaultInventory,
+			inventory,
 			vars,
 			image,
 			pullPolicy,
@@ -126,12 +142,16 @@ func (e *JobGeneratorExecutor) Execute(name string) (*kbatch.Job, *kapi.ConfigMa
 			name,
 			&e.cluster.ClusterDeploymentSpec.Hardware,
 			e.playbooks,
-			DefaultInventory,
+			inventory,
 			vars,
 			image,
 			pullPolicy,
 			e.serviceAccount,
 		)
+	}
+
+	if e.masterMachines != nil {
+		SetJobMachineKeys(job, e.masterMachines)
 	}
 	return job, configMap, nil
 }
@@ -148,4 +168,33 @@ func (e *JobGeneratorExecutor) WithInfraSize(size int) *JobGeneratorExecutor {
 func (e *JobGeneratorExecutor) WithServiceAccount(serviceAccount *kapi.ServiceAccount) *JobGeneratorExecutor {
 	e.serviceAccount = serviceAccount
 	return e
+}
+
+func (e *JobGeneratorExecutor) WithMasterMachines(machines []*capi.Machine) *JobGeneratorExecutor {
+	e.masterMachines = machines
+	return e
+}
+
+func serializeMachineKeys(machines []*capi.Machine) string {
+	keys := []string{}
+	for _, m := range machines {
+		keys = append(keys, fmt.Sprintf("%s/%s", m.Namespace, m.Name))
+	}
+	return strings.Join(keys, ",")
+}
+
+func SetJobMachineKeys(job *kbatch.Job, machines []*capi.Machine) {
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Annotations[machineKeysAnnotation] = serializeMachineKeys(machines)
+}
+
+func GetJobMachineKeys(job *kbatch.Job) []string {
+	result := []string{}
+	value, ok := job.Annotations[machineKeysAnnotation]
+	if !ok {
+		return result
+	}
+	return strings.Split(value, ",")
 }

--- a/pkg/controller/clusterinstall/controller.go
+++ b/pkg/controller/clusterinstall/controller.go
@@ -68,7 +68,6 @@ func NewController(
 	playbooks []string,
 	clusterInformer capiinformers.ClusterInformer,
 	machineSetInformer capiinformers.MachineSetInformer,
-	machineInformer capiinformers.MachineInformer,
 	jobInformer batchinformers.JobInformer,
 	kubeClient kubeclientset.Interface,
 	clustopClient clustopclientset.Interface,
@@ -113,15 +112,6 @@ func NewController(
 		UpdateFunc: c.updateMachineSet,
 		DeleteFunc: c.deleteMachineSet,
 	})
-
-	if machineInformer != nil {
-		machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    c.addMachine,
-			UpdateFunc: c.updateMachine,
-			DeleteFunc: c.deleteMachine,
-		})
-		c.machinesSynced = machineInformer.Informer().HasSynced
-	}
 
 	jobOwnerControl := &jobOwnerControl{controller: c}
 	c.jobControl = controller.NewJobControl(controllerName, clusterKind, kubeClient, jobInformer.Lister(), jobOwnerControl, logger)
@@ -185,6 +175,17 @@ type Controller struct {
 	queue workqueue.RateLimitingInterface
 
 	Logger log.FieldLogger
+}
+
+// SetMachineInformer allows to optionally set a machine informer on the controller so that
+// machine events will also result in queues of their corresponding machine deployments.
+func (c *Controller) SetMachineInformer(machineInformer capiinformers.MachineInformer) {
+	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addMachine,
+		UpdateFunc: c.updateMachine,
+		DeleteFunc: c.deleteMachine,
+	})
+	c.machinesSynced = machineInformer.Informer().HasSynced
 }
 
 func (c *Controller) addCluster(obj interface{}) {
@@ -421,21 +422,11 @@ func (c *Controller) handleErr(err error, key interface{}) {
 }
 
 func isMasterMachineSet(machineSet *capi.MachineSet) bool {
-	for _, role := range machineSet.Spec.Template.Spec.Roles {
-		if role == capicommon.MasterRole {
-			return true
-		}
-	}
-	return false
+	return controller.MachineSetHasRole(machineSet, capicommon.MasterRole)
 }
 
 func isMasterMachine(machine *capi.Machine) bool {
-	for _, role := range machine.Spec.Roles {
-		if role == capicommon.MasterRole {
-			return true
-		}
-	}
-	return false
+	return controller.MachineHasRole(capicommon.MasterRole)
 }
 
 type jobFactory func(string) (*v1batch.Job, *kapi.ConfigMap, error)

--- a/pkg/controller/components/components_controller.go
+++ b/pkg/controller/components/components_controller.go
@@ -63,6 +63,7 @@ func NewController(
 		playbooks,
 		clusterInformer,
 		machineSetInformer,
+		nil,
 		jobInformer,
 		kubeClient,
 		clustopClient,

--- a/pkg/controller/components/components_controller.go
+++ b/pkg/controller/components/components_controller.go
@@ -63,7 +63,6 @@ func NewController(
 		playbooks,
 		clusterInformer,
 		machineSetInformer,
-		nil,
 		jobInformer,
 		kubeClient,
 		clustopClient,

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -631,6 +631,16 @@ func MachineHasRole(machine *clusterapi.Machine, role capicommon.MachineRole) bo
 	return false
 }
 
+// MachineSetHasRole returns true if the machine set has the given cluster-api role.
+func MachineSetHasRole(machineSet *clusterapi.MachineSet, role capicommon.MachineRole) bool {
+	for _, r := range machineSet.Spec.Template.Spec.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
 // ELBMasterExternalName gets the name of the external master ELB for the cluster
 // with the specified cluster ID.
 func ELBMasterExternalName(clusterID string) string {
@@ -696,6 +706,7 @@ func BuildClusterAPIMachineSet(ms *clusteroperator.ClusterMachineSet, clusterDep
 	return &capiMachineSet, nil
 }
 
+// MasterMachineSetName returns the name of the master machineset for the given cluster deployment name
 func MasterMachineSetName(clusterDeploymentName string) string {
 	return fmt.Sprintf("%s-%s", clusterDeploymentName, clusteroperator.MasterMachineSetName)
 }

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -255,6 +255,18 @@ func ClusterForMachineSet(machineSet *clusterapi.MachineSet, clusterLister capil
 	return clusterLister.Clusters(machineSet.Namespace).Get(clusterName)
 }
 
+// ClusterForMachine retrieves the cluster to which a machine belongs.
+func ClusterForMachine(machine *clusterapi.Machine, clusterLister capilister.ClusterLister) (*clusterapi.Cluster, error) {
+	if machine.Labels == nil {
+		return nil, fmt.Errorf("missing %s label", clusteroperator.ClusterNameLabel)
+	}
+	clusterName, ok := machine.Labels[clusteroperator.ClusterNameLabel]
+	if !ok {
+		return nil, fmt.Errorf("missing %s label", clusteroperator.ClusterNameLabel)
+	}
+	return clusterLister.Clusters(machine.Namespace).Get(clusterName)
+}
+
 // MachineSetsForCluster retrieves the machinesets associated with the
 // specified cluster name.
 func MachineSetsForCluster(namespace string, clusterName string, machineSetsLister capilister.MachineSetLister) ([]*clusterapi.MachineSet, error) {
@@ -682,4 +694,8 @@ func BuildClusterAPIMachineSet(ms *clusteroperator.ClusterMachineSet, clusterDep
 	capiMachineSet.Spec.Template.Spec.ProviderConfig.Value = providerConfig
 
 	return &capiMachineSet, nil
+}
+
+func MasterMachineSetName(clusterDeploymentName string) string {
+	return fmt.Sprintf("%s-%s", clusterDeploymentName, clusteroperator.MasterMachineSetName)
 }

--- a/pkg/controller/deployclusterapi/deployclusterapi_controller.go
+++ b/pkg/controller/deployclusterapi/deployclusterapi_controller.go
@@ -57,6 +57,7 @@ func NewController(
 		[]string{playbook},
 		clusterInformer,
 		machineSetInformer,
+		nil,
 		jobInformer,
 		kubeClient,
 		clustopClient,

--- a/pkg/controller/master/master_controller.go
+++ b/pkg/controller/master/master_controller.go
@@ -79,12 +79,12 @@ func NewController(
 		[]string{playbook},
 		clusterInformer,
 		machineSetInformer,
-		machineInformer,
 		jobInformer,
 		kubeClient,
 		clustopClient,
 		capiClient,
 	)
+	controller.SetMachineInformer(machineInformer)
 	installStrategy.logger = controller.Logger
 	return controller
 }

--- a/pkg/controller/nodeconfig/nodeconfig_controller.go
+++ b/pkg/controller/nodeconfig/nodeconfig_controller.go
@@ -57,6 +57,7 @@ func NewController(
 		[]string{playbook},
 		clusterInformer,
 		machineSetInformer,
+		nil,
 		jobInformer,
 		kubeClient,
 		clustopClient,


### PR DESCRIPTION
The master controller now generates an inventory based on which machines are available at the time the controller runs. It uses the Status.Versions.ControlPlane field to keep track of which Machines have had the master job run on them.