### PR TITLE
Fix check for clusterversion existence

### DIFF
--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -81,7 +81,7 @@
     ignore_errors: yes
     register: cluster_version_exists_reg
     retries: 30
-    until: cluster_version_exists_reg.stderr.find("ServiceUnavailable") == -1
+    until: cluster_version_exists_reg.rc == 0 or cluster_version_exists_reg.stderr.find("NotFound") != -1
 
   - set_fact:
       process_cluster_versions: True


### PR DESCRIPTION
The reason the existence check is failing is because the ServiceUnavailable error is not the only error returned when the apiserver is not ready yet. So now just testing for either of the possible valid outcomes ... either there is no error or the error contains "NotFound". Otherwise, keep retrying.