### PR TITLE
Introduce separate flag to build images on deployment

### DIFF
--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -29,6 +29,7 @@
       ansible_image_pull_policy: "{{ ansible_image_pull_policy | default('Never') }}"
 
       # Normally we assume to build and push images for devel deployments:
+      build_images: "{{ build_images | default(True) }}"
       push_images: "{{ push_images | default(True) }}"
 
 # Perform a normal deployment:
@@ -48,7 +49,7 @@
     shell: make images
     args:
       chdir: "{{ playbook_dir }}/../../"
-    when: push_images | bool
+    when: build_images | bool
 
   - name: push devel images to integrated registry
     command: make integrated-registry-push


### PR DESCRIPTION
We likely don't need to rebuild images every time we deploy. This introduces a separate flag so we can control whether images should be built but still allow pushing them to the internal registry.