### PR TITLE
Remove --incluster from cluster-api-controller-manager command.

### DIFF
--- a/contrib/examples/cluster-api-controllers-template.yaml
+++ b/contrib/examples/cluster-api-controllers-template.yaml
@@ -93,7 +93,6 @@ objects:
           imagePullPolicy: ${IMAGE_PULL_POLICY}
           command:
           - "./controller-manager"
-          - --incluster=false
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Removed based on https://github.com/kubernetes-sigs/cluster-api/blob/master/cloud/google/config/configtemplate.go#L120-L123.

```
$ oc logs cluster-api-controller-manager-859b5894f-c6m6b -n openshift-cluster-operator
unknown flag: --incluster
Usage of ./controller-manager:
      --kubeconfig string                      Path to kubeconfig file with authorization and master location information.
      --leader-elect                           Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.
      --leader-elect-lease-duration duration   The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 15s)
      --leader-elect-renew-deadline duration   The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 10s)
      --leader-elect-resource-lock endpoints   The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmap`. (default "endpoints")
      --leader-elect-retry-period duration     The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 2s)
      --log-flush-frequency duration           Maximum number of seconds between log flushes (default 5s)
      --workers int                            The number of workers for controller. (default 5)
```