### PR TITLE
Change cluster name from clusterDeployment.Name to clusterDeployment.Spec.ClusterID

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -438,7 +438,7 @@ func MachineSetSpecFromClusterAPIMachineSpec(ms *clusterapi.MachineSpec) (*clust
 // BuildCluster builds a cluster for the given cluster deployment.
 func BuildCluster(clusterDeployment *clusteroperator.ClusterDeployment) (*clusterapi.Cluster, error) {
 	cluster := &clusterapi.Cluster{}
-	cluster.Name = clusterDeployment.Name
+	cluster.Name = clusterDeployment.Spec.ClusterID
 	cluster.Labels = clusterDeployment.Labels
 	cluster.Namespace = clusterDeployment.Namespace
 	if cluster.Labels == nil {

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -316,7 +316,7 @@ func (c *Controller) syncClusterDeployment(key string) error {
 		return err
 	}
 
-	cluster, err := c.clusterInformer.Clusters(clusterDeployment.Namespace).Get(clusterDeployment.Name)
+	cluster, err := c.clusterInformer.Clusters(clusterDeployment.Namespace).Get(clusterDeployment.Spec.ClusterID)
 	if err != nil {
 		return fmt.Errorf("error retrieving cluster object: %v", err)
 	}

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -468,10 +468,10 @@ type expectedRemoteAction struct {
 	gvr       schema.GroupVersionResource
 }
 
-func getKey(cluster *cov1.ClusterDeployment, t *testing.T) string {
-	key, err := controller.KeyFunc(cluster)
+func getKey(clusterDeployment *cov1.ClusterDeployment, t *testing.T) string {
+	key, err := controller.KeyFunc(clusterDeployment)
 	if err != nil {
-		t.Errorf("Unexpected error getting key for cluster %v: %v", cluster.Name, err)
+		t.Errorf("Unexpected error getting key for clusterdeployment %v: %v", clusterDeployment.Name, err)
 		return ""
 	}
 	return key
@@ -480,7 +480,7 @@ func getKey(cluster *cov1.ClusterDeployment, t *testing.T) string {
 func newCapiCluster(t *testing.T, clusterDeployment *cov1.ClusterDeployment) clusterapiv1.Cluster {
 	cluster := clusterapiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterDeployment.Name,
+			Name:      clusterDeployment.Spec.ClusterID,
 			Namespace: clusterDeployment.Namespace,
 		},
 		Spec: clusterapiv1.ClusterSpec{


### PR DESCRIPTION
- [x] Change cluster name from clusterDeployment.Name to clusterDeployment.Spec.ClusterID
- [x] Test cluster creation results in cluster named with clusterDeployment.Spec.ClusterID
- [x] Test that infrastructure components (instances, ELBs, etc) are named with clusterDeployment.Spec.ClusterID
- [x] Ensure remotemachineset_controller unit tests pass
- [x] Ensure clusterdeployment_controller unit tests pass