### PR TITLE
Change node instances to 'terminate' by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ contrib/examples/*-cluster.yaml
 .kube
 .var
 .vscode
+debug.test
 *.retry
 certs/**

--- a/pkg/clusterapi/aws/actuator.go
+++ b/pkg/clusterapi/aws/actuator.go
@@ -66,11 +66,13 @@ const (
 // Instance tag constants
 // TODO: these do not match the case of the clustop or capi role names
 const (
-	hostTypeNode       = "node"
-	hostTypeMaster     = "master"
-	subHostTypeDefault = "default"
-	subHostTypeInfra   = "infra"
-	subHostTypeCompute = "compute"
+	hostTypeNode              = "node"
+	hostTypeMaster            = "master"
+	subHostTypeDefault        = "default"
+	subHostTypeInfra          = "infra"
+	subHostTypeCompute        = "compute"
+	shutdownBehaviorTerminate = "terminate"
+	shutdownBehaviorStop      = "stop"
 )
 
 var stateMask int64 = 0xFF
@@ -220,9 +222,11 @@ func (a *Actuator) CreateMachine(cluster *clusterv1.Cluster, machine *clusterv1.
 	// AWS tags.
 	hostType := hostTypeNode
 	subHostType := subHostTypeCompute
+	shutdownBehavior := shutdownBehaviorTerminate
 	if controller.MachineHasRole(machine, capicommon.MasterRole) {
 		hostType = hostTypeMaster
 		subHostType = subHostTypeDefault
+		shutdownBehavior = shutdownBehaviorStop
 	}
 	if coMachineSetSpec.Infra {
 		subHostType = subHostTypeInfra
@@ -288,6 +292,7 @@ func (a *Actuator) CreateMachine(cluster *clusterv1.Cluster, machine *clusterv1.
 		TagSpecifications:   []*ec2.TagSpecification{tagInstance, tagVolume},
 		NetworkInterfaces:   networkInterfaces,
 		UserData:            &userDataEnc,
+		InstanceInitiatedShutdownBehavior: aws.String(shutdownBehavior),
 	}
 
 	runResult, err := client.RunInstances(&inputConfig)

--- a/pkg/clusterapi/aws/actuator_test.go
+++ b/pkg/clusterapi/aws/actuator_test.go
@@ -48,19 +48,21 @@ func init() {
 }
 
 const (
-	testNamespace             = "test-namespace"
-	testClusterDeploymentName = "test-cluster-deployment"
-	testClusterDeploymentUUID = types.UID("test-cluster-deployment-uuid")
-	testClusterID             = "test-cluster-id"
-	testClusterVerName        = "v3-10"
-	testClusterVerNS          = "cluster-operator"
-	testClusterVerUID         = types.UID("test-cluster-version")
-	testRegion                = "us-east-1"
-	testImage                 = "testAMI"
-	testVPCID                 = "testVPCID"
-	testSubnetID              = "testSubnetID"
-	testAZ                    = "us-east-1c"
-	testMachineName           = "testmachine"
+	testNamespace              = "test-namespace"
+	testClusterDeploymentName  = "test-cluster-deployment"
+	testClusterDeploymentUUID  = types.UID("test-cluster-deployment-uuid")
+	testClusterID              = "test-cluster-id"
+	testClusterVerName         = "v3-10"
+	testClusterVerNS           = "cluster-operator"
+	testClusterVerUID          = types.UID("test-cluster-version")
+	testRegion                 = "us-east-1"
+	testImage                  = "testAMI"
+	testVPCID                  = "testVPCID"
+	testSubnetID               = "testSubnetID"
+	testAZ                     = "us-east-1c"
+	testMachineName            = "testmachine"
+	testShutdownBehaviorNodes  = "terminate"
+	testShutdownBehaviorMaster = "stop"
 )
 
 func TestUserDataTemplate(t *testing.T) {
@@ -268,8 +270,10 @@ func TestCreateMachine(t *testing.T) {
 				assertRunInstancesInputHasTag(t, runInput, "clusterid", testClusterID)
 				if isMaster {
 					assertRunInstancesInputHasTag(t, runInput, "host-type", "master")
+					assert.Equal(t, *runInput.InstanceInitiatedShutdownBehavior, testShutdownBehaviorMaster)
 				} else {
 					assertRunInstancesInputHasTag(t, runInput, "host-type", "node")
+					assert.Equal(t, *runInput.InstanceInitiatedShutdownBehavior, testShutdownBehaviorNodes)
 				}
 
 				if tc.isInfra {


### PR DESCRIPTION
- [x] Change the AWS shutdown behavior for node instances to "terminate"
- [x] Explicitly set the AWS shutdown behavior for master instances to "stop"
- [x] Add unit test verification for both master and node shutdown behaviors
- [x] Manually test / verify that master instances are created with the shutdown behavior set to stop
- [x] Manually test / verify that node instances are created with the shutdown behavior set to terminate