### PR TITLE
registry infra controller

### DIFF
--- a/cmd/cluster-operator-controller-manager/app/options/options.go
+++ b/cmd/cluster-operator-controller-manager/app/options/options.go
@@ -74,6 +74,7 @@ func NewCMServer() *CMServer {
 			ConcurrentNodeLinkSyncs:          defaultConcurrentSyncs,
 			ConcurrentClusterDeploymentSyncs: defaultConcurrentSyncs,
 			ConcurrentRemoteMachineSetSyncs:  defaultConcurrentSyncs,
+			ConcurrentRegistryInfraSyncs:     defaultConcurrentSyncs,
 			LeaderElection:                   leaderelectionconfig.DefaultLeaderElectionConfiguration(),
 			LeaderElectionNamespace:          defaultLeaderElectionNamespace,
 			ControllerStartInterval:          metav1.Duration{Duration: 0 * time.Second},
@@ -107,6 +108,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.Int32Var(&s.ConcurrentComponentSyncs, "concurrent-component-syncs", s.ConcurrentComponentSyncs, "The number of master machine set objects that are allowed to install components concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentNodeConfigSyncs, "concurrent-nodeconfig-syncs", s.ConcurrentNodeConfigSyncs, "The number of clusters that are allowed to configure the node config daemonset concurrently. Larger number = more responsive node config jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentRemoteMachineSetSyncs, "concurrent-remotemachineset-syncs", s.ConcurrentRemoteMachineSetSyncs, "The number of machine sets we can sync to remote clusters concurrently. Larger number = more responsive sync jobs, but more CPU (and network ) load")
+	fs.Int32Var(&s.ConcurrentRegistryInfraSyncs, "concurrent-registryinfra-syncs", s.ConcurrentRegistryInfraSyncs, "The number of clusters we can build registry infrastructure for concurrently. Larger number = more responsive sync jobs, but more CPU (and network ) load")
 	fs.Int32Var(&s.ConcurrentDeployClusterAPISyncs, "concurrent-deploy-cluster-api-syncs", s.ConcurrentDeployClusterAPISyncs, "The number of master machine set objects that are allowed to install the upstream cluster API controllers concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentClusterDeploymentSyncs, "concurrent-cluster-deployment-syncs", s.ConcurrentClusterDeploymentSyncs, "The number of cluster deployment objects that are allowed to sync concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentELBMachineSyncs, "concurrent-elb-machine-syncs", s.ConcurrentELBMachineSyncs, "The number of master machine objects that are allowed to be added to the internal/external AWS ELB concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")

--- a/contrib/ansible/create-cluster-playbook.yml
+++ b/contrib/ansible/create-cluster-playbook.yml
@@ -42,6 +42,9 @@
     # in the cert dir defined above.
     cluster_ca_name: ca
 
+    # Allow overriding the default of having an S3-backed cluster registry
+    s3_backed_registry: "true"
+
   tasks:
 
   - import_role:
@@ -133,6 +136,7 @@
         AWS_SECRET_ACCESS_KEY: "{{ l_aws_secret_access_key }}"
         SSH_PRIVATE_KEY: "{{ l_aws_ssh_private_key }}"
         SSH_PUBLIC_KEY: "{{ l_aws_ssh_public_key }}"
+        S3_BACKED_REGISTRY: "{{ s3_backed_registry }}"
     register: cluster_reg
 
   - name: create/update cluster

--- a/contrib/examples/cluster-deployment-template.yaml
+++ b/contrib/examples/cluster-deployment-template.yaml
@@ -42,6 +42,10 @@ parameters:
 - name: SSH_KEYPAIR_NAME
   required: false
   description: Name of AWS keypair to use for machines in this cluster.
+- name: S3_BACKED_REGISTRY
+  required: false
+  value: "true"
+  description: Whether the cluster should be configured for an S3-backed registry
 
 objects:
 
@@ -84,6 +88,8 @@ objects:
   metadata:
     name: ${CLUSTER_NAME}
     namespace: ${CLUSTER_NAMESPACE}
+    annotations:
+      clusteroperator.openshift.io/s3-backed-registry: "${S3_BACKED_REGISTRY}"
   spec:
     clusterVersionRef:
       namespace: ${CLUSTER_VERSION_NAMESPACE}

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -65,6 +65,7 @@ type ClusterDeployment struct {
 const (
 	FinalizerClusterDeployment string = "clusteroperator.openshift.io/clusterdeployment"
 	FinalizerRemoteMachineSets string = "clusteroperator.openshift.io/remotemachinesets"
+	FinalizerRegistryInfra     string = "clusteroperator.openshift.io/registryinfra"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -378,6 +379,15 @@ type ClusterProviderStatus struct {
 	// master machine set resource used to generate the latest completed
 	// control-plane installation job.
 	ControlPlaneInstalledJobMachineSetGeneration int64
+
+	// RegistryInfraCompleted is true once the registryinfra controller has
+	// finished processing (doesn't necessarily mean S3 bucket provisioned
+	// if annotations don't want S3 configured).
+	RegistryInfraCompleted bool
+
+	// RegistryInfraInstalledGeneration is the generation of the Cluster used to generate
+	// the latest completed registry infrastructure sync
+	RegistryInfraInstalledGeneration int64 `json:"registryInfraInstalledGeneration"`
 
 	// ComponentsInstalled is true if the additional components needed for the
 	// cluster have been installed

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -65,6 +65,7 @@ type ClusterDeployment struct {
 const (
 	FinalizerClusterDeployment string = "clusteroperator.openshift.io/clusterdeployment"
 	FinalizerRemoteMachineSets string = "clusteroperator.openshift.io/remotemachinesets"
+	FinalizerRegistryInfra     string = "clusteroperator.openshift.io/registryinfra"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -380,6 +381,15 @@ type ClusterProviderStatus struct {
 	// control-plane installation job.
 	ControlPlaneInstalledJobMachineSetGeneration int64 `json:"controlPlaneInstalledJobMachineSetGeneration"`
 
+	// RegistryInfraCompleted is true once the registryinfra controller has
+	// finished processing (doesn't necessarily mean S3 bucket provisioned
+	// if annotations don't want S3 configured).
+	RegistryInfraCompleted bool `json:"registryInfraCompleted"`
+
+	// RegistryInfraInstalledGeneration is the generation of the Cluster used to generate
+	// the latest completed registry infrastructure sync
+	RegistryInfraInstalledGeneration int64 `json:"registryInfraInstalledGeneration"`
+
 	// ComponentsInstalled is true if the additional components needed for the
 	// cluster have been installed
 	ComponentsInstalled bool `json:"componentsInstalled"`
@@ -552,6 +562,11 @@ const (
 	ClusterAPIInstalled ClusterConditionType = "ClusterAPIInstalled"
 	// ClusterReady means the cluster is able to service requests
 	ClusterReady ClusterConditionType = "Ready"
+	// RegistyInfraProvisioned is true when the cluster's registry infra pieces are installed
+	RegistryInfraProvisioned ClusterConditionType = "RegistryInfraProvisioned"
+	// RegistryInfraProvisioningFailed is true when there have been problems deploying the
+	// cluster's registry infra pieces
+	RegistryInfraProvisioningFailed ClusterConditionType = "RegistryInfraProvisioningFailed"
 )
 
 // ClusterMachineSet is the specification of a machine set in a cluster

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -497,6 +497,8 @@ func autoConvert_v1alpha1_ClusterProviderStatus_To_clusteroperator_ClusterProvid
 	out.ControlPlaneInstalled = in.ControlPlaneInstalled
 	out.ControlPlaneInstalledJobClusterGeneration = in.ControlPlaneInstalledJobClusterGeneration
 	out.ControlPlaneInstalledJobMachineSetGeneration = in.ControlPlaneInstalledJobMachineSetGeneration
+	out.RegistryInfraCompleted = in.RegistryInfraCompleted
+	out.RegistryInfraInstalledGeneration = in.RegistryInfraInstalledGeneration
 	out.ComponentsInstalled = in.ComponentsInstalled
 	out.ComponentsInstalledJobClusterGeneration = in.ComponentsInstalledJobClusterGeneration
 	out.ComponentsInstalledJobMachineSetGeneration = in.ComponentsInstalledJobMachineSetGeneration
@@ -527,6 +529,8 @@ func autoConvert_clusteroperator_ClusterProviderStatus_To_v1alpha1_ClusterProvid
 	out.ControlPlaneInstalled = in.ControlPlaneInstalled
 	out.ControlPlaneInstalledJobClusterGeneration = in.ControlPlaneInstalledJobClusterGeneration
 	out.ControlPlaneInstalledJobMachineSetGeneration = in.ControlPlaneInstalledJobMachineSetGeneration
+	out.RegistryInfraCompleted = in.RegistryInfraCompleted
+	out.RegistryInfraInstalledGeneration = in.RegistryInfraInstalledGeneration
 	out.ComponentsInstalled = in.ComponentsInstalled
 	out.ComponentsInstalledJobClusterGeneration = in.ComponentsInstalledJobClusterGeneration
 	out.ComponentsInstalledJobMachineSetGeneration = in.ComponentsInstalledJobMachineSetGeneration

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -103,6 +103,10 @@ type ControllerManagerConfiguration struct {
 	// concurrently. Larger number = more responsive processing but more CPU (and network) load.
 	ConcurrentRemoteMachineSetSyncs int32
 
+	// ConcurrentRegistryInfraSyncs is the number of clusters we can be bulding registry infrastructure for
+	// concurrently. Larger number = more responsive processing but more CPU (and network) load.
+	ConcurrentRegistryInfraSyncs int32
+
 	// ConcurrentDeployClusterAPISyncs is the number of clusters that are allowed to be deploying
 	// the upstream cluster API controllers concurrently. Larger number = more responsive processing
 	// but more CPU (and network) load.

--- a/pkg/clusterapi/aws/mock/client_generated.go
+++ b/pkg/clusterapi/aws/mock/client_generated.go
@@ -7,6 +7,9 @@ package mock
 import (
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	elb "github.com/aws/aws-sdk-go/service/elb"
+	iam "github.com/aws/aws-sdk-go/service/iam"
+	s3 "github.com/aws/aws-sdk-go/service/s3"
+	s3iface "github.com/aws/aws-sdk-go/service/s3/s3iface"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -136,4 +139,172 @@ func (m *MockClient) RegisterInstancesWithLoadBalancer(arg0 *elb.RegisterInstanc
 // RegisterInstancesWithLoadBalancer indicates an expected call of RegisterInstancesWithLoadBalancer
 func (mr *MockClientMockRecorder) RegisterInstancesWithLoadBalancer(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterInstancesWithLoadBalancer", reflect.TypeOf((*MockClient)(nil).RegisterInstancesWithLoadBalancer), arg0)
+}
+
+// CreateAccessKey mocks base method
+func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
+	ret := m.ctrl.Call(m, "CreateAccessKey", arg0)
+	ret0, _ := ret[0].(*iam.CreateAccessKeyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAccessKey indicates an expected call of CreateAccessKey
+func (mr *MockClientMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockClient)(nil).CreateAccessKey), arg0)
+}
+
+// CreateUser mocks base method
+func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
+	ret := m.ctrl.Call(m, "CreateUser", arg0)
+	ret0, _ := ret[0].(*iam.CreateUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUser indicates an expected call of CreateUser
+func (mr *MockClientMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), arg0)
+}
+
+// DeleteAccessKey mocks base method
+func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteAccessKey", arg0)
+	ret0, _ := ret[0].(*iam.DeleteAccessKeyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteAccessKey indicates an expected call of DeleteAccessKey
+func (mr *MockClientMockRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockClient)(nil).DeleteAccessKey), arg0)
+}
+
+// DeleteUser mocks base method
+func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteUser", arg0)
+	ret0, _ := ret[0].(*iam.DeleteUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUser indicates an expected call of DeleteUser
+func (mr *MockClientMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), arg0)
+}
+
+// DeleteUserPolicy mocks base method
+func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteUserPolicy", arg0)
+	ret0, _ := ret[0].(*iam.DeleteUserPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUserPolicy indicates an expected call of DeleteUserPolicy
+func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
+}
+
+// GetUser mocks base method
+func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
+	ret := m.ctrl.Call(m, "GetUser", arg0)
+	ret0, _ := ret[0].(*iam.GetUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUser indicates an expected call of GetUser
+func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
+}
+
+// ListAccessKeys mocks base method
+func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
+	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
+	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAccessKeys indicates an expected call of ListAccessKeys
+func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
+}
+
+// ListUserPolicies mocks base method
+func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
+	ret := m.ctrl.Call(m, "ListUserPolicies", arg0)
+	ret0, _ := ret[0].(*iam.ListUserPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUserPolicies indicates an expected call of ListUserPolicies
+func (mr *MockClientMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockClient)(nil).ListUserPolicies), arg0)
+}
+
+// PutUserPolicy mocks base method
+func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
+	ret := m.ctrl.Call(m, "PutUserPolicy", arg0)
+	ret0, _ := ret[0].(*iam.PutUserPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutUserPolicy indicates an expected call of PutUserPolicy
+func (mr *MockClientMockRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicy", reflect.TypeOf((*MockClient)(nil).PutUserPolicy), arg0)
+}
+
+// CreateBucket mocks base method
+func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	ret := m.ctrl.Call(m, "CreateBucket", arg0)
+	ret0, _ := ret[0].(*s3.CreateBucketOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateBucket indicates an expected call of CreateBucket
+func (mr *MockClientMockRecorder) CreateBucket(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockClient)(nil).CreateBucket), arg0)
+}
+
+// DeleteBucket mocks base method
+func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+	ret := m.ctrl.Call(m, "DeleteBucket", arg0)
+	ret0, _ := ret[0].(*s3.DeleteBucketOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteBucket indicates an expected call of DeleteBucket
+func (mr *MockClientMockRecorder) DeleteBucket(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), arg0)
+}
+
+// ListBuckets mocks base method
+func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
+	ret := m.ctrl.Call(m, "ListBuckets", arg0)
+	ret0, _ := ret[0].(*s3.ListBucketsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBuckets indicates an expected call of ListBuckets
+func (mr *MockClientMockRecorder) ListBuckets(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuckets", reflect.TypeOf((*MockClient)(nil).ListBuckets), arg0)
+}
+
+// GetS3API mocks base method
+func (m *MockClient) GetS3API() s3iface.S3API {
+	ret := m.ctrl.Call(m, "GetS3API")
+	ret0, _ := ret[0].(s3iface.S3API)
+	return ret0
+}
+
+// GetS3API indicates an expected call of GetS3API
+func (mr *MockClientMockRecorder) GetS3API() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetS3API", reflect.TypeOf((*MockClient)(nil).GetS3API))
 }

