### PR TITLE
Honor VPC name and Subnet in AWS hardware spec

### DIFF
--- a/build/cluster-operator-ansible/Dockerfile
+++ b/build/cluster-operator-ansible/Dockerfile
@@ -49,4 +49,8 @@ RUN rm -rf /usr/share/ansible/openshift-ansible/playbooks/cluster-operator/
 # Copy in our playbooks and roles:
 COPY playbooks/cluster-operator ${CLONE_LOCATION}/playbooks/cluster-operator
 
+# Overwrite role files:
+# TODO: Remove this when we have no files to overwrite in roles
+COPY roles ${CLONE_LOCATION}/roles
+
 USER 1001:0

--- a/build/cluster-operator-ansible/roles/openshift_aws/tasks/security_group.yml
+++ b/build/cluster-operator-ansible/roles/openshift_aws/tasks/security_group.yml
@@ -1,0 +1,32 @@
+---
+- name: Fetch the VPC for the vpc.id
+  ec2_vpc_net_facts:
+    region: "{{ openshift_aws_region }}"
+    filters:
+      "tag:Name": "{{ openshift_aws_vpc_name }}"
+  register: vpcout
+
+- name: create the node group sgs
+  oo_ec2_group:
+    name: "{{ item.value.name}}"
+    description: "{{ item.value.desc }}"
+    rules: "{{ item.value.rules if 'rules' in item.value else [] }}"
+    region: "{{ openshift_aws_region }}"
+    vpc_id: "{{ vpcout.vpcs[0].id }}"
+  with_dict: "{{ openshift_aws_node_security_groups }}"
+
+- name: create the k8s sgs for the node group
+  oo_ec2_group:
+    name: "{{ item.value.name }}_k8s"
+    description: "{{ item.value.desc }} for k8s"
+    region: "{{ openshift_aws_region }}"
+    vpc_id: "{{ vpcout.vpcs[0].id }}"
+  with_dict: "{{ openshift_aws_node_security_groups }}"
+  register: k8s_sg_create
+
+- name: tag sg groups with proper tags
+  ec2_tag:
+    tags: "{{ openshift_aws_security_groups_tags }}"
+    resource: "{{ item.group_id }}"
+    region: "{{ openshift_aws_region }}"
+  with_items: "{{ k8s_sg_create.results }}"

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -157,11 +157,21 @@ osm_cluster_network_cidr: [[ .PodCIDR ]]
 
 # openshift_aws_create_vpc defaults to true.  If you don't wish to provision
 # a vpc, set this to false.
+[[if .VPCName ]]
+openshift_aws_vpc_name: [[ .VPCName ]]
+openshift_aws_create_vpc: false
+[[else]]
+openshift_aws_vpc_name: [[ .ClusterID ]]
+openshift_aws_vpc: [[ .VPCDefaults ]]
 openshift_aws_create_vpc: true
+[[end]]
 
 # Name of the subnet in the vpc to use.  Needs to be set if using a pre-existing
 # vpc + subnet.
 #openshift_aws_subnet_name: cluster-engine-subnet-1
+[[if .SubnetName ]]
+openshift_aws_subnet_name: [[ .SubnetName ]]
+[[end]]
 
 # -------------- #
 # Security Group #
@@ -242,9 +252,6 @@ openshift_clusterid: [[ .ClusterID ]]
 openshift_aws_elb_master_external_name: [[ .ELBMasterExternalName ]]
 openshift_aws_elb_master_internal_name: [[ .ELBMasterInternalName ]]
 openshift_aws_elb_infra_name: [[ .ELBInfraName ]]
-openshift_aws_vpc_name: [[ .ClusterID ]]
-
-openshift_aws_vpc: [[ .VPCDefaults ]]
 
 [[if .ClusterAPIImage]]
 cluster_api_image: [[ .ClusterAPIImage ]]
@@ -327,6 +334,8 @@ type clusterParams struct {
 	MachineControllerImagePullPolicy corev1.PullPolicy
 	PodCIDR                          string
 	ServiceCIDR                      string
+	VPCName                          string
+	SubnetName                       string
 }
 
 type clusterVersionParams struct {
@@ -362,6 +371,8 @@ func GenerateClusterWideVars(
 		VPCDefaults:           vpcDefaults,
 		DeploymentType:        version.DeploymentType,
 		InfraSize:             infraSize,
+		VPCName:               hardwareSpec.VPCName,
+		SubnetName:            hardwareSpec.VPCSubnet,
 		// Openshift-ansible only supports a single value:
 		ServiceCIDR: serviceCIDRs.CIDRBlocks[0],
 		PodCIDR:     podCIDRs.CIDRBlocks[0],


### PR DESCRIPTION
Currently we ignore VPCName from the hardware spec. This PR makes it so we honor it and assume it exists when set. We also need a fix in the ansible openshift_aws role to use the vpc name instead of assuming it's the cluster name. That is getting fixed here: https://github.com/openshift/openshift-ansible/pull/9249
When that fix goes through and it gets backported to 3.10, we can remove the override in this repo.