### PR TITLE
Set openshift_node_config_name in userdata.

### DIFF
--- a/contrib/examples/cluster-versions-template.yaml
+++ b/contrib/examples/cluster-versions-template.yaml
@@ -43,7 +43,7 @@ objects:
       awsVMImages:
         regionAMIs:
         - region: us-east-1
-          ami: ami-0e8468df91f4e8b6c
+          ami: ami-0dd8ad483cef75c18
     deploymentType: origin
     version: "v3.10.0"
     # TODO: Update after jdiaz incoming work is merged:

--- a/contrib/examples/clusterapi-template.yml
+++ b/contrib/examples/clusterapi-template.yml
@@ -166,7 +166,7 @@ objects:
             infra: false
             vmImage:
               # Matches origin v3-10 cluster version:
-              awsImage: ami-0e8468df91f4e8b6c
+              awsImage: ami-0dd8ad483cef75c18
 
 
 # TODO: transition these to MachineDeployments once we have the upstream controller running.

--- a/pkg/clusterapi/aws/actuator.go
+++ b/pkg/clusterapi/aws/actuator.go
@@ -547,7 +547,7 @@ write_files:
   owner: 'root:root'
   permissions: '0640'
   content: |
-    openshift_group_type: {{ .NodeType }}
+    openshift_node_config_name: {{ .NodeType }}
 {{- if .IsNode }}
 - path: /etc/origin/node/bootstrap.kubeconfig
   owner: 'root:root'

--- a/pkg/clusterapi/aws/actuator_test.go
+++ b/pkg/clusterapi/aws/actuator_test.go
@@ -81,7 +81,7 @@ write_files:
   owner: 'root:root'
   permissions: '0640'
   content: |
-    openshift_group_type: master
+    openshift_node_config_name: master
 runcmd:
 - [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]`,
 		},
@@ -95,7 +95,7 @@ write_files:
   owner: 'root:root'
   permissions: '0640'
   content: |
-    openshift_group_type: master
+    openshift_node_config_name: master
 runcmd:
 - [ ansible-playbook, /root/openshift_bootstrap/bootstrap.yml]`,
 		},
@@ -110,7 +110,7 @@ write_files:
   owner: 'root:root'
   permissions: '0640'
   content: |
-    openshift_group_type: compute
+    openshift_node_config_name: compute
 - path: /etc/origin/node/bootstrap.kubeconfig
   owner: 'root:root'
   permissions: '0640'
@@ -134,7 +134,7 @@ write_files:
   owner: 'root:root'
   permissions: '0640'
   content: |
-    openshift_group_type: infra
+    openshift_node_config_name: infra
 - path: /etc/origin/node/bootstrap.kubeconfig
   owner: 'root:root'
   permissions: '0640'


### PR DESCRIPTION
This will need to be updated on our side once https://github.com/openshift/openshift-ansible/pull/8923 is backported to 3.10 and we've created a new AMI using the updated release-3.10 branch.