### PR TITLE
Use latest ansible 3.10 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,7 @@ ifeq ($(ARCH),amd64)
 endif
 
 OA_ANSIBLE_URL    ?= https://github.com/openshift/openshift-ansible.git
-OA_ANSIBLE_BRANCH ?= openshift-ansible-3.10.0-0.32.0
+OA_ANSIBLE_BRANCH ?= release-3.10
 
 define build-cluster-operator-ansible-image #(repo, branch, imagename, tag)
 	docker build -t "$3:$4" --build-arg=CO_ANSIBLE_URL=$1 --build-arg=CO_ANSIBLE_BRANCH=$2 build/cluster-operator-ansible

--- a/pkg/clusterapi/aws/actuator.go
+++ b/pkg/clusterapi/aws/actuator.go
@@ -247,12 +247,15 @@ func (a *Actuator) CreateMachine(cluster *clusterv1.Cluster, machine *clusterv1.
 	// AWS tags.
 	hostType := hostTypeNode
 	subHostType := subHostTypeCompute
+	nodeGroupConfigName := "node-config-compute"
 	if isMaster {
 		hostType = hostTypeMaster
 		subHostType = subHostTypeDefault
+		nodeGroupConfigName = "node-config-master"
 	}
 	if coMachineSetSpec.Infra {
 		subHostType = subHostTypeInfra
+		nodeGroupConfigName = "node-config-infra"
 	}
 	mLog.WithFields(log.Fields{"hostType": hostType, "subHostType": subHostType}).Debugf("creating instance with host type")
 
@@ -262,6 +265,7 @@ func (a *Actuator) CreateMachine(cluster *clusterv1.Cluster, machine *clusterv1.
 		{Key: aws.String("host-type"), Value: aws.String(hostType)},
 		{Key: aws.String("sub-host-type"), Value: aws.String(subHostType)},
 		{Key: aws.String("kubernetes.io/cluster/" + clusterSpec.ClusterID), Value: aws.String(clusterSpec.ClusterID)},
+		{Key: aws.String("openshift-node-group-config"), Value: aws.String(nodeGroupConfigName)},
 		{Key: aws.String("Name"), Value: aws.String(machine.Name)},
 	}
 	tagInstance := &ec2.TagSpecification{


### PR DESCRIPTION
Uses the latest 3.10 latest commit from openshift-ansible. Until we get a tag in that branch, we will just pull the latest.

Also modifies the actuator to add a `openshift-node-group-config` tag to the instance