### PR TITLE
Remove AWS credentials before syncing cluster/machinesets

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -663,7 +663,7 @@ func trimForELBBasename(s string, maxLen int) string {
 // objects (ClusterMachineSet/ClusterDeploymentSpec/ClusterVersion) in the provided 'namespace'
 func BuildClusterAPIMachineSet(ms *clusteroperator.ClusterMachineSet, clusterDeploymentSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion *clusteroperator.ClusterVersion, namespace string) (*clusterapi.MachineSet, error) {
 	capiMachineSet := clusterapi.MachineSet{}
-	capiMachineSet.Name = ms.ShortName
+	capiMachineSet.Name = fmt.Sprintf("%s-%s", clusterDeploymentSpec.ClusterID, ms.ShortName)
 	capiMachineSet.Namespace = namespace
 	replicas := int32(ms.Size)
 	capiMachineSet.Spec.Replicas = &replicas

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -388,6 +388,10 @@ func (c *Controller) syncCluster(cluster *clusterapiv1.Cluster, clusterDeploymen
 // create new cluster from cluster deployment and update the namespace to the
 // remote namespace
 func createRemoteClusterAPICluster(clusterDeployment *cov1.ClusterDeployment) (*clusterapiv1.Cluster, error) {
+	if clusterDeployment.Spec.Hardware.AWS != nil {
+		clusterDeployment = clusterDeployment.DeepCopy()
+		clusterDeployment.Spec.Hardware.AWS.AccountSecret.Name = ""
+	}
 	remoteCluster, err := controller.BuildCluster(clusterDeployment)
 	if err != nil {
 		return nil, err
@@ -493,6 +497,10 @@ func (c *Controller) syncMachineSets(clusterDeployment *cov1.ClusterDeployment, 
 // return list of non-master machinesets from a given ClusterDeployment
 func computeClusterAPIMachineSetsFromClusterDeployment(clusterDeployment *cov1.ClusterDeployment, coClusterVersion *cov1.ClusterVersion) ([]*clusterapiv1.MachineSet, error) {
 	machineSets := []*clusterapiv1.MachineSet{}
+	if clusterDeployment.Spec.Hardware.AWS != nil {
+		clusterDeployment = clusterDeployment.DeepCopy()
+		clusterDeployment.Spec.Hardware.AWS.AccountSecret.Name = ""
+	}
 
 	for _, ms := range clusterDeployment.Spec.MachineSets {
 		if ms.NodeType == cov1.NodeTypeMaster {

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -49,6 +49,7 @@ const (
 	testClusterVerNS     = "cluster-operator"
 	testClusterUUID      = types.UID("test-cluster-uuid")
 	testClusterName      = "testcluster"
+	testClusterID        = "testcluster-id"
 	testClusterNamespace = "testsyncns"
 )
 
@@ -283,7 +284,7 @@ func TestMachineSetSyncing(t *testing.T) {
 			remoteMachineSets: []clusterapiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "compute",
+						Name:      testClusterID + "-compute",
 						Namespace: remoteClusterAPINamespace,
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -305,7 +306,7 @@ func TestMachineSetSyncing(t *testing.T) {
 			remoteMachineSets: []clusterapiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "compute",
+						Name:      testClusterID + "-compute",
 						Namespace: remoteClusterAPINamespace,
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -353,7 +354,7 @@ func TestMachineSetSyncing(t *testing.T) {
 			remoteMachineSets: []clusterapiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "compute",
+						Name:      testClusterID + "-compute",
 						Namespace: remoteClusterAPINamespace,
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -362,7 +363,7 @@ func TestMachineSetSyncing(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "compute2",
+						Name:      testClusterID + "-compute2",
 						Namespace: remoteClusterAPINamespace,
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -565,6 +566,7 @@ func newTestClusterDeployment(controlPlaneReady bool) *cov1.ClusterDeployment {
 			UID:       testClusterUUID,
 		},
 		Spec: cov1.ClusterDeploymentSpec{
+			ClusterID: testClusterID,
 			Hardware: cov1.ClusterHardwareSpec{
 				AWS: &cov1.AWSClusterSpec{
 					Region: testRegion,


### PR DESCRIPTION
Also use clusterID as a prefix to remote machineset names. Using clusterID for the cluster will be done in a separate pull.