### PR TITLE
 Detect and terminate stopped nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@ contrib/examples/*-cluster.yaml
 .kube
 .var
 .vscode
-debug.test
 *.retry
 certs/**

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,7 @@ contrib/examples/*-cluster.yaml
 .kube
 .var
 .vscode
+debug.test
+debug
 *.retry
 certs/**

--- a/contrib/cmd/aws-actuator-test/main.go
+++ b/contrib/cmd/aws-actuator-test/main.go
@@ -27,7 +27,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,10 +63,10 @@ func createClusterMachine(name string) error {
 	return nil
 }
 
-func deleteClusterMachine(instanceId string) error {
+func deleteClusterMachine(instanceID string) error {
 	_, machine := testClusterAPIResources("any")
 	machine.Annotations = map[string]string{
-		instanceIDAnnotation: instanceId,
+		instanceIDAnnotation: instanceID,
 	}
 	actuator := aws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
 	err := actuator.DeleteMachine(machine)
@@ -78,10 +77,10 @@ func deleteClusterMachine(instanceId string) error {
 	return nil
 }
 
-func clusterMachineExists(instanceId string) error {
+func clusterMachineExists(instanceID string) error {
 	cluster, machine := testClusterAPIResources("any")
 	machine.Annotations = map[string]string{
-		instanceIDAnnotation: instanceId,
+		instanceIDAnnotation: instanceID,
 	}
 	actuator := aws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
 	exists, err := actuator.Exists(cluster, machine)
@@ -92,7 +91,7 @@ func clusterMachineExists(instanceId string) error {
 	return nil
 }
 
-func NewActuatorTestCommand() *cobra.Command {
+func newActuatorTestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws-actuator-test",
 		Short: "Test for Cluster API AWS actuator",
@@ -134,11 +133,10 @@ func NewActuatorTestCommand() *cobra.Command {
 }
 
 func main() {
-	pflag.Parse()
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
 
-	cmd := NewActuatorTestCommand()
+	cmd := newActuatorTestCommand()
 	err := cmd.Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error occurred: %v\n", err)
@@ -181,6 +179,7 @@ func testClusterAPIResources(name string) (*clusterv1.Cluster, *clusterv1.Machin
 			Kind:       "MachineSetProviderConfigSpec",
 		},
 		MachineSetSpec: cov1.MachineSetSpec{
+			ClusterID: name,
 			VMImage: cov1.VMImage{
 				AWSImage: awsutil.String("ami-0e8468df91f4e8b6c"),
 			},

--- a/pkg/clusterapi/aws/actuator.go
+++ b/pkg/clusterapi/aws/actuator.go
@@ -66,13 +66,11 @@ const (
 // Instance tag constants
 // TODO: these do not match the case of the clustop or capi role names
 const (
-	hostTypeNode              = "node"
-	hostTypeMaster            = "master"
-	subHostTypeDefault        = "default"
-	subHostTypeInfra          = "infra"
-	subHostTypeCompute        = "compute"
-	shutdownBehaviorTerminate = "terminate"
-	shutdownBehaviorStop      = "stop"
+	hostTypeNode       = "node"
+	hostTypeMaster     = "master"
+	subHostTypeDefault = "default"
+	subHostTypeInfra   = "infra"
+	subHostTypeCompute = "compute"
 )
 
 var stateMask int64 = 0xFF
@@ -222,11 +220,9 @@ func (a *Actuator) CreateMachine(cluster *clusterv1.Cluster, machine *clusterv1.
 	// AWS tags.
 	hostType := hostTypeNode
 	subHostType := subHostTypeCompute
-	shutdownBehavior := shutdownBehaviorTerminate
 	if controller.MachineHasRole(machine, capicommon.MasterRole) {
 		hostType = hostTypeMaster
 		subHostType = subHostTypeDefault
-		shutdownBehavior = shutdownBehaviorStop
 	}
 	if coMachineSetSpec.Infra {
 		subHostType = subHostTypeInfra
@@ -292,7 +288,6 @@ func (a *Actuator) CreateMachine(cluster *clusterv1.Cluster, machine *clusterv1.
 		TagSpecifications:   []*ec2.TagSpecification{tagInstance, tagVolume},
 		NetworkInterfaces:   networkInterfaces,
 		UserData:            &userDataEnc,
-		InstanceInitiatedShutdownBehavior: aws.String(shutdownBehavior),
 	}
 
 	runResult, err := client.RunInstances(&inputConfig)

--- a/pkg/clusterapi/aws/actuator_test.go
+++ b/pkg/clusterapi/aws/actuator_test.go
@@ -48,21 +48,19 @@ func init() {
 }
 
 const (
-	testNamespace              = "test-namespace"
-	testClusterDeploymentName  = "test-cluster-deployment"
-	testClusterDeploymentUUID  = types.UID("test-cluster-deployment-uuid")
-	testClusterID              = "test-cluster-id"
-	testClusterVerName         = "v3-10"
-	testClusterVerNS           = "cluster-operator"
-	testClusterVerUID          = types.UID("test-cluster-version")
-	testRegion                 = "us-east-1"
-	testImage                  = "testAMI"
-	testVPCID                  = "testVPCID"
-	testSubnetID               = "testSubnetID"
-	testAZ                     = "us-east-1c"
-	testMachineName            = "testmachine"
-	testShutdownBehaviorNodes  = "terminate"
-	testShutdownBehaviorMaster = "stop"
+	testNamespace             = "test-namespace"
+	testClusterDeploymentName = "test-cluster-deployment"
+	testClusterDeploymentUUID = types.UID("test-cluster-deployment-uuid")
+	testClusterID             = "test-cluster-id"
+	testClusterVerName        = "v3-10"
+	testClusterVerNS          = "cluster-operator"
+	testClusterVerUID         = types.UID("test-cluster-version")
+	testRegion                = "us-east-1"
+	testImage                 = "testAMI"
+	testVPCID                 = "testVPCID"
+	testSubnetID              = "testSubnetID"
+	testAZ                    = "us-east-1c"
+	testMachineName           = "testmachine"
 )
 
 func TestUserDataTemplate(t *testing.T) {
@@ -270,10 +268,8 @@ func TestCreateMachine(t *testing.T) {
 				assertRunInstancesInputHasTag(t, runInput, "clusterid", testClusterID)
 				if isMaster {
 					assertRunInstancesInputHasTag(t, runInput, "host-type", "master")
-					assert.Equal(t, *runInput.InstanceInitiatedShutdownBehavior, testShutdownBehaviorMaster)
 				} else {
 					assertRunInstancesInputHasTag(t, runInput, "host-type", "node")
-					assert.Equal(t, *runInput.InstanceInitiatedShutdownBehavior, testShutdownBehaviorNodes)
 				}
 
 				if tc.isInfra {


### PR DESCRIPTION
- [x] Revert commit of initial attempt at removing stopped instances (aws shutdownBehavior doesn't work in all cases).
- [x] Remove stopped nodes when new nodes are created for the same machine.
- [x] Explicitly do NOT remove stopped master instances.
- [x] Fix missing clusterid in MachineSetSpec in aws-actuator-test/main.go
- [x] Fix go linting issues in aws-actuator-test/main.go
- [x] Fix cli help messages in aws-actuator-test/main.go
