### PR TITLE
Use aws-machine-controller binary on target cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,10 +380,11 @@ OA_ANSIBLE_URL    ?= https://github.com/openshift/openshift-ansible.git
 OA_ANSIBLE_BRANCH ?= release-3.10
 
 define build-cluster-operator-ansible-image #(repo, branch, imagename, tag)
+        cp bin/aws-machine-controller build/cluster-operator-ansible/playbooks/cluster-api-prep/files
 	docker build -t "$3:$4" --build-arg=CO_ANSIBLE_URL=$1 --build-arg=CO_ANSIBLE_BRANCH=$2 build/cluster-operator-ansible
 endef
 
-cluster-operator-ansible-images: build/cluster-operator-ansible/Dockerfile build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml build/cluster-operator-ansible/playbooks/cluster-operator/node-config-daemonset.yml
+cluster-operator-ansible-images: build/cluster-operator-ansible/Dockerfile build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml build/cluster-operator-ansible/playbooks/cluster-operator/node-config-daemonset.yml $(BINDIR)/aws-machine-controller
 	# build v3.9 on openshift-ansible:release-3.9
 	$(call build-cluster-operator-ansible-image,$(OA_ANSIBLE_URL),"release-3.9",$(CLUSTER_OPERATOR_ANSIBLE_IMAGE_NAME),"v3.9")
 

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml
@@ -29,6 +29,13 @@
     import_role:
       name: lib_openshift
 
+  - name: copy cluster-operator binary to master
+    copy:
+      src: files/aws-machine-controller
+      dest: /usr/bin/aws-machine-controller
+      setype: container_file_t
+      mode: 0755
+
   - name: slurp local template content
     slurp:
       src: files/cluster-api-template.yaml

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/.gitignore
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/.gitignore
@@ -1,0 +1,1 @@
+aws-machine-controller

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
@@ -215,6 +215,9 @@ objects:
           - name: bootstrap-kubeconfig
             mountPath: /etc/origin/master
             readOnly: true
+          - name: aws-machine-controller
+            mountPath: /opt/services/aws-machine-controller
+            readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -227,6 +230,9 @@ objects:
         securityContext: {}
         terminationGracePeriodSeconds: 30
         volumes:
+        - name: aws-machine-controller
+          hostPath:
+            path: /usr/bin/aws-machine-controller
         - name: bootstrap-kubeconfig
           secret:
             secretName: bootstrap-kubeconfig
@@ -365,6 +371,43 @@ objects:
     kind: ServiceAccount
     name: cluster-api-controller-manager
     namespace: ${CLUSTER_API_NAMESPACE}
+- allowHostDirVolumePlugin: true
+  allowHostIPC: false
+  allowHostNetwork: false
+  allowHostPID: false
+  allowHostPorts: false
+  allowPrivilegedContainer: false
+  allowedCapabilities: null
+  apiVersion: security.openshift.io/v1
+  defaultAddCapabilities: null
+  fsGroup:
+    type: MustRunAs
+  groups: []
+  kind: SecurityContextConstraints
+  metadata:
+    name: hostmount-restricted-clusterapi
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  runAsUser:
+    type: MustRunAsRange
+  seLinuxContext:
+    type: MustRunAs
+  supplementalGroups:
+    type: RunAsAny
+  users:
+  - system:serviceaccount:${CLUSTER_API_NAMESPACE}:cluster-api-controller-manager
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+  - hostPath
 
 
 parameters:


### PR DESCRIPTION
When testing/developing on AWS actuator, we have to go through the trouble of pushing an image to an external registry and manually changing the deployment on the target cluster. Also when CI tests it, we're not really testing the built AWS actuator on the target cluster. This pull does the following:
- Add the aws-machine-controller binary to the cluster-operator-ansible image
- Modifies the playbook that deploys the cluster api to copy the aws-machine-controller binary to the target master
- Modifies the template for the cluster-api to do a host mount for the aws-machine-controller binary so that it uses that instead of whatever was on the image.

This results in the following limitations:
- Only 1 master is supported
- Only the aws-machine-controller binary is copied over. Other changes to the image are not reflected on the target system.