### PR TITLE
Add public ssh key to cluster create

### DIFF
--- a/contrib/ansible/create-cluster-playbook.yml
+++ b/contrib/ansible/create-cluster-playbook.yml
@@ -28,7 +28,7 @@
     # Section in credentials file with the AWS creds CO should use to create cloud infra and VMs:
     aws_creds_section: default
 
-    # SSH key used for access to all VMs CO creates:
+    # SSH private key used for access to all VMs CO creates:
     ssh_priv_key: '~/.ssh/libra.pem'
 
     # AWS keypair name to use for cluster machines
@@ -107,6 +107,10 @@
       cluster_cert_path: "{{ cluster_cert_dir }}/{{ cluster_name }}.pem"
       cluster_privatekey_path: "{{ cluster_cert_dir }}/{{ cluster_name }}-key.pem"
 
+  - name: generate ssh public key from ssh private key
+    command: "ssh-keygen -y -f {{ ssh_priv_key }}"
+    register: ssh_keygen_output
+
   - name: load cluster certs, keys and credentials
     set_fact:
       # base-64-encoded, pem cert for the cluster's ELB and rounter pods:
@@ -116,6 +120,7 @@
       l_aws_access_key_id: "{{ lookup('ini', 'aws_access_key_id section=' + aws_creds_section + ' file=' + aws_creds_file) | b64encode }}"
       l_aws_secret_access_key: "{{ lookup('ini', 'aws_secret_access_key section=' + aws_creds_section + ' file=' + aws_creds_file) | b64encode }}"
       l_aws_ssh_private_key: "{{ lookup('file', ssh_priv_key) | b64encode }}"
+      l_aws_ssh_public_key: "{{ ssh_keygen_output.stdout | trim | b64encode }}"
 
   - name: process cluster template
     oc_process:
@@ -129,7 +134,8 @@
         CLUSTER_PRIVATE_KEY: "{{ l_cluster_cert_key }}"
         AWS_ACCESS_KEY_ID: "{{ l_aws_access_key_id }}"
         AWS_SECRET_ACCESS_KEY: "{{ l_aws_secret_access_key }}"
-        SSH_KEY: "{{ l_aws_ssh_private_key }}"
+        SSH_PRIVATE_KEY: "{{ l_aws_ssh_private_key }}"
+        SSH_PUBLIC_KEY: "{{ l_aws_ssh_public_key }}"
         SSH_KEYPAIR_NAME: "{{ aws_ssh_keypair }}"
     register: cluster_reg
 

--- a/contrib/examples/cluster-deployment-template.yaml
+++ b/contrib/examples/cluster-deployment-template.yaml
@@ -33,9 +33,12 @@ parameters:
 - name: AWS_SECRET_ACCESS_KEY
   required: true
   description: Base64 encoded AWS secret access key that can be used to provision cluster resources.
-- name: SSH_KEY
+- name: SSH_PRIVATE_KEY
   required: true
   description: Base64 encoded SSH private key that can be used to access the provisioned servers.
+- name: SSH_PUBLIC_KEY
+  required: true
+  description: Base64 encoded SSH public key that can be used to access the provisioned servers.
 - name: SSH_KEYPAIR_NAME
   required: true
   value: libra
@@ -74,7 +77,8 @@ objects:
       app: cluster-operator
   type: Opaque
   data:
-    ssh-privatekey: ${SSH_KEY}
+    ssh-privatekey: ${SSH_PRIVATE_KEY}
+    ssh-publickey: ${SSH_PUBLIC_KEY}
 
 - apiVersion: clusteroperator.openshift.io/v1alpha1
   kind: ClusterDeployment

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -206,11 +206,9 @@ openshift_aws_create_security_groups: true
 openshift_aws_ssh_key_name: [[ .SSHKeyName ]]
 
 # This will ensure these user and public keys are created.
-#openshift_aws_users:
-#- key_name: myuser_key
-#  username: myuser
-#  pub_key: |
-#         ssh-rsa AAAA
+openshift_aws_users:
+- key_name: [[ .SSHKeyName ]]
+  pub_key: "{{ lookup('file', '/ansible/ssh/publickey.pub') }}"
 
 # -- #
 # S3 #

--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -271,6 +271,11 @@ func (r *jobGenerator) GeneratePlaybooksJobWithServiceAccount(
 							Path: "privatekey.pem",
 							Mode: &sshKeyFileMode,
 						},
+						{
+							Key:  "ssh-publickey",
+							Path: "publickey.pub",
+							Mode: &sshKeyFileMode,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
- [x] Add the ability to generate a public ssh key from the private ssh key to be used during cluster create.
- [x] Test that public key is created / updated in AWS
- [x] Test that cluster creation happens as expected.