### PR TITLE
Hookup pod and service network CIDRs in the API.

### DIFF
--- a/contrib/examples/cluster-deployment-template.yaml
+++ b/contrib/examples/cluster-deployment-template.yaml
@@ -85,6 +85,13 @@ objects:
     clusterVersionRef:
       namespace: ${CLUSTER_VERSION_NAMESPACE}
       name: ${CLUSTER_VERSION}
+    networkConfig:
+      services:
+        cidrBlocks:
+          - "172.60.0.0/20"
+      pods:
+        cidrBlocks:
+          - "10.128.10.0/24"
     hardware:
       aws:
         accountSecret:

--- a/pkg/ansible/jobgeneratorexecutor.go
+++ b/pkg/ansible/jobgeneratorexecutor.go
@@ -74,6 +74,8 @@ func (e *JobGeneratorExecutor) Execute(name string) (*kbatch.Job, *kapi.ConfigMa
 			e.cluster.AWSClusterProviderConfig.Hardware,
 			e.clusterVersion,
 			*e.infraSize,
+			e.cluster.ClusterSpec.ClusterNetwork.Services,
+			e.cluster.ClusterSpec.ClusterNetwork.Pods,
 		)
 	case e.infraSize == nil:
 		vars, err = GenerateClusterWideVarsForMachineSet(
@@ -81,6 +83,8 @@ func (e *JobGeneratorExecutor) Execute(name string) (*kbatch.Job, *kapi.ConfigMa
 			e.cluster.Name,
 			e.cluster.AWSClusterProviderConfig.Hardware,
 			e.clusterVersion,
+			e.cluster.ClusterSpec.ClusterNetwork.Services,
+			e.cluster.ClusterSpec.ClusterNetwork.Pods,
 		)
 	default:
 		vars, err = GenerateClusterWideVarsForMachineSetWithInfraSize(
@@ -89,6 +93,8 @@ func (e *JobGeneratorExecutor) Execute(name string) (*kbatch.Job, *kapi.ConfigMa
 			e.cluster.AWSClusterProviderConfig.Hardware,
 			e.clusterVersion,
 			*e.infraSize,
+			e.cluster.ClusterSpec.ClusterNetwork.Services,
+			e.cluster.ClusterSpec.ClusterNetwork.Pods,
 		)
 	}
 	if err != nil {

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -19,6 +19,7 @@ package clusteroperator
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // Annotation constants
@@ -233,6 +234,9 @@ type ClusterDeploymentSpec struct {
 	// Config specifies cluster-wide OpenShift configuration
 	Config ClusterConfigSpec
 
+	// NetworkConfig specifies cluster-wide Kubernetes networking configuration.
+	NetworkConfig capiv1.ClusterNetworkingConfig `json:"networkConfig"`
+
 	// DefaultHardwareSpec specifies hardware defaults for all machine sets
 	// in this cluster
 	// +optional
@@ -317,14 +321,6 @@ type AWSClusterSpec struct {
 type ClusterConfigSpec struct {
 	// SDNPluginName is the name of the SDN plugin to use for this install
 	SDNPluginName string
-
-	// ServiceNetworkSubnet is the CIDR to use for service IPs in the cluster
-	// +optional
-	ServiceNetworkSubnet string
-
-	// PodNetworkSubnet is the CIDR to use for pod IPs in the cluster
-	// +optional
-	PodNetworkSubnet string
 }
 
 // ClusterDeploymentType is a valid value for ClusterConfigSpec.DeploymentType

--- a/pkg/apis/clusteroperator/v1alpha1/defaults.go
+++ b/pkg/apis/clusteroperator/v1alpha1/defaults.go
@@ -18,9 +18,21 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-const defaultSSHUser = "clusteroperator"
+const (
+	defaultSSHUser = "clusteroperator"
+
+	// CIDR for service IPs. This is configured in Ansible via openshift_portal_net.
+	defaultClusterServiceCIDR = "172.30.0.0/16"
+
+	// CIDR for pod IPs. This is configured in Ansible via osm_cluster_network_cidr.
+	defaultClusterPodCIDR = "10.128.0.0/14"
+
+	// Domain for service names in the cluster. This is not configurable for OpenShift clusters.
+	defaultServiceDomain = "svc.cluster.local"
+)
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
@@ -29,5 +41,16 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 func SetDefaults_ClusterDeploymentSpec(spec *ClusterDeploymentSpec) {
 	if spec.Hardware.AWS != nil && spec.Hardware.AWS.SSHUser == "" {
 		spec.Hardware.AWS.SSHUser = defaultSSHUser
+	}
+
+	if len(spec.NetworkConfig.ServiceDomain) == 0 {
+		spec.NetworkConfig.ServiceDomain = defaultServiceDomain
+	}
+
+	if len(spec.NetworkConfig.Services.CIDRBlocks) == 0 {
+		spec.NetworkConfig.Services = capiv1.NetworkRanges{CIDRBlocks: []string{defaultClusterServiceCIDR}}
+	}
+	if len(spec.NetworkConfig.Pods.CIDRBlocks) == 0 {
+		spec.NetworkConfig.Pods = capiv1.NetworkRanges{CIDRBlocks: []string{defaultClusterPodCIDR}}
 	}
 }

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -19,8 +19,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // Annotation constants
@@ -236,6 +235,9 @@ type ClusterDeploymentSpec struct {
 	// Config specifies cluster-wide OpenShift configuration
 	Config ClusterConfigSpec `json:"config"`
 
+	// NetworkConfig specifies cluster-wide Kubernetes networking configuration.
+	NetworkConfig capiv1.ClusterNetworkingConfig `json:"networkConfig"`
+
 	// DefaultHardwareSpec specifies hardware defaults for all machine sets
 	// in this cluster
 	// +optional
@@ -320,14 +322,6 @@ type AWSClusterSpec struct {
 type ClusterConfigSpec struct {
 	// SDNPluginName is the name of the SDN plugin to use for this install
 	SDNPluginName string `json:"sdnPluginName"`
-
-	// ServiceNetworkSubnet is the CIDR to use for service IPs in the cluster
-	// +optional
-	ServiceNetworkSubnet string `json:"serviceNetowrkSubnet,omitempty"`
-
-	// PodNetworkSubnet is the CIDR to use for pod IPs in the cluster
-	// +optional
-	PodNetworkSubnet string `json:"podNetworkSubnet,omitempty"`
 }
 
 // ClusterDeploymentType is a valid value for ClusterConfigSpec.DeploymentType
@@ -687,7 +681,7 @@ type CombinedCluster struct {
 
 	AWSClusterProviderConfig *AWSClusterProviderConfig
 
-	ClusterSpec           *clusterapi.ClusterSpec
-	ClusterStatus         *clusterapi.ClusterStatus
+	ClusterSpec           *capiv1.ClusterSpec
+	ClusterStatus         *capiv1.ClusterStatus
 	ClusterProviderStatus *ClusterProviderStatus
 }

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -272,8 +272,6 @@ func Convert_clusteroperator_ClusterCondition_To_v1alpha1_ClusterCondition(in *c
 
 func autoConvert_v1alpha1_ClusterConfigSpec_To_clusteroperator_ClusterConfigSpec(in *ClusterConfigSpec, out *clusteroperator.ClusterConfigSpec, s conversion.Scope) error {
 	out.SDNPluginName = in.SDNPluginName
-	out.ServiceNetworkSubnet = in.ServiceNetworkSubnet
-	out.PodNetworkSubnet = in.PodNetworkSubnet
 	return nil
 }
 
@@ -284,8 +282,6 @@ func Convert_v1alpha1_ClusterConfigSpec_To_clusteroperator_ClusterConfigSpec(in 
 
 func autoConvert_clusteroperator_ClusterConfigSpec_To_v1alpha1_ClusterConfigSpec(in *clusteroperator.ClusterConfigSpec, out *ClusterConfigSpec, s conversion.Scope) error {
 	out.SDNPluginName = in.SDNPluginName
-	out.ServiceNetworkSubnet = in.ServiceNetworkSubnet
-	out.PodNetworkSubnet = in.PodNetworkSubnet
 	return nil
 }
 
@@ -386,6 +382,7 @@ func autoConvert_v1alpha1_ClusterDeploymentSpec_To_clusteroperator_ClusterDeploy
 	if err := Convert_v1alpha1_ClusterConfigSpec_To_clusteroperator_ClusterConfigSpec(&in.Config, &out.Config, s); err != nil {
 		return err
 	}
+	out.NetworkConfig = in.NetworkConfig
 	out.DefaultHardwareSpec = (*clusteroperator.MachineSetHardwareSpec)(unsafe.Pointer(in.DefaultHardwareSpec))
 	out.MachineSets = *(*[]clusteroperator.ClusterMachineSet)(unsafe.Pointer(&in.MachineSets))
 	if err := Convert_v1alpha1_ClusterVersionReference_To_clusteroperator_ClusterVersionReference(&in.ClusterVersionRef, &out.ClusterVersionRef, s); err != nil {
@@ -407,6 +404,7 @@ func autoConvert_clusteroperator_ClusterDeploymentSpec_To_v1alpha1_ClusterDeploy
 	if err := Convert_clusteroperator_ClusterConfigSpec_To_v1alpha1_ClusterConfigSpec(&in.Config, &out.Config, s); err != nil {
 		return err
 	}
+	out.NetworkConfig = in.NetworkConfig
 	out.DefaultHardwareSpec = (*MachineSetHardwareSpec)(unsafe.Pointer(in.DefaultHardwareSpec))
 	out.MachineSets = *(*[]ClusterMachineSet)(unsafe.Pointer(&in.MachineSets))
 	if err := Convert_clusteroperator_ClusterVersionReference_To_v1alpha1_ClusterVersionReference(&in.ClusterVersionRef, &out.ClusterVersionRef, s); err != nil {

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -306,6 +306,7 @@ func (in *ClusterDeploymentSpec) DeepCopyInto(out *ClusterDeploymentSpec) {
 	*out = *in
 	in.Hardware.DeepCopyInto(&out.Hardware)
 	out.Config = in.Config
+	in.NetworkConfig.DeepCopyInto(&out.NetworkConfig)
 	if in.DefaultHardwareSpec != nil {
 		in, out := &in.DefaultHardwareSpec, &out.DefaultHardwareSpec
 		if *in == nil {

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -305,6 +305,7 @@ func (in *ClusterDeploymentSpec) DeepCopyInto(out *ClusterDeploymentSpec) {
 	*out = *in
 	in.Hardware.DeepCopyInto(&out.Hardware)
 	out.Config = in.Config
+	in.NetworkConfig.DeepCopyInto(&out.NetworkConfig)
 	if in.DefaultHardwareSpec != nil {
 		in, out := &in.DefaultHardwareSpec, &out.DefaultHardwareSpec
 		if *in == nil {

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -50,17 +50,6 @@ const (
 	maxELBBasenameLen = 32 - 7
 
 	clusterDeploymentLabel = "clusteroperator.openshift.io/cluster-deployment"
-
-	// Domain for service names in the cluster. This is not configurable for OpenShift clusters.
-	defaultClusterServiceDomain = "svc.cluster.local"
-
-	// CIDR for service IPs. This is configured in Ansible via openshift_portal_net. However, it is not yet
-	// configurable via cluster operator.
-	defaultClusterServiceCIDR = "172.30.0.0/16"
-
-	// CIDR for pod IPs. This is configured in Ansible via osm_cluster_network_cidr. However, it is not yet
-	// configurable via cluster operator.
-	defaultClusterPodCIDR = "10.128.0.0/14"
 )
 
 var (
@@ -69,17 +58,6 @@ var (
 
 	// ClusterDeploymentKind is the GVK for a ClusterDeployment.
 	ClusterDeploymentKind = clusteroperator.SchemeGroupVersion.WithKind("ClusterDeployment")
-
-	// Domain for service names in the cluster. This is not configurable for OpenShift clusters.
-	defaultServiceDomain = "svc.cluster.local"
-
-	// CIDR for service IPs. This is configured in Ansible via openshift_portal_net. However, it is not yet
-	// configurable via cluster operator.
-	defaultServiceCIDR = "172.30.0.0/16"
-
-	// CIDR for pod IPs. This is configured in Ansible via osm_cluster_network_cidr. However, it is not yet
-	// configurable via cluster operator.
-	defaultPodCIDR = "10.128.0.0/14"
 
 	clusterKind = clusterapi.SchemeGroupVersion.WithKind("Cluster")
 
@@ -533,9 +511,7 @@ func BuildCluster(clusterDeployment *clusteroperator.ClusterDeployment, cv clust
 	cluster.Spec.ProviderConfig.Value = providerConfig
 
 	// Set networking defaults
-	cluster.Spec.ClusterNetwork.ServiceDomain = defaultServiceDomain
-	cluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{defaultPodCIDR}
-	cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{defaultServiceCIDR}
+	cluster.Spec.ClusterNetwork = clusterDeployment.Spec.NetworkConfig
 	return cluster, nil
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -319,20 +319,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
-						"serviceNetowrkSubnet": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ServiceNetworkSubnet is the CIDR to use for service IPs in the cluster",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"podNetworkSubnet": {
-							SchemaProps: spec.SchemaProps{
-								Description: "PodNetworkSubnet is the CIDR to use for pod IPs in the cluster",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
 					},
 					Required: []string{"sdnPluginName"},
 				},
@@ -498,6 +484,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterConfigSpec"),
 							},
 						},
+						"networkConfig": {
+							SchemaProps: spec.SchemaProps{
+								Description: "NetworkConfig specifies cluster-wide Kubernetes networking configuration.",
+								Ref:         ref("sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.ClusterNetworkingConfig"),
+							},
+						},
 						"defaultHardwareSpec": {
 							SchemaProps: spec.SchemaProps{
 								Description: "DefaultHardwareSpec specifies hardware defaults for all machine sets in this cluster",
@@ -524,11 +516,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"clusterID", "hardware", "config", "machineSets", "clusterVersionRef"},
+					Required: []string{"clusterID", "hardware", "config", "networkConfig", "machineSets", "clusterVersionRef"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterConfigSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterMachineSet", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterVersionReference", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterConfigSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterMachineSet", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterVersionReference", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.ClusterNetworkingConfig"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterDeploymentStatus": {
 			Schema: spec.Schema{
@@ -1378,20 +1370,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						"sdnPluginName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "SDNPluginName is the name of the SDN plugin to use for this install",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"serviceNetowrkSubnet": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ServiceNetworkSubnet is the CIDR to use for service IPs in the cluster",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"podNetworkSubnet": {
-							SchemaProps: spec.SchemaProps{
-								Description: "PodNetworkSubnet is the CIDR to use for pod IPs in the cluster",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/registry/clusteroperator/clusterdeployment/storage_test.go
+++ b/pkg/registry/clusteroperator/clusterdeployment/storage_test.go
@@ -28,6 +28,8 @@ import (
 
 	clusteroperatorapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	"github.com/openshift/cluster-operator/pkg/registry/registrytest"
+
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServer) {
@@ -60,6 +62,11 @@ func validNewClusterDeployment(name string) *clusteroperatorapi.ClusterDeploymen
 			ClusterVersionRef: clusteroperatorapi.ClusterVersionReference{
 				Namespace: "openshift-cluster-operator",
 				Name:      "v3-9",
+			},
+			NetworkConfig: capiv1.ClusterNetworkingConfig{
+				Services:      capiv1.NetworkRanges{CIDRBlocks: []string{"172.30.0.0/16"}},
+				Pods:          capiv1.NetworkRanges{CIDRBlocks: []string{"10.128.0.0/14"}},
+				ServiceDomain: "svc.cluster.local",
 			},
 		},
 	}


### PR DESCRIPTION
Re-use the cluster-api NetworkConfig struct.

Supports multiple ranges but currently validates that only one is
provided, as this appears to be all openshift-ansible supports.

Will default if none is provided.

Once set these values are immutable.