### PR TITLE
Mount aws-machine-controller binary only in development case

### DIFF
--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/.gitignore
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/.gitignore
@@ -1,0 +1,1 @@
+deploy-cluster-api.yaml

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-common.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-common.yaml
@@ -1,23 +1,4 @@
 ---
-- name: Setup the master node group
-  hosts: localhost
-  tasks:
-  - import_role:
-      name: openshift_aws
-      tasks_from: setup_master_group.yml
-
-#- name: set the master facts for hostname to elb
-#  hosts: masters
-#  gather_facts: no
-#  remote_user: root
-#  tasks:
-#  - import_role:
-#      name: openshift_aws
-#      tasks_from: master_facts.yml
-
-#- name: run the init
-#  import_playbook: ../init/main.yml
-
 - name: install cluster-api
   hosts: masters[0]
   gather_facts: no
@@ -28,19 +9,6 @@
   - name: import lib_openshift
     import_role:
       name: lib_openshift
-
-  - name: copy cluster-operator binary to master
-    copy:
-      src: files/aws-machine-controller
-      dest: /usr/bin/aws-machine-controller
-      setype: container_file_t
-      mode: 0755
-
-  - name: slurp local template content
-    slurp:
-      src: files/cluster-api-template.yaml
-    delegate_to: localhost
-    register: template
 
   - name: "create {{ cluster_api_namespace }} namesapce"
     oc_project:
@@ -89,33 +57,41 @@
         cluster_api_key: "{{ clusterapi_key.content }}"
         cluster_api_ca_bundle: "{{ clusterapi_crt.content }}"
 
-  - name: create temp file to hold the template
+  - name: create temp directory to hold templates
     tempfile:
-      state: file
-    register: temp_file
+      state: directory
+    register: temp_dir
 
-  - name: copy template over
+  - name: copy main template over
     copy:
       src: files/cluster-api-template.yaml
-      dest: "{{ temp_file.path }}"
+      dest: "{{ temp_dir.path }}/cluster-api-template.yaml"
 
-  - name: process template
+  - name: copy machine controller template over
+    copy:
+      src: "files/{{ machine_controller_template }}"
+      dest: "{{ temp_dir.path }}/machine-controller-template.yaml"
+
+  - name: process templates
     shell: |-
-      oc process -f {{ temp_file.path }} \
+      oc process -f {{ temp_dir.path }}/cluster-api-template.yaml \
          -p CLUSTER_API_NAMESPACE={{ cluster_api_namespace }} \
          -p SERVING_CA={{ cluster_api_ca_bundle }} \
          -p SERVING_CERT={{ cluster_api_cert }} \
          -p SERVING_KEY={{ cluster_api_key }} \
          -p BOOTSTRAP_KUBECONFIG='{{ bootstrap_kubeconfig.content }}' \
          -p CLUSTER_API_IMAGE='{{ cluster_api_image }}' \
-         -p CLUSTER_API_IMAGE_PULL_POLICY='{{ cluster_api_image_pull_policy }}' \
+         -p CLUSTER_API_IMAGE_PULL_POLICY='{{ cluster_api_image_pull_policy }}' | oc apply -f -
+
+      oc process -f {{ temp_dir.path }}/machine-controller-template.yaml \
+         -p CLUSTER_API_NAMESPACE={{ cluster_api_namespace }} \
          -p MACHINE_CONTROLLER_IMAGE='{{ machine_controller_image }}' \
          -p MACHINE_CONTROLLER_IMAGE_PULL_POLICY='{{ machine_controller_image_pull_policy }}' | oc apply -f -
 
-  - name: remove template file
+  - name: remove template files
     file:
       state: absent
-      path: "{{ temp_file.path }}"
+      path: "{{ temp_dir.path }}"
 
   - name: Wait for cluster api deployment to complete
     oc_obj:

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-development.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-development.yaml
@@ -1,0 +1,28 @@
+---
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- name: copy aws-machine-controller binary to target masters
+  hosts: masters
+  gather_facts: no
+  remote_user: root
+  tasks:
+  - name: copy machine controller binary to master
+    copy:
+      src: files/aws-machine-controller
+      dest: /usr/bin/aws-machine-controller
+      setype: container_file_t
+      mode: 0755
+
+- hosts: masters[0]
+  gather_facts: no
+  tasks:
+  - name: set machine controller template
+    set_fact:
+      machine_controller_template: machine-controller-template-dev.yaml
+
+- import_playbook: deploy-cluster-api-common.yaml

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-production.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-production.yaml
@@ -1,0 +1,16 @@
+---
+- name: Setup the master node group
+  hosts: localhost
+  tasks:
+  - import_role:
+      name: openshift_aws
+      tasks_from: setup_master_group.yml
+
+- hosts: masters[0]
+  gather_facts: no
+  tasks:
+  - name: set machine controller template
+    set_fact:
+      machine_controller_template: machine-controller-template.yaml
+
+- import_playbook: deploy-cluster-api-common.yaml

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-api-template.yaml
@@ -9,8 +9,6 @@
 #   SERVING_CA: base-64-encoded, pem CA cert for the ssl certs. Required.
 #   CLUSTER_API_IMAGE: clusterapi container image location
 #   CLUSTER_API_IMAGE_PULL_POLICY: control image pull policy for clusterapi containers
