### PR TITLE
Skip remote machineset cleanup when sync never happend

### DIFF
--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -438,6 +438,14 @@ type ClusterProviderStatus struct {
 
 // ClusterDeploymentStatus contains the status for a cluster
 type ClusterDeploymentStatus struct {
+	// RemoteMachineSetsSynced is true if remote machinesets have been created/updated for the
+	// target cluster
+	RemoteMachineSetsSynced bool
+
+	// RemoteMachinesetsSyncedGeneration is the generation of the cluster deployment that was
+	// last used to sync remote machinesets
+	RemoteMachineSetsSyncedGeneration int64
+
 	// Conditions includes more detailed status for the cluster
 	Conditions []ClusterCondition
 }

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -441,6 +441,14 @@ type ClusterProviderStatus struct {
 
 // ClusterDeploymentStatus contains the status for a cluster
 type ClusterDeploymentStatus struct {
+	// RemoteMachineSetsSynced is true if remote machinesets have been created/updated for the
+	// target cluster
+	RemoteMachineSetsSynced bool
+
+	// RemoteMachinesetsSyncedGeneration is the generation of the cluster deployment that was
+	// last used to sync remote machinesets
+	RemoteMachineSetsSyncedGeneration int64
+
 	// Conditions includes more detailed status for the cluster
 	Conditions []ClusterDeploymentCondition `json:"conditions"`
 }

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -421,6 +421,8 @@ func Convert_clusteroperator_ClusterDeploymentSpec_To_v1alpha1_ClusterDeployment
 }
 
 func autoConvert_v1alpha1_ClusterDeploymentStatus_To_clusteroperator_ClusterDeploymentStatus(in *ClusterDeploymentStatus, out *clusteroperator.ClusterDeploymentStatus, s conversion.Scope) error {
+	out.RemoteMachineSetsSynced = in.RemoteMachineSetsSynced
+	out.RemoteMachineSetsSyncedGeneration = in.RemoteMachineSetsSyncedGeneration
 	out.Conditions = *(*[]clusteroperator.ClusterCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }
@@ -431,6 +433,8 @@ func Convert_v1alpha1_ClusterDeploymentStatus_To_clusteroperator_ClusterDeployme
 }
 
 func autoConvert_clusteroperator_ClusterDeploymentStatus_To_v1alpha1_ClusterDeploymentStatus(in *clusteroperator.ClusterDeploymentStatus, out *ClusterDeploymentStatus, s conversion.Scope) error {
+	out.RemoteMachineSetsSynced = in.RemoteMachineSetsSynced
+	out.RemoteMachineSetsSyncedGeneration = in.RemoteMachineSetsSyncedGeneration
 	out.Conditions = *(*[]ClusterDeploymentCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -535,6 +535,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "ClusterDeploymentStatus contains the status for a cluster",
 					Properties: map[string]spec.Schema{
+						"RemoteMachineSetsSynced": {
+							SchemaProps: spec.SchemaProps{
+								Description: "RemoteMachineSetsSynced is true if remote machinesets have been created/updated for the target cluster",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
+						"RemoteMachineSetsSyncedGeneration": {
+							SchemaProps: spec.SchemaProps{
+								Description: "RemoteMachinesetsSyncedGeneration is the generation of the cluster deployment that was last used to sync remote machinesets",
+								Type:        []string{"integer"},
+								Format:      "int64",
+							},
+						},
 						"conditions": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Conditions includes more detailed status for the cluster",
@@ -549,7 +563,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"conditions"},
+					Required: []string{"RemoteMachineSetsSynced", "RemoteMachineSetsSyncedGeneration", "conditions"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
Fixes issue when clusterdeployment never gets to sync remote machinesets and gets deleted, the finalizer for the remote machinesets remains and doesn't allow the clusterdeployment to be deleted. 