### PR TITLE
Remove ClusterID field from MachineSetSpec

### DIFF
--- a/contrib/cmd/aws-actuator-test/main.go
+++ b/contrib/cmd/aws-actuator-test/main.go
@@ -172,7 +172,6 @@ func testClusterAPIResources(name string) (*clusterv1.Cluster, *clusterv1.Machin
 			Kind:       "MachineSetProviderConfigSpec",
 		},
 		MachineSetSpec: cov1.MachineSetSpec{
-			ClusterID: name,
 			VMImage: cov1.VMImage{
 				AWSImage: awsutil.String("ami-0e8468df91f4e8b6c"),
 			},

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -32,6 +32,10 @@ const (
 	// cluster to which it belongs.
 	ClusterNameLabel = "clusteroperator.openshift.io/cluster"
 
+	// MachineSetNameLabel is the label to apply to objects that belong to the
+	// machine set with the name.
+	MachineSetNameLabel = "clusteroperator.openshift.io/machineset"
+
 	// ClusterDeploymentLabel is the label used on clusters to link to the ClusterDeployment that sourced it.
 	ClusterDeploymentLabel = "clusteroperator.openshift.io/cluster-deployment"
 
@@ -599,9 +603,6 @@ type MachineSetConfig struct {
 // MachineSetSpec is the Cluster Operator specification for a Cluster API machine template provider config.
 // TODO: This should be renamed, it is now used on MachineTemplate.Spec.ProviderConfig.
 type MachineSetSpec struct {
-	// ClusterID is the ID of the cluster in the cloud provider.
-	ClusterID string
-
 	// MachineSetConfig is the configuration for the MachineSet
 	MachineSetConfig
 

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -32,6 +32,10 @@ const (
 	// cluster to which it belongs.
 	ClusterNameLabel = "clusteroperator.openshift.io/cluster"
 
+	// MachineSetNameLabel is the label to apply to objects that belong to the
+	// machine set with the name.
+	MachineSetNameLabel = "clusteroperator.openshift.io/machineset"
+
 	// ClusterDeploymentLabel is the label used on clusters to link to the ClusterDeployment that sourced it.
 	ClusterDeploymentLabel = "clusteroperator.openshift.io/cluster-deployment"
 
@@ -600,9 +604,6 @@ type MachineSetConfig struct {
 // MachineSetSpec is the Cluster Operator specification for a Cluster API machine template provider config.
 // TODO: This should be renamed, it is now used on MachineTemplate.Spec.ProviderConfig.
 type MachineSetSpec struct {
-	// ClusterID is the ID of the cluster in the cloud provider.
-	ClusterID string `json:"clusterID"`
-
 	// MachineSetConfig is the configuration for the MachineSet
 	MachineSetConfig `json:",inline"`
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -803,7 +803,6 @@ func Convert_clusteroperator_MachineSetProviderConfigSpec_To_v1alpha1_MachineSet
 }
 
 func autoConvert_v1alpha1_MachineSetSpec_To_clusteroperator_MachineSetSpec(in *MachineSetSpec, out *clusteroperator.MachineSetSpec, s conversion.Scope) error {
-	out.ClusterID = in.ClusterID
 	if err := Convert_v1alpha1_MachineSetConfig_To_clusteroperator_MachineSetConfig(&in.MachineSetConfig, &out.MachineSetConfig, s); err != nil {
 		return err
 	}
@@ -823,7 +822,6 @@ func Convert_v1alpha1_MachineSetSpec_To_clusteroperator_MachineSetSpec(in *Machi
 }
 
 func autoConvert_clusteroperator_MachineSetSpec_To_v1alpha1_MachineSetSpec(in *clusteroperator.MachineSetSpec, out *MachineSetSpec, s conversion.Scope) error {
-	out.ClusterID = in.ClusterID
 	if err := Convert_clusteroperator_MachineSetConfig_To_v1alpha1_MachineSetConfig(&in.MachineSetConfig, &out.MachineSetConfig, s); err != nil {
 		return err
 	}

--- a/pkg/clusterapi/aws/actuator.go
+++ b/pkg/clusterapi/aws/actuator.go
@@ -543,12 +543,9 @@ func (a *Actuator) updateStatus(machine *clusterv1.Machine, instance *ec2.Instan
 	return nil
 }
 
-func getClusterID(machine *clusterv1.Machine) (string, error) {
-	coMachineSetSpec, err := controller.MachineSetSpecFromClusterAPIMachineSpec(&machine.Spec)
-	if err != nil {
-		return "", err
-	}
-	return coMachineSetSpec.ClusterID, nil
+func getClusterID(machine *clusterv1.Machine) (string, bool) {
+	clusterID, ok := machine.Labels[cov1.ClusterNameLabel]
+	return clusterID, ok
 }
 
 // template for user data

--- a/pkg/clusterapi/aws/actuator_test.go
+++ b/pkg/clusterapi/aws/actuator_test.go
@@ -743,7 +743,6 @@ func testCluster(t *testing.T) (*capiv1.Cluster, error) {
 func testMachine(name, clusterName string, nodeType clustopv1.NodeType, isInfra bool, currentStatus *capiv1.MachineStatus) *capiv1.Machine {
 	testAMI := testImage
 	msSpec := clustopv1.MachineSetSpec{
-		ClusterID: testClusterID,
 		MachineSetConfig: clustopv1.MachineSetConfig{
 			Infra:    isInfra,
 			Size:     3,

--- a/pkg/clusterapi/aws/utils.go
+++ b/pkg/clusterapi/aws/utils.go
@@ -106,9 +106,9 @@ func GetInstances(machine *clusterv1.Machine, client Client, instanceStateFilter
 
 	machineName := machine.Name
 
-	clusterID, err := getClusterID(machine)
-	if err != nil {
-		return []*ec2.Instance{}, fmt.Errorf("unable to get cluster ID for machine %q: %v", machine.Name, err)
+	clusterID, ok := getClusterID(machine)
+	if !ok {
+		return []*ec2.Instance{}, fmt.Errorf("unable to get cluster ID for machine: %q", machine.Name)
 	}
 
 	requestFilters := []*ec2.Filter{

--- a/pkg/controller/awselb/aws_elb_controller.go
+++ b/pkg/controller/awselb/aws_elb_controller.go
@@ -276,6 +276,11 @@ func (c *Controller) syncMachine(key string) error {
 func (c *Controller) processMachine(machine *capiv1.Machine) error {
 	mLog := clustoplog.WithMachine(c.logger, machine)
 
+	clusterID, ok := machine.Labels[clustopv1.ClusterNameLabel]
+	if !ok {
+		return fmt.Errorf("unable to lookup cluster for machine: %s", machine.Name)
+	}
+
 	coMachineSetSpec, err := controller.MachineSetSpecFromClusterAPIMachineSpec(&machine.Spec)
 	if err != nil {
 		return err
@@ -316,11 +321,11 @@ func (c *Controller) processMachine(machine *capiv1.Machine) error {
 	}
 	mLog = mLog.WithField("instanceID", *instance.InstanceId)
 
-	err = c.addInstanceToELB(instance, controller.ELBMasterExternalName(coMachineSetSpec.ClusterID), client, mLog)
+	err = c.addInstanceToELB(instance, controller.ELBMasterExternalName(clusterID), client, mLog)
 	if err != nil {
 		return err
 	}
-	err = c.addInstanceToELB(instance, controller.ELBMasterInternalName(coMachineSetSpec.ClusterID), client, mLog)
+	err = c.addInstanceToELB(instance, controller.ELBMasterInternalName(clusterID), client, mLog)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/awselb/aws_elb_controller_test.go
+++ b/pkg/controller/awselb/aws_elb_controller_test.go
@@ -277,7 +277,6 @@ func testClusterVersion() *clustopv1.ClusterVersion {
 func testMachine(generation int64, name, clusterName string, nodeType clustopv1.NodeType, isInfra bool, currentStatus *clustopv1.AWSMachineProviderStatus) *capiv1.Machine {
 	testAMI := testImage
 	msSpec := clustopv1.MachineSetSpec{
-		ClusterID: testClusterID,
 		MachineSetConfig: clustopv1.MachineSetConfig{
 			Infra:    isInfra,
 			Size:     3,

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -66,8 +66,6 @@ const (
 
 	// versionExists indicates that the cluster's desired version does exist
 	versionExists = "VersionExists"
-
-	machineSetNameLabel = "clusteroperator.openshift.io/machineset"
 )
 
 // NewController returns a new cluster deployment controller.
@@ -709,7 +707,7 @@ func buildMasterMachineSet(clusterDeployment *clustop.ClusterDeployment, cluster
 	ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 	machineSet.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	machineSetLabels := map[string]string{
-		machineSetNameLabel:            machineSet.Name,
+		clustop.MachineSetNameLabel:    machineSet.Name,
 		clustop.ClusterDeploymentLabel: clusterDeployment.Name,
 		clustop.ClusterNameLabel:       cluster.Name,
 	}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -73,9 +73,6 @@ var (
 	// MachineSetUIDLabel is the label to apply to objects that belong to the
 	// machine set with the UID.
 	MachineSetUIDLabel = "machine-set-uid"
-	// MachineSetNameLabel is the label to apply to objects that belong to the
-	// machine set with the name.
-	MachineSetNameLabel = "machine-set"
 	// JobTypeLabel is the label to apply to jobs and configmaps that are used
 	// to execute the type of job.
 	JobTypeLabel = "job-type"
@@ -580,7 +577,6 @@ func EncodeAWSMachineProviderStatus(awsStatus *clusteroperator.AWSMachineProvide
 // MachineProviderConfigFromMachineSetConfig returns a RawExtension with a machine ProviderConfig from a MachineSetConfig
 func MachineProviderConfigFromMachineSetConfig(machineSetConfig *clusteroperator.MachineSetConfig, clusterDeploymentSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion *clusteroperator.ClusterVersion) (*runtime.RawExtension, error) {
 	msSpec := &clusteroperator.MachineSetSpec{
-		ClusterID:        clusterDeploymentSpec.ClusterID,
 		MachineSetConfig: *machineSetConfig,
 	}
 	vmImage, err := getImage(clusterDeploymentSpec, clusterVersion)
@@ -732,8 +728,8 @@ func BuildMachineSet(ms *clusteroperator.ClusterMachineSet, clusterDeploymentSpe
 	replicas := int32(ms.Size)
 	capiMachineSet.Spec.Replicas = &replicas
 	labels := map[string]string{
-		"machineset": machineSetName,
-		"cluster":    clusterDeploymentSpec.ClusterID,
+		clusteroperator.MachineSetNameLabel: machineSetName,
+		clusteroperator.ClusterNameLabel:    clusterDeploymentSpec.ClusterID,
 	}
 	capiMachineSet.Labels = labels
 	capiMachineSet.Spec.Selector.MatchLabels = labels

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -373,7 +373,7 @@ func (c *Controller) syncDeletedClusterDeployment(clusterDeployment *cov1.Cluste
 	if err != nil {
 		return fmt.Errorf("error bulding remoteclusterclient connection: %v", err)
 	}
-	labelSelector := fmt.Sprintf("cluster=%s", clusterDeployment.Spec.ClusterID)
+	labelSelector := fmt.Sprintf("%s=%s", cov1.ClusterNameLabel, clusterDeployment.Spec.ClusterID)
 	remoteMachineSets, err := remoteClusterAPIClient.ClusterV1alpha1().MachineSets(remoteClusterAPINamespace).List(metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return fmt.Errorf("error retrieving remote machinesets: %v", err)

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -176,7 +176,7 @@ func TestClusterSyncing(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// :ASSEMBLE:
+			// Arrange
 			// Setup the mocks, informers, etc
 			ctx := setupTest()
 
@@ -220,10 +220,10 @@ func TestClusterSyncing(t *testing.T) {
 			// Mock that the informer's cache has a cluster opertaor cluster deployment in it.
 			ctx.clusterDeploymentStore.Add(tc.clusterDeployment)
 
-			// :ACT:
+			// Act
 			err = ctx.controller.syncClusterDeployment(getKey(tc.clusterDeployment, t))
 
-			// :ASSERT:
+			// Assert
 			if tc.errorExpected != "" {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tc.errorExpected)
@@ -367,8 +367,8 @@ func TestMachineSetSyncing(t *testing.T) {
 						Name:      testClusterID + "-compute",
 						Namespace: remoteClusterAPINamespace,
 						Labels: map[string]string{
-							"cluster":    testClusterID,
-							"machineset": testClusterID + "-compute",
+							"clusteroperator.openshift.io/cluster":    testClusterID,
+							"clusteroperator.openshift.io/machineset": testClusterID + "-compute",
 						},
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -380,8 +380,8 @@ func TestMachineSetSyncing(t *testing.T) {
 						Name:      testClusterID + "-compute2",
 						Namespace: remoteClusterAPINamespace,
 						Labels: map[string]string{
-							"cluster":    testClusterID,
-							"machineset": testClusterID + "-compute2",
+							"clusteroperator.openshift.io/cluster":    testClusterID,
+							"clusteroperator.openshift.io/machineset": testClusterID + "-compute2",
 						},
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -400,8 +400,8 @@ func TestMachineSetSyncing(t *testing.T) {
 						Name:      testClusterID + "-compute",
 						Namespace: remoteClusterAPINamespace,
 						Labels: map[string]string{
-							"cluster":    testClusterID,
-							"machineset": testClusterID + "-compute",
+							"clusteroperator.openshift.io/cluster":    testClusterID,
+							"clusteroperator.openshift.io/machineset": testClusterID + "-compute",
 						},
 					},
 					Spec: clusterapiv1.MachineSetSpec{
@@ -426,6 +426,7 @@ func TestMachineSetSyncing(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
 			ctx := setupTest()
 			tLog := ctx.controller.logger
 
@@ -457,8 +458,11 @@ func TestMachineSetSyncing(t *testing.T) {
 			ctx.clusterStore.Add(&capiCluster)
 
 			ctx.clusterDeploymentStore.Add(tc.clusterDeployment)
+
+			// Act
 			err = ctx.controller.syncClusterDeployment(getKey(tc.clusterDeployment, t))
 
+			// Assert
 			if tc.errorExpected != "" {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tc.errorExpected)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1179,13 +1179,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 							},
 						},
-						"clusterID": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ClusterID is the ID of the cluster in the cloud provider.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
 						"nodeType": {
 							SchemaProps: spec.SchemaProps{
 								Description: "NodeType is the type of nodes that comprise the MachineSet",
@@ -1246,7 +1239,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"clusterID", "nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef", "vmImage"},
+					Required: []string{"nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef", "vmImage"},
 				},
 			},
 			Dependencies: []string{
@@ -1257,13 +1250,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "MachineSetSpec is the Cluster Operator specification for a Cluster API machine template provider config.",
 					Properties: map[string]spec.Schema{
-						"clusterID": {
-							SchemaProps: spec.SchemaProps{
-								Description: "ClusterID is the ID of the cluster in the cloud provider.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
 						"nodeType": {
 							SchemaProps: spec.SchemaProps{
 								Description: "NodeType is the type of nodes that comprise the MachineSet",
@@ -1324,7 +1310,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"clusterID", "nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef", "vmImage"},
+					Required: []string{"nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef", "vmImage"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
- [x] Remove ClusterID field from MachineSetSpec
- [x] Fix bug where remote machine set is created with a label of "cluster:" instead of "clusteroperator.openshift.io/cluster"
- [x] Test cluster creation works as expected