--- a/pkg/controller/clusterinstall/controller.go
+++ b/pkg/controller/clusterinstall/controller.go
@@ -426,7 +426,10 @@ func (s *jobSyncStrategy) GetJobFactory(owner metav1.Object, deleting bool) (con
 
 	jobGeneratorExecutor := ansible.NewJobGeneratorExecutorForMasterMachineSet(s.controller.ansibleGenerator, s.controller.playbooks, cluster, cluster.AWSClusterProviderConfig.OpenShiftConfig.Version)
 	if decorateStrategy, shouldDecorate := s.controller.installStrategy.(InstallJobDecorationStrategy); shouldDecorate {
-		decorateStrategy.DecorateJobGeneratorExecutor(jobGeneratorExecutor, cluster)
+		err = decorateStrategy.DecorateJobGeneratorExecutor(jobGeneratorExecutor, cluster)
+		if err != nil {
+			return nil, fmt.Errorf("error while decorating job: %v", err)
+		}
 	}
 
 	return jobFactory(func(name string) (*v1batch.Job, *kapi.ConfigMap, error) {

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -466,9 +466,13 @@ func BuildCluster(clusterDeployment *clusteroperator.ClusterDeployment, cv clust
 	cluster := &clusterapi.Cluster{}
 	cluster.Name = clusterDeployment.Spec.ClusterName
 	cluster.Labels = clusterDeployment.Labels
+	cluster.Annotations = clusterDeployment.Annotations
 	cluster.Namespace = clusterDeployment.Namespace
 	if cluster.Labels == nil {
 		cluster.Labels = make(map[string]string)
+	}
+	if cluster.Annotations == nil {
+		cluster.Annotations = make(map[string]string)
 	}
 	cluster.Labels[clusteroperator.ClusterDeploymentLabel] = clusterDeployment.Name
 	blockOwnerDeletion := false
@@ -789,4 +793,16 @@ func GetSecretNameFromMachineSetSpec(msSpec *clusteroperator.MachineSetSpec) (st
 	}
 
 	return secretName, nil
+}
+
+// RegistryObjectStoreName takes the clusterID and returns what the remote object store
+// name should be for the cluster
+func RegistryObjectStoreName(clusterID string) string {
+	return clusterID + "-registry"
+}
+
+// RegistryCredsSecretName return the name we should store the registry secrets into
+// given the clusterID
+func RegistryCredsSecretName(clusterID string) string {
+	return clusterID + "-registry"
 }

--- a/pkg/controller/registryinfra/registryinfra_controller.go
+++ b/pkg/controller/registryinfra/registryinfra_controller.go
@@ -1,0 +1,906 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryinfra
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+	"time"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/cluster-operator/pkg/ansible"
+	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
+	"github.com/openshift/cluster-operator/pkg/logging"
+
+	"github.com/openshift/cluster-operator/pkg/controller"
+
+	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	clusteroperatorclient "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	clusterdeploymentinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions/clusteroperator/v1alpha1"
+	clusterdeploymentlister "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
+
+	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clusterapiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	clusterapiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
+	capilister "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	clustopaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+)
+
+const (
+	// maxRetries is the number of times a service will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuings of a service.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
+	maxRetries = 15
+
+	controllerName = "registryinfra"
+
+	infraDeployed          = "RegistryInfraDeployed"
+	infraDeploymentFailure = "RegistryInfraFailure"
+
+	// watch out for leading newline in policy JSON
+	// AWS will reject the policy with unhelpful error messages
+	// This policy taken from
+	// https://docs.docker.com/registry/storage-drivers/s3/#s3-permission-scopes
+	s3PolicyTemplate = `{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads"
+            ],
+            "Resource": "arn:aws:s3:::{{ .BucketName }}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::{{ .BucketName }}/*"
+        }
+    ]
+}`
+
+	// allow opting out of deploying with an S3-backed registry (must be set to "false" otherwise
+	// assumed to be "true")
+	s3RegistryOptOutAnnotation = "clusteroperator.openshift.io/s3-backed-registry"
+)
+
+type s3PolicyTemplateParams struct {
+	BucketName string
+}
+
+// NewController returns a new *Controller to use with
+// cluster-api resources.
+func NewController(
+	clusterInformer clusterapiinformers.ClusterInformer,
+	clusterDeploymentInformer clusterdeploymentinformers.ClusterDeploymentInformer,
+	kubeClient kubeclientset.Interface,
+	clusteroperatorClient clusteroperatorclient.Interface,
+	clusterapiClient clusterapiclientset.Interface,
+) *Controller {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	// TODO: remove the wrapper when every clients have moved to use the clientset.
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
+
+	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage(
+			fmt.Sprintf("clusteroperator_%s_controller", controllerName),
+			kubeClient.CoreV1().RESTClient().GetRateLimiter(),
+		)
+	}
+
+	logger := log.WithField("controller", controllerName)
+	c := &Controller{
+		kubeClient:              kubeClient,
+		coClient:                clusteroperatorClient,
+		capiClient:              clusterapiClient,
+		queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		logger:                  logger,
+		clusterLister:           clusterInformer.Lister(),
+		clusterDeploymentLister: clusterDeploymentInformer.Lister(),
+		clustersSynced:          clusterInformer.Informer().HasSynced,
+		awsClientBuilder:        clustopaws.NewClient,
+	}
+
+	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addCluster,
+		UpdateFunc: c.updateCluster,
+		DeleteFunc: c.deleteCluster,
+	})
+
+	c.syncHandler = c.syncCluster
+	c.enqueueCluster = c.enqueue
+
+	c.awsEmptyBucket = c.emptyS3Bucket
+
+	return c
+}
+
+// Controller manages clusters.
+type Controller struct {
+	kubeClient kubeclientset.Interface
+	coClient   clusteroperatorclient.Interface
+	capiClient clusterapiclientset.Interface
+
+	// To allow injection of syncCluster for testing.
+	syncHandler func(hKey string) error
+
+	// To allow injection of mock ansible generator for testing
+	ansibleGenerator ansible.JobGenerator
+
+	// used for unit testing
+	enqueueCluster func(cluster metav1.Object)
+
+	clusterLister           capilister.ClusterLister
+	clusterDeploymentLister clusterdeploymentlister.ClusterDeploymentLister
+
+	// clustersSynced returns true if the cluster shared informer has been synced at least once.
+	// Added as a member to the struct to allow injection for testing.
+	clustersSynced cache.InformerSynced
+
+	// Clusters that need to be synced
+	queue workqueue.RateLimitingInterface
+
+	logger *log.Entry
+
+	// AWS client builder
+	awsClientBuilder func(kubeClient kubeclientset.Interface, secretName, namespace, region string) (clustopaws.Client, error)
+
+	// AWS bucket emptier
+	awsEmptyBucket func(bucketName string, awsClient clustopaws.Client) error
+}
+
+func (c *Controller) addCluster(obj interface{}) {
+	cluster := obj.(*clusterapi.Cluster)
+	logging.WithCluster(c.logger, cluster).Debugf("Adding cluster")
+	c.enqueueCluster(cluster)
+}
+
+func (c *Controller) updateCluster(old, obj interface{}) {
+	cluster := obj.(*clusterapi.Cluster)
+	logging.WithCluster(c.logger, cluster).Debugf("Updating cluster")
+	c.enqueueCluster(cluster)
+}
+
+func (c *Controller) deleteCluster(obj interface{}) {
+	cluster, ok := obj.(*clusterapi.Cluster)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		cluster, ok = tombstone.Obj.(*clusterapi.Cluster)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Object %#v", obj))
+			return
+		}
+	}
+	logging.WithCluster(c.logger, cluster).Debugf("Deleting cluster")
+	c.enqueueCluster(cluster)
+}
+
+// Run runs c; will not return until stopCh is closed. workers determines how
+// many clusters will be handled in parallel.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Infof("starting %s controller", controllerName)
+	defer c.logger.Infof("shutting down %s controller", controllerName)
+
+	if !controller.WaitForCacheSync("registryinfra", stopCh, c.clustersSynced) {
+		c.logger.Errorf("Could not sync caches for %s controller", controllerName)
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *Controller) enqueue(cluster metav1.Object) {
+	key, err := controller.KeyFunc(cluster)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", cluster, err))
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncHandler(key.(string))
+	c.handleErr(err, key)
+
+	return true
+}
+
+func (c *Controller) handleErr(err error, key interface{}) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	logger := c.logger.WithField("cluster", key)
+
+	logger.Errorf("error syncing registry infra: %v", err)
+	if c.queue.NumRequeues(key) < maxRetries {
+		logger.Errorf("retrying registry infra")
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	utilruntime.HandleError(err)
+	logger.Infof("dropping cluster out of the queue: %v", err)
+	c.queue.Forget(key)
+}
+
+func (c *Controller) syncCluster(key string) error {
+	startTime := time.Now()
+	c.logger.WithField("key", key).Debug("syncing registry infra")
+	defer func() {
+		c.logger.WithFields(log.Fields{
+			"key":      key,
+			"duration": time.Now().Sub(startTime),
+		}).Debug("finished syncing registry infra")
+	}()
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	capiCluster, err := c.clusterLister.Clusters(namespace).Get(name)
+	if errors.IsNotFound(err) {
+		c.logger.WithField("key", key).Debug("cluster has been deleted")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if val, ok := capiCluster.Annotations[s3RegistryOptOutAnnotation]; ok && val == "false" {
+		// skip processing this cluster as it doesn't want an s3-backed registry
+		c.logger.WithField("cluster", capiCluster.Name).Debug("cluster doesn't want s3-backed registry. skipping.")
+
+		// but update cluster object to indicate that the controller has processed the cluster object
+		err = c.updateClusterStatus(capiCluster, true, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	cluster, err := controller.ConvertToCombinedCluster(capiCluster)
+	if err != nil {
+		return fmt.Errorf("failure converting to combined cluster: %v", err)
+	}
+
+	clusterProviderStatus, err := controller.ClusterProviderStatusFromCluster(capiCluster)
+	if err != nil {
+		return fmt.Errorf("error retrieving clusterproviderstatus: %v", err)
+	}
+
+	// check if the cluster is being deleted
+	if capiCluster.DeletionTimestamp != nil {
+		c.logger.WithField("cluster", key).Debug("cleaning up registry infrastructure pieces")
+
+		err = c.syncRegistryInfra(cluster, false /* deprovision infra */)
+		if err != nil {
+			return fmt.Errorf("error deleting registry infra: %v", err)
+		}
+		err = c.deleteFinalizer(capiCluster)
+		return err
+	}
+
+	if clusterGenerationAlreadyProcessed(capiCluster, clusterProviderStatus) {
+		// nothing to do as we've already handled this generation of the cluster
+		return nil
+	}
+
+	if !hasRegistryInfraFinalizer(capiCluster) {
+		c.logger.Debugf("adding registryinfra finalizer to cluster %v", capiCluster.Name)
+		return c.addFinalizer(capiCluster)
+	}
+
+	// create infra if needed
+	c.logger.Debugf("creating registry infrastructure pieces for cluster %v", capiCluster.Name)
+
+	err = c.syncRegistryInfra(cluster, true /* create infra */)
+	if err != nil {
+		c.updateClusterStatus(capiCluster, false, err)
+		return fmt.Errorf("error setting up infrastructure for registry: %v", err)
+	}
+
+	err = c.updateClusterStatus(capiCluster, true, nil)
+	if err != nil {
+		return fmt.Errorf("error updating cluster status: %v", err)
+	}
+
+	return nil
+}
+
+// configureAWS will return a client for interacting with AWS for the provided cluster
+func (c *Controller) configureAWS(cluster *clusteroperator.CombinedCluster) (clustopaws.Client, error) {
+	adminCredsSecretName := cluster.AWSClusterProviderConfig.Hardware.AccountSecret.Name
+	region := cluster.AWSClusterProviderConfig.Hardware.Region
+
+	client, err := c.awsClientBuilder(c.kubeClient, adminCredsSecretName, cluster.Namespace, region)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up aws client: %v", err)
+	}
+	return client, nil
+
+}
+
+func (c *Controller) emptyS3Bucket(bucketName string, awsClient clustopaws.Client) error {
+	s3API := awsClient.GetS3API()
+	iter := s3manager.NewDeleteListIterator(s3API, &s3.ListObjectsInput{
+		Bucket: aws.String(bucketName),
+	})
+	err := s3manager.NewBatchDeleteWithClient(s3API).Delete(aws.BackgroundContext(), iter)
+	if err != nil {
+		return fmt.Errorf("error deleting objects from bucket %v: %v", bucketName, err)
+	}
+
+	return nil
+}
+
+func (c *Controller) deprovisionS3Bucket(bucketName string, awsClient clustopaws.Client) error {
+
+	s3Bucket, err := getBucketByName(bucketName, awsClient)
+	if err != nil {
+		return fmt.Errorf("error searching for existing bucket: %v", err)
+	}
+
+	if s3Bucket == nil {
+		return nil
+	}
+
+	// first we need to empty all the objects out of the bucket
+	err = c.awsEmptyBucket(bucketName, awsClient)
+	if err != nil {
+		return err
+	}
+
+	// now we can delete the bucket
+	_, err = awsClient.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting bucket: %v", err)
+	}
+
+	return nil
+}
+
+// create S3 bucket (if necessary) for cluster's registry
+func (c *Controller) setupS3Bucket(bucketName string, awsClient clustopaws.Client) error {
+
+	s3Bucket, err := getBucketByName(bucketName, awsClient)
+	if err != nil {
+		return fmt.Errorf("error searching for existing bucket: %v", err)
+	}
+
+	if s3Bucket != nil {
+		// already have a bucket, don't try to re-create it
+		return nil
+	}
+
+	if s3Bucket == nil {
+		// bucket doesn't exist, need to create
+		_, err := awsClient.CreateBucket(&s3.CreateBucketInput{
+			Bucket: aws.String(bucketName),
+		})
+		if err != nil {
+			return fmt.Errorf("error creating bucket: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func deprovisionIamUserCreds(userName string, awsClient clustopaws.Client) error {
+	// need to delete all access keys associated with the IAM user
+	// to be able to eventually delete the user
+	accessKeys, err := awsClient.ListAccessKeys(&iam.ListAccessKeysInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		return fmt.Errorf("error listing access keys: %v", err)
+	}
+	for _, aKey := range accessKeys.AccessKeyMetadata {
+		_, err = awsClient.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+			UserName:    aws.String(userName),
+			AccessKeyId: aKey.AccessKeyId,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting user's access key: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// setupIamUserCreds unconditionally creates and returns access/secret key for iam userName
+func (c *Controller) setupIamUserCreds(userName string, awsClient clustopaws.Client) (*iam.AccessKey, error) {
+	result, err := awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
+		UserName: &userName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating iam creds for user %v: %v", userName, err)
+	}
+
+	return result.AccessKey, nil
+}
+
+func deprovisionS3IamUser(clusterID, bucketName string, awsClient clustopaws.Client) error {
+	existingUser, err := findExistingRegistryUser(clusterID, awsClient)
+	if err != nil {
+		return err
+	}
+
+	if existingUser != nil {
+		// delete inline policy before deleting user
+		err = deprovisionS3IamUserPolicy(*existingUser.UserName, awsClient)
+		if err != nil {
+			return err
+		}
+
+		// delete iam creds before deleting user
+		err = deprovisionIamUserCreds(*existingUser.UserName, awsClient)
+		if err != nil {
+			return err
+		}
+
+		_, err := awsClient.DeleteUser(&iam.DeleteUserInput{
+			UserName: existingUser.UserName,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting IAM user: %v", err)
+		}
+		return nil
+	}
+
+	return nil
+}
+
+// setupS3IamUser creates an IAM user with an inline policy granting r/w permission on bucketName
+// return iam creds if we are told that there are no exising credentials
+func (c *Controller) setupS3IamUser(clusterID, bucketName string, awsClient clustopaws.Client) (*iam.AccessKey, error) {
+
+	existingUser, err := findExistingRegistryUser(clusterID, awsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	userName := getRegistryUserName(clusterID)
+
+	if existingUser == nil {
+		// create user
+		_, err := awsClient.CreateUser(&iam.CreateUserInput{
+			UserName: aws.String(userName),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error creating iam user: %v", err)
+		}
+	}
+
+	// attach policy to user
+	err = c.s3IamUserPolicy(clusterID, userName, bucketName, awsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// create AWS access/secret for user if we haven't previously generated
+	// credentials for this user
+	var accessKey *iam.AccessKey
+	if existingUser == nil {
+		accessKey, err = c.setupIamUserCreds(userName, awsClient)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// return a nil accessKey if we didn't generate new creds (b/c they already exist)
+	return accessKey, nil
+}
+
+func deprovisionS3IamUserPolicy(userName string, awsClient clustopaws.Client) error {
+	// need to remove all inline policies to be able to remove user
+	userPolicies, err := awsClient.ListUserPolicies(&iam.ListUserPoliciesInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		return fmt.Errorf("error listing user inline policies: %v", err)
+	}
+	for _, policy := range userPolicies.PolicyNames {
+		_, err = awsClient.DeleteUserPolicy(&iam.DeleteUserPolicyInput{
+			UserName:   aws.String(userName),
+			PolicyName: policy,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting inline user policies: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// s3IamUserPolicy will attach iam policy to user granting r/w access to S3 bucketName
+func (c *Controller) s3IamUserPolicy(clusterID, userName, bucketName string, awsClient clustopaws.Client) error {
+	policyName := clusterID + "S3Access"
+	policyDocument, err := createS3IamPolicy(bucketName)
+	if err != nil {
+		return err
+	}
+
+	_, err = awsClient.PutUserPolicy(&iam.PutUserPolicyInput{
+		UserName:       aws.String(userName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(policyDocument),
+	})
+	if err != nil {
+		return fmt.Errorf("error attaching policy to user: %v", err)
+	}
+
+	return nil
+}
+
+func createS3IamPolicy(bucketName string) (string, error) {
+	t, err := template.New("s3policy").Parse(s3PolicyTemplate)
+	if err != nil {
+		return "", fmt.Errorf("error parsing s3policy template: %v", err)
+	}
+
+	params := s3PolicyTemplateParams{
+		BucketName: bucketName,
+	}
+
+	var buf bytes.Buffer
+	err = t.Execute(&buf, params)
+	if err != nil {
+		return "", fmt.Errorf("error processing s3policy template: %v", err)
+	}
+	policyDocument := buf.String()
+
+	return policyDocument, nil
+}
+
+func (c *Controller) syncRegistryInfra(cluster *clusteroperator.CombinedCluster, createInfra bool) error {
+	clusterID := cluster.Name
+
+	bucketName := controller.RegistryObjectStoreName(clusterID)
+
+	awsClient, err := c.configureAWS(cluster)
+	if err != nil {
+		return fmt.Errorf("error configuring AWS connection settings: %v", err)
+	}
+
+	if createInfra {
+		// create bucket if necessary
+		err = c.setupS3Bucket(bucketName, awsClient)
+		if err != nil {
+			return err
+		}
+
+		// create user if necessary
+		newAccessKey, err := c.setupS3IamUser(clusterID, bucketName, awsClient)
+		if err != nil {
+			return err
+		}
+
+		// save iam user's AWS creds into secret
+		err = c.setupRegistrySecret(clusterID, cluster.Namespace, newAccessKey)
+		if err != nil {
+			return err
+		}
+
+		// end of provisioning registry infra
+		return nil
+	}
+
+	//else deprovision
+	err = c.deprovisionS3Bucket(bucketName, awsClient)
+	if err != nil {
+		return fmt.Errorf("error deleting bucket: %v", err)
+	}
+
+	err = deprovisionS3IamUser(clusterID, bucketName, awsClient)
+	if err != nil {
+		return fmt.Errorf("error deleting registry IAM user: %v", err)
+	}
+
+	secretName := controller.RegistryCredsSecretName(clusterID)
+	err = c.deleteRegistyUserSecret(secretName, cluster.Namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// deleteRegistryUserSecret will delete secret holding IAM registry user's cloud creds
+func (c *Controller) deleteRegistyUserSecret(secretName string, secretNamespace string) error {
+	_, err := c.kubeClient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error querying for existing registry secret: %v", err)
+	} else if err == nil {
+		// found existing secret
+		err = c.kubeClient.CoreV1().Secrets(secretNamespace).Delete(secretName, &metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting registry secret: %v", err)
+		}
+	}
+	return nil
+}
+
+// setupRegistrySecret will save IAM registry user's cloud creds into secret for later
+// use when setting up the cluster registry
+func (c *Controller) setupRegistrySecret(clusterID, secretNamespace string, accessKey *iam.AccessKey) error {
+
+	if accessKey == nil {
+		// accessKey == nil means no access key to store
+		return nil
+	}
+
+	registrySecretAlreadyExists := false
+
+	// name for secret where we will store the registry object store credentials
+	objectStoreSecretName := controller.RegistryCredsSecretName(clusterID)
+
+	_, err := c.kubeClient.CoreV1().Secrets(secretNamespace).Get(objectStoreSecretName, metav1.GetOptions{})
+	secretFound := (err == nil)
+	unexpectedError := (err != nil && !errors.IsNotFound(err))
+
+	if unexpectedError {
+		return fmt.Errorf("error querying for existing registry secret: %v", err)
+	} else if secretFound {
+		registrySecretAlreadyExists = true
+	}
+
+	if registrySecretAlreadyExists {
+		// delete the current secret before saving the new accessKey creds
+		c.deleteRegistyUserSecret(objectStoreSecretName, secretNamespace)
+	}
+
+	// now create the secret with the creds
+	_, err = c.kubeClient.CoreV1().Secrets(secretNamespace).Create(&kapi.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objectStoreSecretName,
+			Namespace: secretNamespace,
+		},
+		StringData: map[string]string{
+			"awsAccessKeyId":     *accessKey.AccessKeyId,
+			"awsSecretAccessKey": *accessKey.SecretAccessKey,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error saving aws creds into registry secret: %v", err)
+	}
+
+	return nil
+}
+
+func (c *Controller) updateClusterStatus(cluster *clusterapi.Cluster, success bool, syncError error) error {
+	clusterProviderStatus, err := controller.ClusterProviderStatusFromCluster(cluster)
+	if err != nil {
+		return fmt.Errorf("error retrieving cluster status: %v", err)
+	}
+
+	newConditions := c.updateClusterCondition(clusterProviderStatus, success, syncError)
+	clusterProviderStatus.Conditions = newConditions
+
+	clusterProviderStatus.RegistryInfraCompleted = success
+
+	if success {
+		clusterProviderStatus.RegistryInfraInstalledGeneration = cluster.Generation
+	}
+
+	raw, err := controller.EncodeClusterProviderStatus(clusterProviderStatus)
+	if err != nil {
+		return fmt.Errorf("error converting clusterproviderstatus: %v", err)
+	}
+
+	clusterCopy := cluster.DeepCopy()
+	clusterCopy.Status.ProviderStatus = raw
+
+	err = controller.UpdateClusterStatus(c.capiClient, clusterCopy)
+	if err != nil {
+		return fmt.Errorf("error updating cluster status: %v", err)
+	}
+
+	return nil
+}
+
+func (c *Controller) updateClusterCondition(clusterProviderStatus *clusteroperator.ClusterProviderStatus, suceeded bool, syncError error) []clusteroperator.ClusterCondition {
+	type ConditionFields struct {
+		condition   clusteroperator.ClusterConditionType
+		status      kapi.ConditionStatus
+		msg         string
+		reason      string
+		updateCheck controller.UpdateConditionCheck
+	}
+	conditions := []ConditionFields{}
+
+	if suceeded {
+		// set conditions indicating RegistryInfraProvisioned=true and RegistryInfraProvisioningFailed=false
+		conditions = append(conditions, ConditionFields{
+			condition:   clusteroperator.RegistryInfraProvisioned,
+			status:      kapi.ConditionTrue,
+			msg:         fmt.Sprintf("registry infrastructure deployed/configured"),
+			reason:      infraDeployed,
+			updateCheck: controller.UpdateConditionIfReasonOrMessageChange,
+		})
+		conditions = append(conditions, ConditionFields{
+			condition:   clusteroperator.RegistryInfraProvisioningFailed,
+			status:      kapi.ConditionFalse,
+			msg:         fmt.Sprintf("registry infra provisioning has not failed"),
+			reason:      infraDeployed,
+			updateCheck: controller.UpdateConditionIfReasonOrMessageChange,
+		})
+	} else {
+		// set conditions indicating RegistryInfraProvisioned=false and RegistryInfraProvisioningFailed=true
+		conditions = append(conditions, ConditionFields{
+			condition:   clusteroperator.RegistryInfraProvisioningFailed,
+			status:      kapi.ConditionTrue,
+			msg:         fmt.Sprintf("registry infrastructure deployment failed: %v", syncError),
+			reason:      infraDeploymentFailure,
+			updateCheck: controller.UpdateConditionIfReasonOrMessageChange,
+		})
+		conditions = append(conditions, ConditionFields{
+			condition:   clusteroperator.RegistryInfraProvisioned,
+			status:      kapi.ConditionFalse,
+			msg:         fmt.Sprintf("registy infrastructure failed to provision"),
+			reason:      fmt.Sprintf("error provisioning registry infra: %v", syncError),
+			updateCheck: controller.UpdateConditionIfReasonOrMessageChange,
+		})
+	}
+
+	conditionsToReturn := clusterProviderStatus.Conditions
+	for _, condition := range conditions {
+		conditionsToReturn = controller.SetClusterCondition(conditionsToReturn,
+			condition.condition,
+			condition.status,
+			condition.reason,
+			condition.msg,
+			condition.updateCheck)
+	}
+
+	return conditionsToReturn
+}
+
+func hasRegistryInfraFinalizer(cluster *clusterapi.Cluster) bool {
+	return controller.HasFinalizer(cluster, clusteroperator.FinalizerRegistryInfra)
+}
+
+func (c *Controller) deleteFinalizer(cluster *clusterapi.Cluster) error {
+	cluster = cluster.DeepCopy()
+	controller.DeleteFinalizer(cluster, clusteroperator.FinalizerRegistryInfra)
+	_, err := c.capiClient.ClusterV1alpha1().Clusters(cluster.Namespace).UpdateStatus(cluster)
+	return err
+}
+
+func (c *Controller) addFinalizer(cluster *clusterapi.Cluster) error {
+	cluster = cluster.DeepCopy()
+	controller.AddFinalizer(cluster, clusteroperator.FinalizerRegistryInfra)
+	_, err := c.capiClient.ClusterV1alpha1().Clusters(cluster.Namespace).UpdateStatus(cluster)
+	return err
+}
+
+func getBucketByName(bucketName string, awsClient clustopaws.Client) (*s3.Bucket, error) {
+	bucketList, err := awsClient.ListBuckets(nil)
+	if err != nil {
+		return nil, fmt.Errorf("error listing buckets: %v", err)
+	}
+
+	var s3Bucket *s3.Bucket
+	for _, bucket := range bucketList.Buckets {
+		if *bucket.Name == bucketName {
+			s3Bucket = bucket
+		}
+	}
+
+	return s3Bucket, nil
+}
+
+func getRegistryUserName(clusterID string) string {
+	return clusterID + "-registry"
+}
+
+func findExistingRegistryUser(clusterID string, awsClient clustopaws.Client) (*iam.User, error) {
+	userName := getRegistryUserName(clusterID)
+	userAlreadyExists := true
+
+	userResults, err := awsClient.GetUser(&iam.GetUserInput{
+		UserName: &userName,
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case iam.ErrCodeNoSuchEntityException:
+				userAlreadyExists = false
+			default:
+				return nil, fmt.Errorf("error querying iam user: %v", err)
+			}
+		} else {
+			return nil, fmt.Errorf("error querying iam user: %v", err)
+		}
+	}
+
+	if userAlreadyExists {
+		return userResults.User, nil
+	}
+
+	// no user found
+	return nil, nil
+}
+
+func clusterGenerationAlreadyProcessed(cluster *clusterapi.Cluster, providerStatus *clusteroperator.ClusterProviderStatus) bool {
+	currentGeneration := cluster.Generation
+
+	if currentGeneration == providerStatus.RegistryInfraInstalledGeneration {
+		return true
+	}
+
+	return false
+}

--- a/pkg/controller/registryinfra/registryinfra_controller_test.go
+++ b/pkg/controller/registryinfra/registryinfra_controller_test.go
@@ -1,0 +1,671 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryinfra
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	kv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	kschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/stretchr/testify/assert"
+
+	log "github.com/sirupsen/logrus"
+
+	clusteropclientfake "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset/fake"
+	clusteropinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions"
+
+	clusterapiclientfake "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
+	clusterapiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions"
+
+	clusterapiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	clusteroperatorv1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+
+	"github.com/openshift/cluster-operator/pkg/controller"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/golang/mock/gomock"
+	clustopaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+	mockaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws/mock"
+)
+
+const (
+	testRegion                      = "us-east-1"
+	testClusterVerUID               = types.UID("test-cluster-version")
+	testClusterVerName              = "v3-9"
+	testClusterVerNS                = "cluster-operator"
+	testClusterUUID                 = types.UID("test-cluster-uuid")
+	testClusterDeploymentName       = "testcluster"
+	testClusterDeploymentGeneration = 1
+	testClusterName                 = "testcluster-id"
+	testClusterNamespace            = "testsyncns"
+	testAccessKeyID                 = "MYTESTACCESSKEY"
+	testSecretAccessKey             = "MYTESTSECRETACCESSKEY"
+)
+
+type expectedAction struct {
+	namespace string
+	verb      string
+	gvr       kschema.GroupVersionResource
+	validate  func(t *testing.T, action clientgotesting.Action)
+}
+
+type testContext struct {
+	controller     *Controller
+	clusterStore   cache.Store
+	fakeKubeClient *clientgofake.Clientset
+}
+
+// Sets up all of the mocks, informers, cache, etc for tests.
+func setupTest() *testContext {
+	capiClient := &clusterapiclientfake.Clientset{}
+	clusteropClient := &clusteropclientfake.Clientset{}
+	kubeClient := &clientgofake.Clientset{}
+
+	clusterapiInformers := clusterapiinformers.NewSharedInformerFactory(capiClient, 0)
+	clusteropInformers := clusteropinformers.NewSharedInformerFactory(clusteropClient, 0)
+
+	ctx := &testContext{
+		controller: NewController(
+			clusterapiInformers.Cluster().V1alpha1().Clusters(),
+			clusteropInformers.Clusteroperator().V1alpha1().ClusterDeployments(),
+			kubeClient,
+			clusteropClient,
+			capiClient,
+		),
+		clusterStore:   clusterapiInformers.Cluster().V1alpha1().Clusters().Informer().GetStore(),
+		fakeKubeClient: kubeClient,
+	}
+
+	return ctx
+}
+
+func newClusterVer(namespace, name string, uid types.UID) *clusteroperatorv1.ClusterVersion {
+	cv := &clusteroperatorv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       uid,
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: clusteroperatorv1.ClusterVersionSpec{
+			Images: clusteroperatorv1.ClusterVersionImages{
+				ImageFormat: "openshift/origin-${component}:${version}",
+			},
+			VMImages: clusteroperatorv1.VMImages{
+				AWSImages: &clusteroperatorv1.AWSVMImages{
+					RegionAMIs: []clusteroperatorv1.AWSRegionAMIs{
+						{
+							Region: testRegion,
+							AMI:    "computeAMI_ID",
+						},
+					},
+				},
+			},
+		},
+	}
+	return cv
+}
+func newClusterFromClusterDeployment(t *testing.T, clusterDeployment *clusteroperatorv1.ClusterDeployment) *clusterapiv1.Cluster {
+	cluster := &clusterapiv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       clusterDeployment.Spec.ClusterName,
+			Namespace:  clusterDeployment.Namespace,
+			Generation: clusterDeployment.Generation,
+		},
+		Spec: clusterapiv1.ClusterSpec{},
+	}
+
+	cv := newClusterVer(testClusterVerNS, testClusterVerName, testClusterVerUID)
+	providerConfig, err := controller.BuildAWSClusterProviderConfig(&clusterDeployment.Spec, cv.Spec)
+	if err != nil {
+		t.Fatalf("error getting provider config from clusterdeployment: %v", err)
+	}
+	cluster.Spec.ProviderConfig.Value = providerConfig
+
+	controller.AddFinalizer(cluster, clusteroperatorv1.FinalizerRegistryInfra)
+
+	return cluster
+}
+
+func newClusterDeployment() *clusteroperatorv1.ClusterDeployment {
+	clusterDeployment := &clusteroperatorv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testClusterDeploymentName,
+			Namespace:  testClusterNamespace,
+			UID:        testClusterUUID,
+			Generation: testClusterDeploymentGeneration,
+		},
+		Spec: clusteroperatorv1.ClusterDeploymentSpec{
+			ClusterName: testClusterName,
+			Hardware: clusteroperatorv1.ClusterHardwareSpec{
+				AWS: &clusteroperatorv1.AWSClusterSpec{
+					Region: testRegion,
+				},
+			},
+		},
+	}
+
+	return clusterDeployment
+}
+
+func TestCreateInfra(t *testing.T) {
+	cases := []struct {
+		name              string
+		clusterDeployment *clusteroperatorv1.ClusterDeployment
+		existingBucket    bool
+		existingIAMUser   bool
+		setupS3           func(*mockaws.MockClient, *clusterapiv1.Cluster)
+		setupIamUser      func(*mockaws.MockClient, *clusterapiv1.Cluster, *testContext, *testing.T)
+
+		expectedActions   []expectedAction
+		unexpectedActions []expectedAction
+	}{
+		{
+			name:              "everything already exists",
+			clusterDeployment: newClusterDeployment(),
+			existingIAMUser:   true,
+			setupS3:           mockS3ProvisionExistingBucket,
+			setupIamUser:      mockIAMProvisionExistingUser,
+			unexpectedActions: []expectedAction{
+				{
+					namespace: testClusterNamespace,
+					verb:      "create",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+			},
+		},
+		{
+			name:              "nothing exists",
+			clusterDeployment: newClusterDeployment(),
+			existingIAMUser:   false,
+			setupS3:           mockS3ProvisionNoExistingBucket,
+			setupIamUser:      mockIAMProvisionNoExistingUser,
+			expectedActions: []expectedAction{
+				{
+					namespace: testClusterNamespace,
+					verb:      "get",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+				{
+					namespace: testClusterNamespace,
+					verb:      "create",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			ctx := setupTest()
+
+			// get visibility into logger
+			tLog := ctx.controller.logger
+
+			// create cluster objects
+			cluster := newClusterFromClusterDeployment(t, tc.clusterDeployment)
+			ctx.clusterStore.Add(cluster)
+
+			// mock presense of existing secret holding iam creds if user already exists
+			if tc.existingIAMUser {
+				//
+				ctx.fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, kruntime.Object, error) {
+					return true, nil, nil
+				})
+			} else {
+				// return notFound when searching for the secret
+				ctx.fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, kruntime.Object, error) {
+					return true, nil, errors.NewNotFound(kschema.GroupResource{}, "")
+				})
+			}
+
+			// set up cloud
+			mockCtrl := gomock.NewController(t)
+			mockAWSClient := mockaws.NewMockClient(mockCtrl)
+
+			tc.setupS3(mockAWSClient, cluster)
+			tc.setupIamUser(mockAWSClient, cluster, ctx, t)
+
+			ctx.controller.awsClientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (clustopaws.Client, error) {
+				return mockAWSClient, nil
+			}
+			// Act
+			err := ctx.controller.syncCluster(getKey(cluster, t))
+
+			// Assert
+			assert.NoError(t, err)
+
+			validateExpectedActions(t, tLog, ctx.fakeKubeClient.Actions(), tc.expectedActions)
+			validateUnexpectedActions(t, tLog, ctx.fakeKubeClient.Actions(), tc.unexpectedActions)
+		})
+	}
+}
+
+func TestDeleteInfra(t *testing.T) {
+	cases := []struct {
+		name              string
+		clusterDeployment *clusteroperatorv1.ClusterDeployment
+		setupS3           func(*mockaws.MockClient, *clusterapiv1.Cluster, *testContext)
+		setupIAMUser      func(*mockaws.MockClient, *clusterapiv1.Cluster, *testContext, *testing.T)
+		expectedActions   []expectedAction
+		unexpectedActions []expectedAction
+	}{
+		{
+			name:              "need to delete everything",
+			clusterDeployment: newClusterDeployment(),
+			setupS3:           mockS3DeprovisionExisitingBucket,
+			setupIAMUser:      mockIAMDeprovisionExistingUser,
+			unexpectedActions: []expectedAction{
+				{
+					namespace: testClusterNamespace,
+					verb:      "create",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+			},
+			expectedActions: []expectedAction{
+				{
+					namespace: testClusterNamespace,
+					verb:      "get",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+				{
+					namespace: testClusterNamespace,
+					verb:      "delete",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+			},
+		},
+		{
+			name:              "nothing exists",
+			clusterDeployment: newClusterDeployment(),
+			setupS3:           mockS3DeprovisionNoExistingBucket,
+			setupIAMUser:      mockIAMDeprovisionNoExistingUser,
+			unexpectedActions: []expectedAction{
+				{
+					namespace: testClusterNamespace,
+					verb:      "delete",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+			},
+			expectedActions: []expectedAction{
+				{
+					namespace: testClusterNamespace,
+					verb:      "get",
+					gvr:       kv1.SchemeGroupVersion.WithResource("secrets"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			ctx := setupTest()
+
+			// get visibility into logger
+			tLog := ctx.controller.logger
+
+			// create cluster objects
+			cluster := newClusterFromClusterDeployment(t, tc.clusterDeployment)
+			deletionTime := &metav1.Time{
+				Time: time.Now(),
+			}
+			cluster.DeletionTimestamp = deletionTime
+			ctx.clusterStore.Add(cluster)
+
+			// set up cloud client
+			mockCtrl := gomock.NewController(t)
+			mockAWSClient := mockaws.NewMockClient(mockCtrl)
+
+			tc.setupS3(mockAWSClient, cluster, ctx)
+			tc.setupIAMUser(mockAWSClient, cluster, ctx, t)
+
+			ctx.controller.awsClientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (clustopaws.Client, error) {
+				return mockAWSClient, nil
+			}
+
+			// Act
+			err := ctx.controller.syncCluster(getKey(cluster, t))
+
+			// Assert
+			assert.NoError(t, err)
+
+			validateExpectedActions(t, tLog, ctx.fakeKubeClient.Actions(), tc.expectedActions)
+			validateUnexpectedActions(t, tLog, ctx.fakeKubeClient.Actions(), tc.unexpectedActions)
+		})
+	}
+}
+
+// set up S3 deprovision expectations when the S3 bucket already exists
+func mockS3DeprovisionExisitingBucket(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster, ctx *testContext) {
+	bucketName := cluster.Name + "-registry"
+	listBucketOutput := &s3.ListBucketsOutput{}
+
+	mockBucket := s3.Bucket{
+		Name: aws.String(bucketName),
+	}
+	listBucketOutput.Buckets = []*s3.Bucket{
+		&mockBucket,
+	}
+
+	mockAwsClient.EXPECT().ListBuckets(nil).Return(listBucketOutput, nil)
+
+	ctx.controller.awsEmptyBucket = func(string, clustopaws.Client) error { return nil }
+
+	deleteBucketInput := &s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	}
+	mockAwsClient.EXPECT().DeleteBucket(deleteBucketInput).Return(&s3.DeleteBucketOutput{}, nil)
+}
+
+// set up S3 deprovision expectations when the S3 bucket has already been deleted
+func mockS3DeprovisionNoExistingBucket(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster, ctx *testContext) {
+	listBucketOutput := &s3.ListBucketsOutput{}
+
+	mockAwsClient.EXPECT().ListBuckets(nil).Return(listBucketOutput, nil)
+}
+
+// set up S3 provision expectations when the S3 bucket hasn't already been provisioned
+func mockS3ProvisionNoExistingBucket(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster) {
+	bucketName := cluster.Name + "-registry"
+	listOutput := &s3.ListBucketsOutput{}
+
+	// expect some creates
+	createInput := &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	}
+	createOutput := &s3.CreateBucketOutput{}
+
+	mockAwsClient.EXPECT().ListBuckets(nil).Return(listOutput, nil)
+	mockAwsClient.EXPECT().CreateBucket(createInput).Return(createOutput, nil)
+
+}
+
+// set up S3 provision expectations when the S3 bucket has already been provisioned
+func mockS3ProvisionExistingBucket(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster) {
+	bucketName := cluster.Name + "-registry"
+	listOutput := &s3.ListBucketsOutput{}
+
+	// no create call expected
+	fakeBucket := s3.Bucket{
+		Name: aws.String(bucketName),
+	}
+	listOutput.Buckets = []*s3.Bucket{
+		&fakeBucket,
+	}
+
+	mockAwsClient.EXPECT().ListBuckets(nil).Return(listOutput, nil)
+}
+
+// set up IAM deprovision expectations when the IAM user has previously been provisioned
+func mockIAMDeprovisionExistingUser(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster, ctx *testContext, t *testing.T) {
+	userName := cluster.Name + "-registry"
+	policyName := cluster.Name + "S3Access"
+
+	// set up a fake secret holding the IAM creds
+	ctx.fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, kruntime.Object, error) {
+		return true, nil, nil
+	})
+
+	// always a GetUser to query for an existing user
+	getUserInput := &iam.GetUserInput{
+		UserName: aws.String(userName),
+	}
+	getUserOutput := &iam.GetUserOutput{}
+
+	// return that there is an existing user
+	getUserOutput.User = &iam.User{
+		UserName: aws.String(userName),
+	}
+	mockAwsClient.EXPECT().GetUser(getUserInput).Return(getUserOutput, nil)
+
+	// provide the policies attached to that user
+	listUserPoliciesInput := &iam.ListUserPoliciesInput{
+		UserName: aws.String(userName),
+	}
+	listUserPoliciesOutput := &iam.ListUserPoliciesOutput{
+		PolicyNames: []*string{
+			aws.String(policyName),
+		},
+	}
+	mockAwsClient.EXPECT().ListUserPolicies(listUserPoliciesInput).Return(listUserPoliciesOutput, nil)
+
+	// watch for deletion of the policies attached to the user
+	deleteUserPolicyInput := &iam.DeleteUserPolicyInput{
+		UserName:   aws.String(userName),
+		PolicyName: aws.String(policyName),
+	}
+	mockAwsClient.EXPECT().DeleteUserPolicy(deleteUserPolicyInput).Return(&iam.DeleteUserPolicyOutput{}, nil)
+
+	// provide list of access keys attached to user
+	listAccessKeysInput := &iam.ListAccessKeysInput{
+		UserName: aws.String(userName),
+	}
+	listAccessKeysOutput := &iam.ListAccessKeysOutput{
+		AccessKeyMetadata: []*iam.AccessKeyMetadata{
+			{
+				AccessKeyId: aws.String(testAccessKeyID),
+			},
+		},
+	}
+	mockAwsClient.EXPECT().ListAccessKeys(listAccessKeysInput).Return(listAccessKeysOutput, nil)
+
+	// catch the delete of the access key
+	deleteAccessKeyInput := &iam.DeleteAccessKeyInput{
+		UserName:    aws.String(userName),
+		AccessKeyId: aws.String(testAccessKeyID),
+	}
+	mockAwsClient.EXPECT().DeleteAccessKey(deleteAccessKeyInput).Return(&iam.DeleteAccessKeyOutput{}, nil)
+
+	// and finally the DeleteUser()
+	deleteUserInput := &iam.DeleteUserInput{
+		UserName: aws.String(userName),
+	}
+	mockAwsClient.EXPECT().DeleteUser(deleteUserInput).Return(&iam.DeleteUserOutput{}, nil)
+}
+
+// set up IAM deprovision expectations when the IAM user has been previously deprovisioned
+func mockIAMDeprovisionNoExistingUser(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster, ctx *testContext, t *testing.T) {
+	userName := cluster.Name + "-registry"
+
+	// indicate that there is no secret holding the IAM creds
+	ctx.fakeKubeClient.AddReactor("get", "secrets", func(action clientgotesting.Action) (bool, kruntime.Object, error) {
+		return true, nil, errors.NewNotFound(kschema.GroupResource{}, "")
+	})
+
+	// always a GetUser to query for an existing user
+	getUserInput := &iam.GetUserInput{
+		UserName: aws.String(userName),
+	}
+
+	// user doesn't exist
+	err := awserr.New(iam.ErrCodeNoSuchEntityException, "user not found", fmt.Errorf("user not found"))
+	mockAwsClient.EXPECT().GetUser(getUserInput).Return(nil, err)
+}
+
+// set up IAM provision expectations when the user has already been provisioned
+func mockIAMProvisionExistingUser(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster, ctx *testContext, t *testing.T) {
+	bucketName := controller.RegistryObjectStoreName(cluster.Name)
+	userName := cluster.Name + "-registry"
+	policyName := cluster.Name + "S3Access"
+	policyDocument, err := createS3IamPolicy(bucketName)
+	if err != nil {
+		t.Fatalf("error creating expected policy document: %v", err)
+	}
+
+	// always a GetUser to query for an existing user
+	getUserInput := &iam.GetUserInput{
+		UserName: aws.String(userName),
+	}
+	getUserOutput := &iam.GetUserOutput{
+		User: &iam.User{
+			UserName: aws.String(userName),
+		},
+	}
+	mockAwsClient.EXPECT().GetUser(getUserInput).Return(getUserOutput, nil)
+
+	// always a PutUserPolicy (even if user already exists)
+	putUserPolicyInput := &iam.PutUserPolicyInput{
+		UserName:       aws.String(userName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(policyDocument),
+	}
+	putUserPolicyOutput := &iam.PutUserPolicyOutput{}
+	mockAwsClient.EXPECT().PutUserPolicy(putUserPolicyInput).Return(putUserPolicyOutput, nil)
+
+}
+
+// set up IAM provision expectations when the user hasn't yet been provisioned
+func mockIAMProvisionNoExistingUser(mockAwsClient *mockaws.MockClient, cluster *clusterapiv1.Cluster, ctx *testContext, t *testing.T) {
+	bucketName := controller.RegistryObjectStoreName(cluster.Name)
+	userName := cluster.Name + "-registry"
+	policyName := cluster.Name + "S3Access"
+	policyDocument, err := createS3IamPolicy(bucketName)
+	if err != nil {
+		t.Fatalf("error creating expected policy document: %v", err)
+	}
+
+	// always a GetUser to query for an existing user
+	// user doesn't exist
+	getUserInput := &iam.GetUserInput{
+		UserName: aws.String(userName),
+	}
+	err = awserr.New(iam.ErrCodeNoSuchEntityException, "user not found", fmt.Errorf("user not found"))
+	mockAwsClient.EXPECT().GetUser(getUserInput).Return(nil, err)
+
+	// always a PutUserPolicy (even if user already exists)
+	putUserPolicyInput := &iam.PutUserPolicyInput{
+		UserName:       aws.String(userName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(policyDocument),
+	}
+	putUserPolicyOutput := &iam.PutUserPolicyOutput{}
+	mockAwsClient.EXPECT().PutUserPolicy(putUserPolicyInput).Return(putUserPolicyOutput, nil)
+
+	// expect a CreateUser
+	createUserInput := &iam.CreateUserInput{
+		UserName: aws.String(userName),
+	}
+	createUserOutput := &iam.CreateUserOutput{}
+	mockAwsClient.EXPECT().CreateUser(createUserInput).Return(createUserOutput, nil)
+
+	// expect a CreateAccessKey for the new user
+	createAccessKeyInput := &iam.CreateAccessKeyInput{
+		UserName: aws.String(userName),
+	}
+	createAccessKeyOutput := &iam.CreateAccessKeyOutput{
+		AccessKey: &iam.AccessKey{
+			AccessKeyId:     aws.String(testAccessKeyID),
+			SecretAccessKey: aws.String(testSecretAccessKey),
+		},
+	}
+	mockAwsClient.EXPECT().CreateAccessKey(createAccessKeyInput).Return(createAccessKeyOutput, nil)
+
+}
+
+func validateUnexpectedActions(t *testing.T, tLog log.FieldLogger, actions []clientgotesting.Action, unexpectedActions []expectedAction) {
+	for _, uea := range unexpectedActions {
+		for _, a := range actions {
+			ns := a.GetNamespace()
+			verb := a.GetVerb()
+			res := a.GetResource()
+			if ns == uea.namespace &&
+				res == uea.gvr &&
+				verb == uea.verb {
+				t.Errorf("found unexpected kube action: %v", a)
+			}
+		}
+	}
+}
+
+func validateExpectedActions(t *testing.T, tLog log.FieldLogger, actions []clientgotesting.Action, expectedActions []expectedAction) {
+	anyMissing := false
+	for _, ea := range expectedActions {
+		found := false
+		for _, a := range actions {
+			ns := a.GetNamespace()
+			res := a.GetResource()
+			verb := a.GetVerb()
+			if ns == ea.namespace &&
+				res == ea.gvr &&
+				verb == ea.verb {
+				found = true
+				if ea.validate != nil {
+					ea.validate(t, a)
+				}
+			}
+		}
+		if !found {
+			anyMissing = true
+			assert.True(t, found, "unable to find expected action: %v", ea)
+		}
+	}
+	if anyMissing {
+		tLog.Warnf("actions found: %v", actions)
+	}
+}
+func TestRegistryUserName(t *testing.T) {
+	cases := []struct {
+		name           string
+		clusterID      string
+		expectedResult string
+	}{
+		{
+			name:           "test registry user",
+			clusterID:      "testcluster-a123f",
+			expectedResult: "testcluster-a123f-registry",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			result := getRegistryUserName(tc.clusterID)
+
+			// Assert
+			assert.True(t, result == tc.expectedResult, "expected %v got %v", tc.expectedResult, result)
+		})
+	}
+}
+
+func getKey(cluster *clusterapiv1.Cluster, t *testing.T) string {
+	key, err := controller.KeyFunc(cluster)
+	if err != nil {
+		t.Errorf("Unexpected error getting key for cluster %v: %v", cluster.Name, err)
+		return ""
+	}
+	return key
+}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -729,6 +729,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
+						"registryInfraCompleted": {
+							SchemaProps: spec.SchemaProps{
+								Description: "RegistryInfraCompleted is true once the registryinfra controller has finished processing (doesn't necessarily mean S3 bucket provisioned if annotations don't want S3 configured).",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
+						"registryInfraInstalledGeneration": {
+							SchemaProps: spec.SchemaProps{
+								Description: "RegistryInfraInstalledGeneration is the generation of the Cluster used to generate the latest completed registry infrastructure sync",
+								Type:        []string{"integer"},
+								Format:      "int64",
+							},
+						},
 						"componentsInstalled": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ComponentsInstalled is true if the additional components needed for the cluster have been installed",
@@ -818,7 +832,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"conditions", "provisioned", "provisionedJobGeneration", "controlPlaneInstalled", "controlPlaneInstalledJobClusterGeneration", "controlPlaneInstalledJobMachineSetGeneration", "componentsInstalled", "componentsInstalledJobClusterGeneration", "componentsInstalledJobMachineSetGeneration", "nodeConfigInstalled", "nodeConfigInstalledJobClusterGeneration", "nodeConfigInstalledJobMachineSetGeneration", "nodeConfigLastInstalled", "clusterAPIInstalled", "clusterAPIInstalledJobClusterGeneration", "clusterAPIInstalledJobMachineSetGeneration", "clusterAPIInstalledTime", "ready"},
+					Required: []string{"conditions", "provisioned", "provisionedJobGeneration", "controlPlaneInstalled", "controlPlaneInstalledJobClusterGeneration", "controlPlaneInstalledJobMachineSetGeneration", "registryInfraCompleted", "registryInfraInstalledGeneration", "componentsInstalled", "componentsInstalledJobClusterGeneration", "componentsInstalledJobMachineSetGeneration", "nodeConfigInstalled", "nodeConfigInstalledJobClusterGeneration", "nodeConfigInstalledJobMachineSetGeneration", "nodeConfigLastInstalled", "clusterAPIInstalled", "clusterAPIInstalledJobClusterGeneration", "clusterAPIInstalledJobMachineSetGeneration", "clusterAPIInstalledTime", "ready"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
controller to handle setting up the necessary infra pieces so that a cluster can run with an S3-backed registry

update pkg/ansible/generate to populate the various openshift_hosted_registry* ansible variables

introduce registryinfra controller to watch for new clusters and create:
an s3 bucket
an IAM user for the cluster registry to use to talk to the s3 bucket
a kube secret holding the IAM creds to be passed to the registry

allow non-s3-backed-registry by annotating the clusterdeployment:
clusteroperator.openshift.io/s3-backed-registry: "false"

