### PR TITLE
Use release-3.10 branch instead of master for cluster-operator-ansible build.

### DIFF
--- a/build/cluster-operator-ansible/Dockerfile
+++ b/build/cluster-operator-ansible/Dockerfile
@@ -15,7 +15,7 @@
 FROM openshift/origin-ansible:v3.10
 
 ARG CO_ANSIBLE_URL=https://github.com/openshift/openshift-ansible.git
-ARG CO_ANSIBLE_BRANCH=master
+ARG CO_ANSIBLE_BRANCH=release-3.10
 ARG CLONE_LOCATION=/usr/share/ansible/openshift-ansible
 
 USER root


### PR DESCRIPTION
release-3.10 has been branched for openshift-ansible so we should use it in the cluster-operator-ansible build.