### PR TITLE
handle running controller-manager in debug session

### DIFF
--- a/cmd/cluster-operator/controller-manager.go
+++ b/cmd/cluster-operator/controller-manager.go
@@ -17,19 +17,32 @@ limitations under the License.
 package main
 
 import (
+	"path"
+
 	"github.com/openshift/cluster-operator/cmd/cluster-operator-controller-manager/app"
 	"github.com/openshift/cluster-operator/cmd/cluster-operator-controller-manager/app/options"
 	"github.com/openshift/cluster-operator/pkg/hyperkube"
 )
 
+const (
+	// program name for debug builds
+	debugProgramName = "debug"
+)
+
 // NewControllerManager creates a new hyperkube Server object that includes the
 // description and flags.
-func NewControllerManager() *hyperkube.Server {
+func NewControllerManager(programName string) *hyperkube.Server {
 	s := options.NewCMServer()
+
+	altName := "cluster-operator-controller-manager"
+
+	if path.Base(programName) == debugProgramName {
+		altName = debugProgramName
+	}
 
 	hks := hyperkube.Server{
 		PrimaryName:     "controller-manager",
-		AlternativeName: "cluster-operator-controller-manager",
+		AlternativeName: altName,
 		SimpleUsage:     "controller-manager",
 		Long:            `The clusteroperator controller manager is a daemon that embeds the core control loops shipped with the clusteroperator.`,
 		Run: func(_ *hyperkube.Server, args []string, stopCh <-chan struct{}) error {

--- a/cmd/cluster-operator/main.go
+++ b/cmd/cluster-operator/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	hk.AddServer(NewAPIServer())
-	hk.AddServer(NewControllerManager())
+	hk.AddServer(NewControllerManager(os.Args[0]))
 
 	hk.RunToExit(os.Args)
 }


### PR DESCRIPTION
some environments build go binaries as 'debug' before launching the debugger. gracefully handle the posibility that controller-manager will be launched as 'debug'.