-#   MACHINE_CONTROLLER_IMAGE: machine controller image reference
-#   MACHINE_CONTROLLER_IMAGE_PULL_POLICY: pull policy for machine controller image
 #
 ########
 
@@ -185,61 +183,6 @@ objects:
 - apiVersion: apps/v1beta1
   kind: Deployment
   metadata:
-    name: aws-machine-controller
-    namespace: ${CLUSTER_API_NAMESPACE}
-    labels:
-      app: aws-machine-controller
-  spec:
-    selector:
-      matchLabels:
-        app: aws-machine-controller
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          app: aws-machine-controller
-      spec:
-        serviceAccountName: cluster-api-controller-manager
-        nodeSelector:
-          node-role.kubernetes.io/master: "true"
-        containers:
-        - name: machine-controller
-          image: ${MACHINE_CONTROLLER_IMAGE}
-          imagePullPolicy: ${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}
-          command:
-          - /opt/services/aws-machine-controller
-          args:
-          - --log-level=debug
-          - --default-availability-zone=${DEFAULT_AVAILABILITY_ZONE}
-          volumeMounts:
-          - name: bootstrap-kubeconfig
-            mountPath: /etc/origin/master
-            readOnly: true
-          - name: aws-machine-controller
-            mountPath: /opt/services/aws-machine-controller
-            readOnly: true
-          resources:
-            requests:
-              cpu: 100m
-              memory: 20Mi
-            limits:
-              cpu: 100m
-              memory: 30Mi
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-        volumes:
-        - name: aws-machine-controller
-          hostPath:
-            path: /usr/bin/aws-machine-controller
-        - name: bootstrap-kubeconfig
-          secret:
-            secretName: bootstrap-kubeconfig
-
-- apiVersion: apps/v1beta1
-  kind: Deployment
-  metadata:
     name: cluster-api-controller-manager
     namespace: ${CLUSTER_API_NAMESPACE}
     labels:
@@ -371,44 +314,6 @@ objects:
     kind: ServiceAccount
     name: cluster-api-controller-manager
     namespace: ${CLUSTER_API_NAMESPACE}
-- allowHostDirVolumePlugin: true
-  allowHostIPC: false
-  allowHostNetwork: false
-  allowHostPID: false
-  allowHostPorts: false
-  allowPrivilegedContainer: false
-  allowedCapabilities: null
-  apiVersion: security.openshift.io/v1
-  defaultAddCapabilities: null
-  fsGroup:
-    type: MustRunAs
-  groups: []
-  kind: SecurityContextConstraints
-  metadata:
-    name: hostmount-restricted-clusterapi
-  readOnlyRootFilesystem: false
-  requiredDropCapabilities:
-  - KILL
-  - MKNOD
-  - SETUID
-  - SETGID
-  runAsUser:
-    type: MustRunAsRange
-  seLinuxContext:
-    type: MustRunAs
-  supplementalGroups:
-    type: RunAsAny
-  users:
-  - system:serviceaccount:${CLUSTER_API_NAMESPACE}:cluster-api-controller-manager
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
-  - hostPath
-
 
 parameters:
 # namespace to install clusterapi services onto
@@ -429,10 +334,5 @@ parameters:
 # location of container image
 - name: CLUSTER_API_IMAGE
 # machine controller image
