### PR TITLE
stop including ansible vars with '-e'

### DIFF
--- a/build/cluster-operator-ansible/Dockerfile
+++ b/build/cluster-operator-ansible/Dockerfile
@@ -42,6 +42,11 @@ WORKDIR ${CLONE_LOCATION}
 RUN mkdir ${CLONE_LOCATION}/playbooks/cluster-api-prep && ln -s ../../roles ./playbooks/cluster-api-prep
 COPY playbooks/cluster-api-prep/ ${CLONE_LOCATION}/playbooks/cluster-api-prep
 
+# WORKAROUND: /usr/local/bin/run doesn't handle INVENTORY_DIR when the
+# files are symlinks (like when pointing to a configmap).
+# Remove when openshift-ansible image has fix https://github.com/openshift/openshift-ansible/pull/9309
+COPY run /usr/local/bin/run
+
 # Remove any remnants of our playbooks in the upstream openshift-ansible image:
 # TODO: This can be removed once we drop our directory from openshift-ansible.
 RUN rm -rf /usr/share/ansible/openshift-ansible/playbooks/cluster-operator/

--- a/build/cluster-operator-ansible/run
+++ b/build/cluster-operator-ansible/run
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+#
+# This file serves as the default command to the openshift-ansible image.
+# Runs a playbook with inventory as specified by environment variables.
+#
+# For more information see the documentation:
+#	https://github.com/openshift/openshift-ansible/blob/master/README_CONTAINER_IMAGE.md
+
+# SOURCE and HOME DIRECTORY: /opt/app-root/src
+
+if [[ -z "${PLAYBOOK_FILE}" ]]; then
+  echo
+  echo "PLAYBOOK_FILE must be provided."
+  exec /usr/local/bin/usage
+fi
+
+INVENTORY="$(mktemp)"
+if [[ -v INVENTORY_FILE ]]; then
+  # Make a copy so that ALLOW_ANSIBLE_CONNECTION_LOCAL below
+  # does not attempt to modify the original
+  cp ${INVENTORY_FILE} ${INVENTORY}
+elif [[ -v INVENTORY_DIR ]]; then
+  INVENTORY="$(mktemp -d)"
+  cp -RL ${INVENTORY_DIR}/* ${INVENTORY}
+elif [[ -v INVENTORY_URL ]]; then
+  curl -o ${INVENTORY} ${INVENTORY_URL}
+elif [[ -v DYNAMIC_SCRIPT_URL ]]; then
+  curl -o ${INVENTORY} ${DYNAMIC_SCRIPT_URL}
+  chmod 755 ${INVENTORY}
+elif [[ -v GENERATE_INVENTORY ]]; then
+  # dynamically generate inventory file using bind-mounted info
+  /usr/local/bin/generate ${INVENTORY}
+else
+  echo
+  echo "One of INVENTORY_FILE, INVENTORY_DIR, INVENTORY_URL, GENERATE_INVENTORY, or DYNAMIC_SCRIPT_URL must be provided."
+  exec /usr/local/bin/usage
+fi
+INVENTORY_ARG="-i ${INVENTORY}"
+
+if [[ "$ALLOW_ANSIBLE_CONNECTION_LOCAL" = false ]]; then
+  sed -i s/ansible_connection=local// ${INVENTORY}
+fi
+
+if [[ -v VAULT_PASS ]]; then
+  VAULT_PASS_FILE="$(mktemp)"
+  echo ${VAULT_PASS} > ${VAULT_PASS_FILE}
+  VAULT_PASS_ARG="--vault-password-file ${VAULT_PASS_FILE}"
+fi
+
+cd ${WORK_DIR}
+
+exec ansible-playbook ${INVENTORY_ARG} ${VAULT_PASS_ARG} ${OPTS} ${PLAYBOOK_FILE}

--- a/contrib/fake-openshift-ansible/fake-openshift-ansible
+++ b/contrib/fake-openshift-ansible/fake-openshift-ansible
@@ -12,8 +12,8 @@ set -o errexit
 [ ! -f "${PLAYBOOK_FILE}" ] && { echo "Playbook file ${PLAYBOOK_FILE} not found."; exit 1; }
 
 # Ensure that the inventory file exists.
-[ -z $INVENTORY_FILE ] && { echo "INVENTORY_FILE environment variable not set."; exit 1; }
-[ ! -f "${INVENTORY_FILE}" ] && { echo "Inventory file ${INVENTORY_FILE} not found."; exit 1; }
+[ -z $INVENTORY_DIR ] && { echo "INVENTORY_DIR environment variable not set."; exit 1; }
+[ ! -d "${INVENTORY_DIR}" ] && { echo "Inventory directory ${INVENTORY_DIR} not found."; exit 1; }
 
 # Ensure that the AWS access key ID exists.
 [ -z $AWS_ACCESS_KEY_ID ] && { echo "AWS_ACCESS_KEY_ID environment variable not set."; exit 1; }

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -35,260 +35,262 @@ import (
 // Today this is AWS specific but will need to be broken down for multi-provider.
 const (
 	vpcDefaults = `
-  name: "{{ openshift_aws_vpc_name }}"
-  cidr: 172.31.0.0/16
-  subnets:
-    us-east-1:
-    - cidr: 172.31.48.0/20
-      az: "us-east-1c"
-      default_az: true
-    - cidr: 172.31.32.0/20
-      az: "us-east-1e"
-    - cidr: 172.31.16.0/20
-      az: "us-east-1a"
-    us-east-2:
-    - cidr: 172.31.48.0/20
-      az: "us-east-2a"
-      default_az: True
-    - cidr: 172.31.32.0/20
-      az: "us-east-2b"
-      default_az: false
-    - cidr: 172.31.16.0/20
-      az: "us-east-2c"
-    us-west-1:
-    - cidr: 172.31.16.0/20
-      az: "us-west-1c"
-      default_az: True
-    - cidr: 172.31.0.0/20
-      az: "us-west-1b"
-    us-west-2:
-    - cidr: 172.31.48.0/20
-      az: "us-west-2c"
-      default_az: True
-    - cidr: 172.31.32.0/20
-      az: "us-west-2b"
-    - cidr: 172.31.16.0/20
-      az: "us-west-2a"
+      name: "{{ openshift_aws_vpc_name }}"
+      cidr: 172.31.0.0/16
+      subnets:
+        us-east-1:
+        - cidr: 172.31.48.0/20
+          az: "us-east-1c"
+          default_az: true
+        - cidr: 172.31.32.0/20
+          az: "us-east-1e"
+        - cidr: 172.31.16.0/20
+          az: "us-east-1a"
+        us-east-2:
+        - cidr: 172.31.48.0/20
+          az: "us-east-2a"
+          default_az: True
+        - cidr: 172.31.32.0/20
+          az: "us-east-2b"
+          default_az: false
+        - cidr: 172.31.16.0/20
+          az: "us-east-2c"
+        us-west-1:
+        - cidr: 172.31.16.0/20
+          az: "us-west-1c"
+          default_az: True
+        - cidr: 172.31.0.0/20
+          az: "us-west-1b"
+        us-west-2:
+        - cidr: 172.31.48.0/20
+          az: "us-west-2c"
+          default_az: True
+        - cidr: 172.31.32.0/20
+          az: "us-west-2b"
+        - cidr: 172.31.16.0/20
+          az: "us-west-2a"
 `
 	clusterVarsTemplate = `---
-# Variables that are commented in this file are optional; uncommented variables
-# are mandatory.
-
-# Default values for each variable are provided, as applicable.
-# Example values for mandatory variables are provided as a comment at the end
-# of the line.
-
-# ------------------------ #
-# Common/Cluster Variables #
-# ------------------------ #
-# Variables in this section affect all areas of the cluster
-ansible_ssh_user: [[ .SSHUser ]]
-
-################################################################################
-# Ensure these variables are set for bootstrap
-################################################################################
-# Deployment type must be specified. ('origin' or 'openshift-enterprise')
-openshift_deployment_type: [[ .DeploymentType ]]
-
-openshift_master_bootstrap_enabled: True
-
-openshift_hosted_router_wait: False
-openshift_hosted_registry_wait: False
-# cap to size 1 instead of .InfraSize while we use PV-backed registry storage
-#openshift_hosted_registry_replicas: "{{ [ [[ .InfraSize ]], 2 ] | min }}"
-openshift_hosted_registry_replicas: 1
-
-# Override router edits to set the ROUTER_USE_PROXY_PROTOCOL
-# environment variable. Defaults are taken from
-# roles/openshift_hosted/defaults/main.yml in openshift-ansible and
-# are set in addition to ROUTER_USE_PROXY_PROTOCOL.
-openshift_hosted_router_edits:
-- key: spec.strategy.rollingParams.intervalSeconds
-  value: 1
-  action: put
-- key: spec.strategy.rollingParams.updatePeriodSeconds
-  value: 1
-  action: put
-- key: spec.strategy.activeDeadlineSeconds
-  value: 21600
-  action: put
-- key: spec.template.spec.containers[0].env
-  value:
-    name: ROUTER_USE_PROXY_PROTOCOL
-    value: 'true'
-  action: update
-
-################################################################################
-# cluster specific settings
-################################################################################
-
-# Use containerized installation of master
-containerized: True
-
-# TODO: development specific
-openshift_disable_check: disk_availability,memory_availability,docker_storage,package_version,docker_image_availability
-
-# AWS region
-# This value will instruct the plays where all items should be created.
-# Multi-region deployments are not supported using these plays at this time.
-openshift_aws_region: [[ .Region ]]
-
-openshift_hosted_infra_selector: "node-role.kubernetes.io/infra=true"
-
-#openshift_aws_create_launch_config: true
-#openshift_aws_create_scale_group: true
-
-# AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY are added to job environment
-openshift_cloudprovider_kind: aws
-openshift_cloudprovider_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
-openshift_cloudprovider_aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
-
-# Enable auto-approve of CSRs
-# TODO: Disable this when we have a controller that accepts nodes based on
-# the existing cluster API machine resources
-openshift_master_bootstrap_auto_approve: true
-
-os_sdn_network_plugin_name: "[[ .SDNPluginName ]]"
-openshift_portal_net: [[ .ServiceCIDR ]]
-osm_cluster_network_cidr: [[ .PodCIDR ]]
-
-# --- #
-# VPC #
-# --- #
-
-# openshift_aws_create_vpc defaults to true.  If you don't wish to provision
-# a vpc, set this to false.
-[[if .VPCName ]]
-openshift_aws_vpc_name: [[ .VPCName ]]
-openshift_aws_create_vpc: false
-[[else]]
-openshift_aws_vpc_name: [[ .ClusterID ]]
-openshift_aws_vpc: [[ .VPCDefaults ]]
-openshift_aws_create_vpc: true
-[[end]]
-
-# Name of the subnet in the vpc to use.  Needs to be set if using a pre-existing
-# vpc + subnet.
-#openshift_aws_subnet_name: cluster-engine-subnet-1
-[[if .SubnetName ]]
-openshift_aws_subnet_name: [[ .SubnetName ]]
-[[end]]
-
-# -------------- #
-# Security Group #
-# -------------- #
-
-# openshift_aws_create_security_groups defaults to true.  If you wish to use
-# an existing security group, set this to false.
-openshift_aws_create_security_groups: true
-
-# openshift_aws_build_ami_group is the name of the security group to build the
-# ami in.  This defaults to the value of openshift_aws_clusterid.
-#openshift_aws_build_ami_group: cluster-engine
-
-# openshift_aws_launch_config_security_groups specifies the security groups to
-# apply to the launch config.  The launch config security groups will be what
-# the cluster actually is deployed in.
-# openshift_aws_launch_config_security_groups:
-#   compute:
-#   - cluster-engine
-#   - cluster-engine_compute
-#   - cluster-engine_compute_k8s
-#   infra:
-#   - cluster-engine
-#   - cluster-engine_infra
-#   - cluster-engine_infra_k8s
-#   master:
-#   - cluster-engine
-#   - cluster-engine_master
-#   - cluster-engine_master_k8s
-
-# openshift_aws_node_security_groups are created when
-# openshift_aws_create_security_groups is set to true.
-#openshift_aws_node_security_groups: see roles/openshift_aws/defaults/main.yml
-
-# -------- #
-# ssh keys #
-# -------- #
-
-# Specify the key pair name here to connect to the provisioned instances.  This
-# can be an existing key, or it can be one of the keys specified in
-# openshift_aws_users
-openshift_aws_ssh_key_name: [[ .SSHKeyName ]]
-
-# This will ensure these user and public keys are created.
-openshift_aws_users:
-- key_name: [[ .SSHKeyName ]]
-  pub_key: "{{ lookup('file', '/ansible/ssh/publickey.pub') }}"
-
-# -- #
-# S3 #
-# -- #
-
-# Create an s3 bucket.
-openshift_aws_create_s3: false
-
-# --- #
-# ELB #
-# --- #
-
-# openshift_aws_elb_name will be the base-name of the ELBs.
-# TODO: looks like this is supposed to just be basename variant
-#openshift_aws_elb_name: dgoodwin-dev
-
-# custom certificates are required for the ELB
-openshift_aws_iam_cert_path: /ansible/ssl/server.crt
-openshift_aws_iam_cert_key_path: /ansible/ssl/server.key
-
-# TODO: WARNING: set when we're not using self-signed certs
-#openshift_aws_iam_cert_chain_path: /ansible/ssl/ca.crt
-
-openshift_aws_create_iam_role: True
-openshift_node_use_instance_profiles: True
-
-openshift_aws_clusterid: [[ .ClusterID ]]
-openshift_clusterid: [[ .ClusterID ]]
-openshift_aws_elb_master_external_name: [[ .ELBMasterExternalName ]]
-openshift_aws_elb_master_internal_name: [[ .ELBMasterInternalName ]]
-openshift_aws_elb_infra_name: [[ .ELBInfraName ]]
-
-[[if .ClusterAPIImage]]
-cluster_api_image: [[ .ClusterAPIImage ]]
-[[end]]
-[[if .ClusterAPIImagePullPolicy]]
-cluster_api_image_pull_policy: [[ .ClusterAPIImagePullPolicy ]]
-[[end]]
-[[if .MachineControllerImage]]
-machine_controller_image: [[ .MachineControllerImage ]]
-[[end]]
-[[if .MachineControllerImagePullPolicy]]
-machine_controller_image_pull_policy: [[ .MachineControllerImagePullPolicy ]]
-[[end]]
-
-openshift_aws_master_group:
-- name: "{{ openshift_aws_clusterid }} master group"
-  group: master
-  tags:
-    host-type: master
-    sub-host-type: default
-    runtime: docker
-    Name: "{{ openshift_aws_clusterid }}-master"
-
-openshift_aws_node_groups:
-- name: "{{ openshift_aws_clusterid }} infra group"
-  group: infra
-  tags:
-    host-type: node
-    sub-host-type: infra
-    runtime: docker
-    Name: "{{ openshift_aws_clusterid }}-infra"
-- name: "{{ openshift_aws_clusterid }} compute group"
-  group: compute
-  tags:
-    host-type: node
-    sub-host-type: compute
-    runtime: docker
-    Name: "{{ openshift_aws_clusterid }}-compute"
+all:
+  vars:
+    # Variables that are commented in this file are optional; uncommented variables
+    # are mandatory.
+    
+    # Default values for each variable are provided, as applicable.
+    # Example values for mandatory variables are provided as a comment at the end
+    # of the line.
+    
+    # ------------------------ #
+    # Common/Cluster Variables #
+    # ------------------------ #
+    # Variables in this section affect all areas of the cluster
+    ansible_ssh_user: [[ .SSHUser ]]
+    
+    ################################################################################
+    # Ensure these variables are set for bootstrap
+    ################################################################################
+    # Deployment type must be specified. ('origin' or 'openshift-enterprise')
+    openshift_deployment_type: [[ .DeploymentType ]]
+    
+    openshift_master_bootstrap_enabled: True
+    
+    openshift_hosted_router_wait: False
+    openshift_hosted_registry_wait: False
+    # cap to size 1 instead of .InfraSize while we use PV-backed registry storage
+    #openshift_hosted_registry_replicas: "{{ [ [[ .InfraSize ]], 2 ] | min }}"
+    openshift_hosted_registry_replicas: 1
+    
+    # Override router edits to set the ROUTER_USE_PROXY_PROTOCOL
+    # environment variable. Defaults are taken from
+    # roles/openshift_hosted/defaults/main.yml in openshift-ansible and
+    # are set in addition to ROUTER_USE_PROXY_PROTOCOL.
+    openshift_hosted_router_edits:
+    - key: spec.strategy.rollingParams.intervalSeconds
+      value: 1
+      action: put
+    - key: spec.strategy.rollingParams.updatePeriodSeconds
+      value: 1
+      action: put
+    - key: spec.strategy.activeDeadlineSeconds
+      value: 21600
+      action: put
+    - key: spec.template.spec.containers[0].env
+      value:
+        name: ROUTER_USE_PROXY_PROTOCOL
+        value: 'true'
+      action: update
+    
+    ################################################################################
+    # cluster specific settings
+    ################################################################################
+    
+    # Use containerized installation of master
+    containerized: True
+    
+    # TODO: development specific
+    openshift_disable_check: disk_availability,memory_availability,docker_storage,package_version,docker_image_availability
+    
+    # AWS region
+    # This value will instruct the plays where all items should be created.
+    # Multi-region deployments are not supported using these plays at this time.
+    openshift_aws_region: [[ .Region ]]
+    
+    openshift_hosted_infra_selector: "node-role.kubernetes.io/infra=true"
+    
+    #openshift_aws_create_launch_config: true
+    #openshift_aws_create_scale_group: true
+    
+    # AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY are added to job environment
+    openshift_cloudprovider_kind: aws
+    openshift_cloudprovider_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
+    openshift_cloudprovider_aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
+    
+    # Enable auto-approve of CSRs
+    # TODO: Disable this when we have a controller that accepts nodes based on
+    # the existing cluster API machine resources
+    openshift_master_bootstrap_auto_approve: true
+    
+    os_sdn_network_plugin_name: "[[ .SDNPluginName ]]"
+    openshift_portal_net: [[ .ServiceCIDR ]]
+    osm_cluster_network_cidr: [[ .PodCIDR ]]
+    
+    # --- #
+    # VPC #
+    # --- #
+    
+    # openshift_aws_create_vpc defaults to true.  If you don't wish to provision
+    # a vpc, set this to false.
+    [[if .VPCName ]]
+    openshift_aws_vpc_name: [[ .VPCName ]]
+    openshift_aws_create_vpc: false
+    [[else]]
+    openshift_aws_vpc_name: [[ .ClusterID ]]
+    openshift_aws_vpc: [[ .VPCDefaults ]]
+    openshift_aws_create_vpc: true
+    [[end]]
+    
+    # Name of the subnet in the vpc to use.  Needs to be set if using a pre-existing
+    # vpc + subnet.
+    #openshift_aws_subnet_name: cluster-engine-subnet-1
+    [[if .SubnetName ]]
+    openshift_aws_subnet_name: [[ .SubnetName ]]
+    [[end]]
+    
+    # -------------- #
+    # Security Group #
+    # -------------- #
+    
+    # openshift_aws_create_security_groups defaults to true.  If you wish to use
+    # an existing security group, set this to false.
+    openshift_aws_create_security_groups: true
+    
+    # openshift_aws_build_ami_group is the name of the security group to build the
+    # ami in.  This defaults to the value of openshift_aws_clusterid.
+    #openshift_aws_build_ami_group: cluster-engine
+    
+    # openshift_aws_launch_config_security_groups specifies the security groups to
+    # apply to the launch config.  The launch config security groups will be what
+    # the cluster actually is deployed in.
+    # openshift_aws_launch_config_security_groups:
+    #   compute:
+    #   - cluster-engine
+    #   - cluster-engine_compute
+    #   - cluster-engine_compute_k8s
+    #   infra:
+    #   - cluster-engine
+    #   - cluster-engine_infra
+    #   - cluster-engine_infra_k8s
+    #   master:
+    #   - cluster-engine
+    #   - cluster-engine_master
+    #   - cluster-engine_master_k8s
+    
+    # openshift_aws_node_security_groups are created when
+    # openshift_aws_create_security_groups is set to true.
+    #openshift_aws_node_security_groups: see roles/openshift_aws/defaults/main.yml
+    
+    # -------- #
+    # ssh keys #
+    # -------- #
+    
+    # Specify the key pair name here to connect to the provisioned instances.  This
+    # can be an existing key, or it can be one of the keys specified in
+    # openshift_aws_users
+    openshift_aws_ssh_key_name: [[ .SSHKeyName ]]
+    
+    # This will ensure these user and public keys are created.
+    openshift_aws_users:
+    - key_name: [[ .SSHKeyName ]]
+      pub_key: "{{ lookup('file', '/ansible/ssh/publickey.pub') }}"
+    
+    # -- #
+    # S3 #
+    # -- #
+    
+    # Create an s3 bucket.
+    openshift_aws_create_s3: false
+    
+    # --- #
+    # ELB #
+    # --- #
+    
+    # openshift_aws_elb_name will be the base-name of the ELBs.
+    # TODO: looks like this is supposed to just be basename variant
+    #openshift_aws_elb_name: dgoodwin-dev
+    
+    # custom certificates are required for the ELB
+    openshift_aws_iam_cert_path: /ansible/ssl/server.crt
+    openshift_aws_iam_cert_key_path: /ansible/ssl/server.key
+    
+    # TODO: WARNING: set when we're not using self-signed certs
+    #openshift_aws_iam_cert_chain_path: /ansible/ssl/ca.crt
+    
+    openshift_aws_create_iam_role: True
+    openshift_node_use_instance_profiles: True
+    
+    openshift_aws_clusterid: [[ .ClusterID ]]
+    openshift_clusterid: [[ .ClusterID ]]
+    openshift_aws_elb_master_external_name: [[ .ELBMasterExternalName ]]
+    openshift_aws_elb_master_internal_name: [[ .ELBMasterInternalName ]]
+    openshift_aws_elb_infra_name: [[ .ELBInfraName ]]
+    
+    [[if .ClusterAPIImage]]
+    cluster_api_image: [[ .ClusterAPIImage ]]
+    [[end]]
+    [[if .ClusterAPIImagePullPolicy]]
+    cluster_api_image_pull_policy: [[ .ClusterAPIImagePullPolicy ]]
+    [[end]]
+    [[if .MachineControllerImage]]
+    machine_controller_image: [[ .MachineControllerImage ]]
+    [[end]]
+    [[if .MachineControllerImagePullPolicy]]
+    machine_controller_image_pull_policy: [[ .MachineControllerImagePullPolicy ]]
+    [[end]]
+    
+    openshift_aws_master_group:
+    - name: "{{ openshift_aws_clusterid }} master group"
+      group: master
+      tags:
+        host-type: master
+        sub-host-type: default
+        runtime: docker
+        Name: "{{ openshift_aws_clusterid }}-master"
+    
+    openshift_aws_node_groups:
+    - name: "{{ openshift_aws_clusterid }} infra group"
+      group: infra
+      tags:
+        host-type: node
+        sub-host-type: infra
+        runtime: docker
+        Name: "{{ openshift_aws_clusterid }}-infra"
+    - name: "{{ openshift_aws_clusterid }} compute group"
+      group: compute
+      tags:
+        host-type: node
+        sub-host-type: compute
+        runtime: docker
+        Name: "{{ openshift_aws_clusterid }}-compute"
 `
 	clusterVersionVarsTemplate = `
 

--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -45,7 +45,9 @@ type JobGenerator interface {
 	// hardware - details of the hardware of the target cluster
 	// playbook - name of the playbook to run
 	// inventory - inventory to pass to the playbook
-	// vars - Ansible variables to the pass to the playbook
+	// vars - Ansible variables to the pass to the playbook (expected to be
+	//   in ansible inventory format where the variables apply to the
+	//   [all] host group)
 	// openshiftAnsibleImage - name of the openshift-ansible image that the
 	//   jobs created by the job generator will use
 	// openshiftAnsibleImagePullPolicy - policy to use to pull the
@@ -198,8 +200,8 @@ func (r *jobGenerator) GeneratePlaybooksJobWithServiceAccount(
 
 	env := []kapi.EnvVar{
 		{
-			Name:  "INVENTORY_FILE",
-			Value: "/ansible/inventory/hosts",
+			Name:  "INVENTORY_DIR",
+			Value: "/ansible/inventory",
 		},
 		{
 			Name:  "ANSIBLE_HOST_KEY_CHECKING",
@@ -207,7 +209,7 @@ func (r *jobGenerator) GeneratePlaybooksJobWithServiceAccount(
 		},
 		{
 			Name:  "OPTS",
-			Value: "-vvv --private-key=/ansible/ssh/privatekey.pem -e @/ansible/inventory/vars",
+			Value: "-vvv --private-key=/ansible/ssh/privatekey.pem",
 		},
 	}
 


### PR DESCRIPTION
using '-e' with ansible-playbook means that the variables included with the '-e' are immutable.

migrate the format of the vars file to be an ansible inventory file that applies to '[all]' hosts to avoid this immutability.

use INVENTORY_DIR when running the openshift-ansible container (instead of INVENTORY_FILE) to pull in the hosts and vars files in /ansible/inventory/.

fix handing of INVENTORY_DIR in openshift-ansible when the files are symlinks (it would copy the symlink instead of the contents of what the symlinks were pointing to). https://github.com/openshift/openshift-ansible/pull/9309 is the upstream fix.