### PR TITLE
Utility to wait for existence and ready status of an API service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ build: .init .generate_files \
 	$(BINDIR)/aws-machine-controller \
 	$(BINDIR)/fake-machine-controller \
 	$(BINDIR)/aws-actuator-test \
-	$(BINDIR)/wait-for-cluster-ready
+	$(BINDIR)/wait-for-cluster-ready \
+	$(BINDIR)/wait-for-apiservice
 
 .PHONY: $(BINDIR)/cluster-operator
 cluster-operator: $(BINDIR)/cluster-operator
@@ -136,6 +137,11 @@ $(BINDIR)/fake-machine-controller: .init
 wait-for-cluster-ready: $(BINDIR)/wait-for-cluster-ready
 $(BINDIR)/wait-for-cluster-ready: .init
 	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(CLUSTER_OPERATOR_PKG)/contrib/cmd/wait-for-cluster-ready
+
+.PHONY: $(BINDIR)/wait-for-apiservice
+wait-for-apiservice: $(BINDIR)/wait-for-apiservice
+$(BINDIR)/wait-for-apiservice: .init
+	$(DOCKER_CMD) $(GO_BUILD) -o $@ $(CLUSTER_OPERATOR_PKG)/contrib/cmd/wait-for-apiservice
 
 .PHONY: $(BINDIR)/aws-actuator-test
 aws-actuator-test: $(BINDIR)/aws-actuator-test
@@ -339,7 +345,9 @@ images: cluster-operator-image \
 	cluster-operator-ansible-images \
 	fake-openshift-ansible-image \
 	aws-machine-controller-image \
-	fake-machine-controller-image
+	fake-machine-controller-image \
+	$(BINDIR)/wait-for-cluster-ready \
+	$(BINDIR)/wait-for-apiservice
 
 images-all: $(addprefix arch-image-,$(ALL_ARCH))
 arch-image-%:

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -58,13 +58,9 @@
       chdir: "{{ playbook_dir }}/../../"
     when: push_images | bool
 
-  - name: wait for apiserver deployment to finish
+  - name: wait for cluster operator apiservice
     command: |-
-      oc rollout status deploymentconfig/cluster-operator-apiserver -n {{ cluster_operator_namespace | quote }}
-
-  - name: wait for controller-manager deployment to finish
-    command: |-
-      oc rollout status deploymentconfig/cluster-operator-controller-manager -n {{ cluster_operator_namespace | quote }}
+      {{ playbook_dir }}/../../bin/wait-for-apiservice v1alpha1.clusteroperator.openshift.io
 
   - import_role:
       name: kubectl-ansible
@@ -80,8 +76,6 @@
     changed_when: false
     ignore_errors: yes
     register: cluster_version_exists_reg
-    retries: 30
-    until: cluster_version_exists_reg.rc == 0 or cluster_version_exists_reg.stderr.find("NotFound") != -1
 
   - set_fact:
       process_cluster_versions: True

--- a/contrib/cmd/wait-for-apiservice/waitforservice.go
+++ b/contrib/cmd/wait-for-apiservice/waitforservice.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Waits for a given apiservice to exist and become available
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var log *logger.Entry
+
+func main() {
+	cmd := NewWaitForAPIServiceCommand()
+	cmd.Execute()
+}
+
+type WaitForAPIServiceOptions struct {
+	Name    string
+	Timeout time.Duration
+}
+
+func NewWaitForAPIServiceCommand() *cobra.Command {
+	opt := &WaitForAPIServiceOptions{}
+	logLevel := "info"
+	cmd := &cobra.Command{
+		Use:   "wait-for-apiservice SERVICENAME",
+		Short: "Wait for an API service to exist and become available",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				cmd.Usage()
+				return
+			}
+
+			// Set log level
+			level, err := logger.ParseLevel(logLevel)
+			if err != nil {
+				logger.WithError(err).Error("Cannot parse log level")
+				os.Exit(1)
+			}
+
+			log = logger.NewEntry(&logger.Logger{
+				Out: os.Stdout,
+				Formatter: &logger.TextFormatter{
+					FullTimestamp: true,
+				},
+				Hooks: make(logger.LevelHooks),
+				Level: level,
+			})
+
+			// Run command
+			opt.Name = args[0]
+			err = opt.WaitForAPIService()
+			if err != nil {
+				log.Errorf("Error: %v", err)
+				os.Exit(1)
+			}
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&logLevel, "loglevel", "info", "log level, one of: debug, info, warn, error, fatal, panic")
+	flags.DurationVar(&opt.Timeout, "timeout", 5*time.Minute, "time to wait for API service resource to be ready")
+	return cmd
+}
+
+func (o *WaitForAPIServiceOptions) WaitForAPIService() error {
+	client, err := o.getClient()
+	if err != nil {
+		log.WithError(err).Error("Cannot obtain cluster client")
+		return err
+	}
+	err = o.waitForAPIService(client)
+	if err != nil {
+		return err
+	}
+	log.Infof("APIService %s is ready", o.Name)
+	return nil
+}
+
+func (o *WaitForAPIServiceOptions) waitForAPIService(client discovery.DiscoveryInterface) error {
+	log.Debug("Waiting for API service")
+	parts := strings.Split(o.Name, ".")
+	groupVersion := fmt.Sprintf("%s/%s", strings.Join(parts[1:], "."), parts[0])
+	err := wait.PollImmediate(5*time.Second, o.Timeout, func() (bool, error) {
+		log.WithField("groupversion", groupVersion).Debug("Fetching resources")
+		_, err := client.ServerResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			log.WithError(err).WithField("groupversion", groupVersion).Debug("Error fetching resources")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout {
+			log.WithField("timeout", o.Timeout).Error("Timed out waiting for APIService in discovery output")
+		} else {
+			log.WithError(err).Error("Unexpected error waiting to find APIService in discovery output")
+		}
+		return err
+	}
+	log.Info("APIService found in discovery output")
+	return nil
+}
+
+func (o *WaitForAPIServiceOptions) getClient() (discovery.DiscoveryInterface, error) {
+	log.Debug("Obtaining discovery client for local cluster")
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
+	cfg, err := kubeconfig.ClientConfig()
+	if err != nil {
+		log.WithError(err).Error("Cannot obtain client config")
+		return nil, err
+	}
+	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		log.WithError(err).Error("Cannot create discovery client from client config")
+		return nil, err
+	}
+	log.Debug("Obtained discovery client for local cluster")
+	return client, nil
+}


### PR DESCRIPTION
- Adds utility that waits until the API service is working and available.
- Updates the makefile to include utility binary builds in the image target
- Updates the deployment playbook so that it uses the new utility to ensure the clusteroperator apiservice is available.