-- name: MACHINE_CONTROLLER_IMAGE
-- name: MACHINE_CONTROLLER_IMAGE_PULL_POLICY
-  value: Always
-- name: DEFAULT_AVAILABILITY_ZONE
-  value: us-east-1c
 - name: BOOTSTRAP_KUBECONFIG
   value: ""

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/machine-controller-template-dev.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/machine-controller-template-dev.yaml
@@ -1,0 +1,122 @@
+########
+#
+# Template for deploying the AWS Machine Controller on the target cluster
+# This is the development version which mounts a binary from the host file
+# system and runs that instead of the binary burned in the image.
+#
+# Parameters:
+#   CLUSTER_API_NAMESPACE: namespace to hold clusterapi objects/services
+#   MACHINE_CONTROLLER_IMAGE: machine controller image reference
+#   MACHINE_CONTROLLER_IMAGE_PULL_POLICY: pull policy for machine controller image
+#
+########
+
+apiVersion: v1
+kind: Template
+metadata:
+  name: machine-controller-template-dev
+
+objects:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: aws-machine-controller
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: aws-machine-controller
+  spec:
+    selector:
+      matchLabels:
+        app: aws-machine-controller
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: aws-machine-controller
+      spec:
+        serviceAccountName: cluster-api-controller-manager
+        nodeSelector:
+          node-role.kubernetes.io/master: "true"
+        containers:
+        - name: machine-controller
+          image: ${MACHINE_CONTROLLER_IMAGE}
+          imagePullPolicy: ${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}
+          command:
+          - /opt/services/aws-machine-controller
+          args:
+          - --log-level=debug
+          - --default-availability-zone=${DEFAULT_AVAILABILITY_ZONE}
+          volumeMounts:
+          - name: bootstrap-kubeconfig
+            mountPath: /etc/origin/master
+            readOnly: true
+          - name: aws-machine-controller
+            mountPath: /opt/services/aws-machine-controller
+            readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 30Mi
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: aws-machine-controller
+          hostPath:
+            path: /usr/bin/aws-machine-controller
+        - name: bootstrap-kubeconfig
+          secret:
+            secretName: bootstrap-kubeconfig
+
+- allowHostDirVolumePlugin: true
+  allowHostIPC: false
+  allowHostNetwork: false
+  allowHostPID: false
+  allowHostPorts: false
+  allowPrivilegedContainer: false
+  allowedCapabilities: null
+  apiVersion: security.openshift.io/v1
+  defaultAddCapabilities: null
+  fsGroup:
+    type: MustRunAs
+  groups: []
+  kind: SecurityContextConstraints
+  metadata:
+    name: hostmount-restricted-clusterapi
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  runAsUser:
+    type: MustRunAsRange
+  seLinuxContext:
+    type: MustRunAs
+  supplementalGroups:
+    type: RunAsAny
+  users:
+  - system:serviceaccount:${CLUSTER_API_NAMESPACE}:cluster-api-controller-manager
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+  - hostPath
+
+
+parameters:
+# namespace to install clusterapi services onto
+- name: CLUSTER_API_NAMESPACE
+  value: kube-cluster
+- name: MACHINE_CONTROLLER_IMAGE
+- name: MACHINE_CONTROLLER_IMAGE_PULL_POLICY
+  value: Always
+- name: DEFAULT_AVAILABILITY_ZONE
+  value: us-east-1c

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/machine-controller-template.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/machine-controller-template.yaml
@@ -1,0 +1,75 @@
+########
+#
+# Template for deploying the AWS Machine Controller on the target cluster
+#
+# Parameters:
+#   CLUSTER_API_NAMESPACE: namespace to hold clusterapi objects/services
+#   MACHINE_CONTROLLER_IMAGE: machine controller image reference
+#   MACHINE_CONTROLLER_IMAGE_PULL_POLICY: pull policy for machine controller image
+#
+########
+
+apiVersion: v1
+kind: Template
+metadata:
+  name: machine-controller-template
+
+objects:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: aws-machine-controller
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: aws-machine-controller
+  spec:
+    selector:
+      matchLabels:
+        app: aws-machine-controller
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: aws-machine-controller
+      spec:
+        serviceAccountName: cluster-api-controller-manager
+        nodeSelector:
+          node-role.kubernetes.io/master: "true"
+        containers:
+        - name: machine-controller
+          image: ${MACHINE_CONTROLLER_IMAGE}
+          imagePullPolicy: ${MACHINE_CONTROLLER_IMAGE_PULL_POLICY}
+          command:
+          - /opt/services/aws-machine-controller
+          args:
+          - --log-level=debug
+          - --default-availability-zone=${DEFAULT_AVAILABILITY_ZONE}
+          volumeMounts:
+          - name: bootstrap-kubeconfig
+            mountPath: /etc/origin/master
+            readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 30Mi
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: bootstrap-kubeconfig
+          secret:
+            secretName: bootstrap-kubeconfig
+
+parameters:
+# namespace to install clusterapi services onto
+- name: CLUSTER_API_NAMESPACE
+  value: kube-cluster
+- name: MACHINE_CONTROLLER_IMAGE
+- name: MACHINE_CONTROLLER_IMAGE_PULL_POLICY
+  value: Always
+- name: DEFAULT_AVAILABILITY_ZONE
+  value: us-east-1c

--- a/contrib/ansible/deploy-devel-playbook.yml
+++ b/contrib/ansible/deploy-devel-playbook.yml
@@ -25,7 +25,7 @@
       machine_controller_image_pull_policy: "{{ machine_controller_image_pull_policy | default('Always') }}"
 
       fake_deployment: "{{ fake_deployment | default(True) }}"
-      ansible_image: "{{ ansible_image | default('cluster-operator-ansible:canary') }}"
+      ansible_image: "{{ ansible_image | default('cluster-operator-ansible:dev') }}"
       ansible_image_pull_policy: "{{ ansible_image_pull_policy | default('Never') }}"
 
       # Normally we assume to build and push images for devel deployments:


### PR DESCRIPTION
Creates a separate cluster-operator-ansible image that supports the binary mount of aws-machine-controller. That way, if you want to use the normal non-hacky way of running aws-machine-controller, you can specify the original image when deploying cluster-operator:
```
./contrib/ansible/deploy-devel-playbook.yml -e ansible_image=cluster-operator-ansible:canary
```
The default will be to use the new :dev tag so that we get our code onto the target cluster.

It also includes the fix to copy the machine controller binary to all masters, enabling support for > 1 master.