### PR TITLE
Remove unused label consts.

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -49,7 +49,9 @@ const (
 	// 7 = length of longest ELB name suffix ("-cp-ext")
 	maxELBBasenameLen = 32 - 7
 
-	clusterDeploymentLabel = "clusteroperator.openshift.io/cluster-deployment"
+	// JobTypeLabel is the label to apply to jobs and configmaps that are used
+	// to execute the type of job.
+	JobTypeLabel = "job-type"
 )
 
 var (
@@ -60,22 +62,6 @@ var (
 	ClusterDeploymentKind = clusteroperator.SchemeGroupVersion.WithKind("ClusterDeployment")
 
 	clusterKind = clusterapi.SchemeGroupVersion.WithKind("Cluster")
-
-	// ClusterUIDLabel is the label to apply to objects that belong to the cluster
-	// with the UID.
-	ClusterUIDLabel = "cluster-uid"
-	// ClusterNameLabel is the label to apply to objects that belong to the
-	// cluster with the name.
-	ClusterNameLabel = "cluster"
-	// MachineSetShortNameLabel is the label to apply to machine sets, and their
-	// descendants, with the short name.
-	MachineSetShortNameLabel = "machine-set-short-name"
-	// MachineSetUIDLabel is the label to apply to objects that belong to the
-	// machine set with the UID.
-	MachineSetUIDLabel = "machine-set-uid"
-	// JobTypeLabel is the label to apply to jobs and configmaps that are used
-	// to execute the type of job.
-	JobTypeLabel = "job-type"
 )
 
 // WaitForCacheSync is a wrapper around cache.WaitForCacheSync that generates log messages
@@ -347,25 +333,14 @@ func ClusterDeploymentForMachineSet(machineSet *clusterapi.MachineSet, clusterDe
 	return clusterDeployment, nil
 }
 
-// MachineSetLabels returns the labels to apply to a machine set belonging to the
-// specified cluster deployment and having the specified short name.
-func MachineSetLabels(clusterDeployment *clusteroperator.ClusterDeployment, machineSetShortName string) map[string]string {
-	return map[string]string{
-		ClusterUIDLabel:          string(clusterDeployment.UID),
-		ClusterNameLabel:         clusterDeployment.Name,
-		MachineSetShortNameLabel: machineSetShortName,
-	}
-}
-
 // JobLabelsForClusterController returns the labels to apply to a job doing a task
 // for the specified cluster.
 // The cluster parameter is a metav1.Object because it could be either a
 // cluster-operator Cluster, and cluster-api Cluster, or a CombinedCluster.
 func JobLabelsForClusterController(cluster metav1.Object, jobType string) map[string]string {
 	return map[string]string{
-		ClusterUIDLabel:  string(cluster.GetUID()),
-		ClusterNameLabel: cluster.GetName(),
-		JobTypeLabel:     jobType,
+		clusteroperator.ClusterNameLabel: cluster.GetName(),
+		JobTypeLabel:                     jobType,
 	}
 }
 

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -506,31 +506,14 @@ func TestGetObjectController(t *testing.T) {
 	}
 }
 
-func TestMachineSetLabels(t *testing.T) {
-	clusterDeployment := &clusteroperator.ClusterDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:  "test-uid",
-			Name: "test-name",
-		},
-	}
-	expected := map[string]string{
-		"cluster-uid":            "test-uid",
-		"cluster":                "test-name",
-		"machine-set-short-name": "test-short-name",
-	}
-	actual := MachineSetLabels(clusterDeployment, "test-short-name")
-	assert.Equal(t, expected, actual)
-}
-
 func TestJobLabelsForClusterController(t *testing.T) {
 	cluster := &metav1.ObjectMeta{
 		UID:  "test-uid",
 		Name: "test-name",
 	}
 	expected := map[string]string{
-		"cluster-uid": "test-uid",
-		"cluster":     "test-name",
-		"job-type":    "test-job-type",
+		"clusteroperator.openshift.io/cluster": "test-name",
+		"job-type":                             "test-job-type",
 	}
 	actual := JobLabelsForClusterController(cluster, "test-job-type")
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
While reviewing another PR, I noticed that there were a handful of unused labels consts in controller_utils.go. This PR removes those. It also removes the unneeded "cluster-uid" label and replaces the "cluster" label placed on jobs with the more specific and ubiquitous "clusteroperator.openshift.io/cluster" label.