### PR TITLE
Skip role creation on infra

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-operator/aws/infrastructure.yml
+++ b/build/cluster-operator-ansible/playbooks/cluster-operator/aws/infrastructure.yml
@@ -20,30 +20,30 @@
 
 - import_playbook: ../../aws/openshift-cluster/provision_elb.yml
 
-- name: Create iam roles
-  hosts: localhost
-  roles:
-  - openshift_aws
-  tasks:
-  - include_role:
-      name: openshift_aws
-      tasks_from: iam_role
-    vars:
-      l_node_group_config: "{{ openshift_aws_node_group_config }}"
-      openshift_aws_iam_node_role_name: "openshift_node_describe_instances"
-      openshift_aws_iam_node_role_policy_json: "{{ lookup('file', 'describeinstances.json') }}"
-      openshift_aws_iam_node_role_policy_name: "describe_instances"
-    loop_control:
-      loop_var: openshift_aws_node_group
-    with_items: "{{ openshift_aws_node_groups }}"
-  - include_role:
-      name: openshift_aws
-      tasks_from:  iam_role
-    vars:
-      l_node_group_config: "{{ openshift_aws_master_group_config }}"
-      openshift_aws_iam_master_role_name: "openshift_master_launch_instances"
-      openshift_aws_iam_master_role_policy_name: "launch_instances"
-      openshift_aws_iam_master_role_policy_json: "{{ lookup('template', 'launchinstances.json.j2') }}"
-    loop_control:
-      loop_var: openshift_aws_node_group
-    with_items: "{{ openshift_aws_master_group }}"
+# - name: Create iam roles
+#   hosts: localhost
+#   roles:
+#   - openshift_aws
+#   tasks:
+#   - include_role:
+#       name: openshift_aws
+#       tasks_from: iam_role
+#     vars:
+#       l_node_group_config: "{{ openshift_aws_node_group_config }}"
+#       openshift_aws_iam_node_role_name: "openshift_node_describe_instances"
+#       openshift_aws_iam_node_role_policy_json: "{{ lookup('file', 'describeinstances.json') }}"
+#       openshift_aws_iam_node_role_policy_name: "describe_instances"
+#     loop_control:
+#       loop_var: openshift_aws_node_group
+#     with_items: "{{ openshift_aws_node_groups }}"
+#   - include_role:
+#       name: openshift_aws
+#       tasks_from:  iam_role
+#     vars:
+#       l_node_group_config: "{{ openshift_aws_master_group_config }}"
+#       openshift_aws_iam_master_role_name: "openshift_master_launch_instances"
+#       openshift_aws_iam_master_role_policy_name: "launch_instances"
+#       openshift_aws_iam_master_role_policy_json: "{{ lookup('template', 'launchinstances.json.j2') }}"
+#     loop_control:
+#       loop_var: openshift_aws_node_group
+#     with_items: "{{ openshift_aws_master_group }}"


### PR DESCRIPTION
For now, skips role creation on infra until we get back to per-cluster roles.