### PR TITLE
Add controller to link machines to nodes and apply labels + taints.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,7 @@ OA_ANSIBLE_BRANCH ?= release-3.10
 define build-cluster-operator-ansible-image #(repo, branch, imagename, tag, clusterapi_playbook)
         cp build/cluster-operator-ansible/playbooks/cluster-api-prep/$5 build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api.yaml
         cp bin/aws-machine-controller build/cluster-operator-ansible/playbooks/cluster-api-prep/files
-	cp bin/cluster-operator build/cluster-operator-ansible/playbooks/cluster-api-prep/files
+        cp bin/cluster-operator build/cluster-operator-ansible/playbooks/cluster-api-prep/files
 	docker build -t "$3:$4" --build-arg=CO_ANSIBLE_URL=$1 --build-arg=CO_ANSIBLE_BRANCH=$2 build/cluster-operator-ansible
 endef
 

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-common.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-common.yaml
@@ -10,7 +10,7 @@
     import_role:
       name: lib_openshift
 
-  - name: "create {{ cluster_api_namespace }} namesapce"
+  - name: "create {{ cluster_api_namespace }} namespace"
     oc_project:
       state: present
       name: "{{ cluster_api_namespace }}"
@@ -72,6 +72,11 @@
       src: "files/{{ machine_controller_template }}"
       dest: "{{ temp_dir.path }}/machine-controller-template.yaml"
 
+  - name: copy cluster operator controllers template over
+    copy:
+      src: "files/{{ cluster_operator_controllers_template }}"
+      dest: "{{ temp_dir.path }}/cluster-operator-remote-controllers-template.yaml"
+
   - name: process templates
     shell: |-
       oc process -f {{ temp_dir.path }}/cluster-api-template.yaml \
@@ -87,6 +92,11 @@
          -p CLUSTER_API_NAMESPACE={{ cluster_api_namespace }} \
          -p MACHINE_CONTROLLER_IMAGE='{{ machine_controller_image }}' \
          -p MACHINE_CONTROLLER_IMAGE_PULL_POLICY='{{ machine_controller_image_pull_policy }}' | oc apply -f -
+
+      oc process -f {{ temp_dir.path }}/cluster-operator-remote-controllers-template.yaml \
+         -p CLUSTER_API_NAMESPACE={{ cluster_api_namespace }} \
+         -p CONTROLLER_IMAGE='{{ machine_controller_image }}' \
+         -p CONTROLLER_IMAGE_PULL_POLICY='{{ machine_controller_image_pull_policy }}' | oc apply -f -
 
   - name: remove template files
     file:

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-development.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-development.yaml
@@ -23,6 +23,7 @@
       dest: /usr/bin/cluster-operator
       setype: container_file_t
       mode: 0755
+
 - hosts: masters[0]
   gather_facts: no
   tasks:
@@ -30,5 +31,6 @@
     set_fact:
       machine_controller_template: machine-controller-template-dev.yaml
       cluster_api_template: cluster-api-template-dev.yaml
+      cluster_operator_controllers_template: cluster-operator-remote-controllers-template-dev.yaml
 
 - import_playbook: deploy-cluster-api-common.yaml

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-production.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/deploy-cluster-api-production.yaml
@@ -13,5 +13,6 @@
     set_fact:
       machine_controller_template: machine-controller-template.yaml
       cluster_api_template: cluster-api-template.yaml
+      cluster_operator_controllers_template: cluster-operator-remote-controllers-template.yaml
 
 - import_playbook: deploy-cluster-api-common.yaml

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-operator-remote-controllers-template-dev.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-operator-remote-controllers-template-dev.yaml
@@ -1,0 +1,146 @@
+########
+#
+# Template for deploying the Cluster Operator Controllers that run in the target cluster.
+# This is the development version which mounts a binary from the host file
+# system and runs that instead of the binary burned in the image.
+#
+# Parameters:
+#   CLUSTER_API_NAMESPACE: namespace to hold clusterapi objects/services
+#   CONTROLLER_IMAGE: machine controller image reference
+#   CONTROLLER_IMAGE_PULL_POLICY: pull policy for machine controller image
+#
+########
+
+apiVersion: v1
+kind: Template
+metadata:
+  name: cluster-operator-controllers-template-dev
+
+objects:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: cluster-operator-remote-controller-manager
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: cluster-operator-remote-controller
+  spec:
+    selector:
+      matchLabels:
+        app: cluster-operator-remote-controller
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: cluster-operator-remote-controller
+      spec:
+        serviceAccountName: cluster-api-controller-manager
+        nodeSelector:
+          node-role.kubernetes.io/master: "true"
+        containers:
+        - name: cluster-operator-controllers
+          image: ${CONTROLLER_IMAGE}
+          imagePullPolicy: ${CONTROLLER_IMAGE_PULL_POLICY}
+          command:
+          - /opt/services/cluster-operator
+          args:
+          - controller-manager
+          - --port
+          - "8080"
+          - --leader-election-namespace
+          - ${CLUSTER_API_NAMESPACE}
+          - --leader-elect-resource-lock
+          - "configmaps"
+          - --profiling
+          - "false"
+          - --contention-profiling
+          - "false"
+          - -v
+          - "1"
+          - --log-level
+          - "debug"
+          - --controllers
+          - "nodelink"
+          - --clusteroperator-skip-apiserver-wait
+          volumeMounts:
+          - name: cluster-operator-binary
+            mountPath: /opt/services/cluster-operator
+            readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 30Mi
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /healthz
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /healthz
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+        volumes:
+        - name: cluster-operator-binary
+          hostPath:
+            path: /usr/bin/cluster-operator
+
+- allowHostDirVolumePlugin: true
+  allowHostIPC: false
+  allowHostNetwork: false
+  allowHostPID: false
+  allowHostPorts: false
+  allowPrivilegedContainer: false
+  allowedCapabilities: null
+  apiVersion: security.openshift.io/v1
+  defaultAddCapabilities: null
+  fsGroup:
+    type: MustRunAs
+  groups: []
+  kind: SecurityContextConstraints
+  metadata:
+    name: hostmount-restricted-co-controllers
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  runAsUser:
+    type: MustRunAsRange
+  seLinuxContext:
+    type: MustRunAs
+  supplementalGroups:
+    type: RunAsAny
+  users:
+  - system:serviceaccount:${CLUSTER_API_NAMESPACE}:cluster-api-controller-manager
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+  - hostPath
+
+
+parameters:
+# namespace to install clusterapi services onto
+- name: CLUSTER_API_NAMESPACE
+  value: kube-cluster
+- name: CONTROLLER_IMAGE
+- name: CONTROLLER_IMAGE_PULL_POLICY
+  value: Always

--- a/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-operator-remote-controllers-template.yaml
+++ b/build/cluster-operator-ansible/playbooks/cluster-api-prep/files/cluster-operator-remote-controllers-template.yaml
@@ -1,0 +1,97 @@
+########
+#
+# Template for deploying the Cluster Operator Controllers that run in the target cluster.
+#
+# Parameters:
+#   CLUSTER_API_NAMESPACE: namespace to hold clusterapi objects/services
+#   CONTROLLER_IMAGE: machine controller image reference
+#   CONTROLLER_IMAGE_PULL_POLICY: pull policy for machine controller image
+#
+########
+
+apiVersion: v1
+kind: Template
+metadata:
+  name: cluster-operator-controllers-template
+
+objects:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: cluster-operator-remote-controller-manager
+    namespace: ${CLUSTER_API_NAMESPACE}
+    labels:
+      app: cluster-operator-remote-controller
+  spec:
+    selector:
+      matchLabels:
+        app: cluster-operator-remote-controller
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: cluster-operator-remote-controller
+      spec:
+        serviceAccountName: cluster-api-controller-manager
+        nodeSelector:
+          node-role.kubernetes.io/master: "true"
+        containers:
+        - name: cluster-operator-controllers
+          image: ${CONTROLLER_IMAGE}
+          imagePullPolicy: ${CONTROLLER_IMAGE_PULL_POLICY}
+          command:
+          - /opt/services/cluster-operator
+          args:
+          - controller-manager
+          - --port
+          - "8080"
+          - --leader-election-namespace
+          - ${CLUSTER_API_NAMESPACE}
+          - --leader-elect-resource-lock
+          - "configmaps"
+          - --profiling
+          - "false"
+          - --contention-profiling
+          - "false"
+          - -v
+          - "1"
+          - --log-level
+          - "debug"
+          - --controllers
+          - "nodelink"
+          - --clusteroperator-skip-apiserver-wait
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 100m
+              memory: 30Mi
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /healthz
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /healthz
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+
+parameters:
+# namespace to install clusterapi services onto
+- name: CLUSTER_API_NAMESPACE
+  value: kube-cluster
+- name: CONTROLLER_IMAGE
+- name: CONTROLLER_IMAGE_PULL_POLICY
+  value: Always

--- a/cmd/cluster-operator-controller-manager/app/options/options.go
+++ b/cmd/cluster-operator-controller-manager/app/options/options.go
@@ -71,6 +71,7 @@ func NewCMServer() *CMServer {
 			ConcurrentNodeConfigSyncs:        defaultConcurrentSyncs,
 			ConcurrentDeployClusterAPISyncs:  defaultConcurrentSyncs,
 			ConcurrentELBMachineSyncs:        defaultConcurrentSyncs,
+			ConcurrentNodeLinkSyncs:          defaultConcurrentSyncs,
 			ConcurrentClusterDeploymentSyncs: defaultConcurrentSyncs,
 			ConcurrentRemoteMachineSetSyncs:  defaultConcurrentSyncs,
 			LeaderElection:                   leaderelectionconfig.DefaultLeaderElectionConfiguration(),
@@ -99,6 +100,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.StringVar(&s.ClusterOperatorAPIServerURL, "clusteroperator-api-server-url", "", "The URL for the clusteroperator API server")
 	fs.StringVar(&s.ClusterOperatorKubeconfigPath, "clusteroperator-kubeconfig", "", "Path to clusteroperator kubeconfig")
 	fs.BoolVar(&s.ClusterOperatorInsecureSkipVerify, "clusteroperator-insecure-skip-verify", s.ClusterOperatorInsecureSkipVerify, "Skip verification of the TLS certificate for the clusteroperator API server")
+	fs.BoolVar(&s.ClusterOperatorSkipAPIServerWait, "clusteroperator-skip-apiserver-wait", s.ClusterOperatorSkipAPIServerWait, "Skip waiting for the types registered by the clusteroperator API server")
 	fs.DurationVar(&s.MinResyncPeriod.Duration, "min-resync-period", s.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod")
 	fs.Int32Var(&s.ConcurrentClusterSyncs, "concurrent-cluster-syncs", s.ConcurrentClusterSyncs, "The number of cluster objects that are allowed to sync concurrently. Larger number = more responsive clusters, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentMasterSyncs, "concurrent-master-syncs", s.ConcurrentMasterSyncs, "The number of master machine objects that are allowed to sync concurrently. Larger number = more responsive master machines, but more CPU (and network) load")
@@ -108,6 +110,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.Int32Var(&s.ConcurrentDeployClusterAPISyncs, "concurrent-deploy-cluster-api-syncs", s.ConcurrentDeployClusterAPISyncs, "The number of master machine set objects that are allowed to install the upstream cluster API controllers concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentClusterDeploymentSyncs, "concurrent-cluster-deployment-syncs", s.ConcurrentClusterDeploymentSyncs, "The number of cluster deployment objects that are allowed to sync concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentELBMachineSyncs, "concurrent-elb-machine-syncs", s.ConcurrentELBMachineSyncs, "The number of master machine objects that are allowed to be added to the internal/external AWS ELB concurrently. Larger number = more responsive accept jobs, but more CPU (and network) load")
+	fs.Int32Var(&s.ConcurrentNodeLinkSyncs, "concurrent-node-link-syncs", s.ConcurrentNodeLinkSyncs, "The number of node objects that are allowed to be linked concurrently. Larger number = more responsive machine to node linking, but more CPU (and network) load")
 	fs.BoolVar(&s.EnableProfiling, "profiling", s.EnableProfiling, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.BoolVar(&s.EnableContentionProfiling, "contention-profiling", s.EnableContentionProfiling, "Enable lock contention profiling, if profiling is enabled")
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)

--- a/contrib/examples/cluster-deployment-template.yaml
+++ b/contrib/examples/cluster-deployment-template.yaml
@@ -112,11 +112,20 @@ objects:
     machineSets:
     - nodeType: Master
       size: 1
+      nodeLabels:
+        testnodetype: master
+        hello: world
     - shortName: infra
       nodeType: Compute
       infra: true
       size: 1
+      nodeLabels:
+        testnodetype: infra
+        foo: bar
     - shortName: compute
       nodeType: Compute
       size: 1
+      nodeLabels:
+        testnodetype: compute
+        bar: foo
 

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -598,6 +598,11 @@ type MachineSetConfig struct {
 	// NodeLabels specifies the labels that will be applied to nodes in this
 	// MachineSet
 	NodeLabels map[string]string
+
+	// NodeTaints specifies the taints that should be applied to nodes in this MachineSet.
+	// This list is authoritative and will always be reconciled to the node, fully replacing
+	// past values.
+	NodeTaints []corev1.Taint
 }
 
 // MachineSetSpec is the Cluster Operator specification for a Cluster API machine template provider config.

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -599,6 +599,11 @@ type MachineSetConfig struct {
 	// NodeLabels specifies the labels that will be applied to nodes in this
 	// MachineSet
 	NodeLabels map[string]string `json:"nodeLabels"`
+
+	// NodeTaints specifies the taints that should be applied to nodes in this MachineSet.
+	// This list is authoritative and will always be reconciled to the node, fully replacing
+	// past values.
+	NodeTaints []corev1.Taint `json:"nodeTaints"`
 }
 
 // MachineSetSpec is the Cluster Operator specification for a Cluster API machine template provider config.

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -734,6 +734,7 @@ func autoConvert_v1alpha1_MachineSetConfig_To_clusteroperator_MachineSetConfig(i
 	out.Size = in.Size
 	out.Hardware = (*clusteroperator.MachineSetHardwareSpec)(unsafe.Pointer(in.Hardware))
 	out.NodeLabels = *(*map[string]string)(unsafe.Pointer(&in.NodeLabels))
+	out.NodeTaints = *(*[]core_v1.Taint)(unsafe.Pointer(&in.NodeTaints))
 	return nil
 }
 
@@ -748,6 +749,7 @@ func autoConvert_clusteroperator_MachineSetConfig_To_v1alpha1_MachineSetConfig(i
 	out.Size = in.Size
 	out.Hardware = (*MachineSetHardwareSpec)(unsafe.Pointer(in.Hardware))
 	out.NodeLabels = *(*map[string]string)(unsafe.Pointer(&in.NodeLabels))
+	out.NodeTaints = *(*[]core_v1.Taint)(unsafe.Pointer(&in.NodeTaints))
 	return nil
 }
 

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.deepcopy.go
@@ -753,6 +753,13 @@ func (in *MachineSetConfig) DeepCopyInto(out *MachineSetConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.NodeTaints != nil {
+		in, out := &in.NodeTaints, &out.NodeTaints
+		*out = make([]core_v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/clusteroperator/zz_generated.deepcopy.go
+++ b/pkg/apis/clusteroperator/zz_generated.deepcopy.go
@@ -689,6 +689,13 @@ func (in *MachineSetConfig) DeepCopyInto(out *MachineSetConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.NodeTaints != nil {
+		in, out := &in.NodeTaints, &out.NodeTaints
+		*out = make([]core_v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -70,6 +70,11 @@ type ControllerManagerConfiguration struct {
 	// This should be used only for testing.
 	ClusterOperatorInsecureSkipVerify bool
 
+	// ClusterOperatorSkipAPIServerWait controls whether the controller manager should
+	// wait for the types registered by the cluster operator API Server. Useful in deployments
+	// where the Cluster Operator API server is not used. (in remote clusters)
+	ClusterOperatorSkipAPIServerWait bool
+
 	// minResyncPeriod is the resync period in reflectors; will be random between
 	// minResyncPeriod and 2*minResyncPeriod.
 	MinResyncPeriod metav1.Duration
@@ -111,6 +116,11 @@ type ControllerManagerConfiguration struct {
 	// allowed to sync concurrently in the controller which adds them to the internal/external master ELBs.
 	// Larger number = more responsive master machines, but more CPU (and network) load.
 	ConcurrentELBMachineSyncs int32
+
+	// ConcurrentNodeLinkSyncs is the number of node objects that are
+	// allowed to sync concurrently in the controller which links them to their respective machines.
+	// Larger number = more responsive node linking, but more CPU (and network) load.
+	ConcurrentNodeLinkSyncs int32
 
 	// leaderElection defines the configuration of leader election client.
 	LeaderElection componentconfig.LeaderElectionConfiguration

--- a/pkg/controller/nodelink/node_link_controller.go
+++ b/pkg/controller/nodelink/node_link_controller.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodelink
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
+
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiclient "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	capiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
+	lister "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
+
+	clustopclient "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	"github.com/openshift/cluster-operator/pkg/controller"
+	"github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
+)
+
+const (
+	// maxRetries is the number of times a service will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuings of a service.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
+	maxRetries     = 15
+	controllerName = "nodelink"
+
+	// machineAnnotationKey is the annotation storing a link between a node and it's machine. Should match upstream cluster-api machine controller. (node.go)
+	machineAnnotationKey = "machine"
+	kubeClusterNamespace = "kube-cluster"
+)
+
+// NewController returns a new *Controller.
+func NewController(
+	nodeInformer coreinformers.NodeInformer,
+	machineInformer capiinformers.MachineInformer,
+	kubeClient kubeclientset.Interface,
+	capiClient capiclient.Interface) *Controller {
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	// TODO: remove the wrapper when every clients have moved to use the clientset.
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
+
+	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
+		metrics.RegisterMetricAndTrackRateLimiterUsage("clusteroperator_awselb_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+	}
+
+	c := &Controller{
+		capiClient: capiClient,
+		kubeClient: kubeClient,
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "nodelink"),
+	}
+
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addNode,
+		UpdateFunc: c.updateNode,
+		DeleteFunc: c.deleteNode,
+	})
+	c.nodeLister = nodeInformer.Lister()
+	c.nodesSynced = nodeInformer.Informer().HasSynced
+
+	c.machinesLister = machineInformer.Lister()
+	c.machinesSynced = machineInformer.Informer().HasSynced
+
+	c.syncHandler = c.syncNode
+	c.enqueueNode = c.enqueue
+	c.logger = log.WithField("controller", controllerName)
+
+	return c
+}
+
+// Controller monitors nodes and links them to their machines when possible, as well as applies desired labels and taints.
+type Controller struct {
+	client     clustopclient.Interface
+	capiClient capiclient.Interface
+	kubeClient kubeclientset.Interface
+
+	// To allow injection for testing.
+	syncHandler func(hKey string) error
+
+	// used for unit testing
+	enqueueNode func(node *corev1.Node)
+
+	nodeLister  corelister.NodeLister
+	nodesSynced cache.InformerSynced
+
+	machinesLister lister.MachineLister
+	machinesSynced cache.InformerSynced
+
+	// Machines that need to be synced
+	queue workqueue.RateLimitingInterface
+
+	logger log.FieldLogger
+}
+
+func (c *Controller) addNode(obj interface{}) {
+	node := obj.(*corev1.Node)
+	c.logger.WithField("node", node.Name).Debug("adding node")
+	c.enqueueNode(node)
+}
+
+func (c *Controller) updateNode(old, cur interface{}) {
+	//oldNode := old.(*corev1.Node)
+	curNode := cur.(*corev1.Node)
+
+	c.logger.WithField("node", curNode.Name).Debug("updating node")
+	c.enqueueNode(curNode)
+}
+
+func (c *Controller) deleteNode(obj interface{}) {
+
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			return
+		}
+		node, ok = tombstone.Obj.(*corev1.Node)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Node %#v", obj))
+			return
+		}
+	}
+
+	c.logger.WithField("node", node.Name).Debug("deleting node")
+	c.enqueueNode(node)
+}
+
+// Run runs c; will not return until stopCh is closed. workers determines how
+// many machines will be handled in parallel.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	log.Infof("Starting nodelink controller")
+	defer log.Infof("Shutting down nodelink controller")
+
+	if !controller.WaitForCacheSync("machine", stopCh, c.machinesSynced) {
+		return
+	}
+
+	if !controller.WaitForCacheSync("node", stopCh, c.nodesSynced) {
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *Controller) enqueue(node *corev1.Node) {
+	key, err := controller.KeyFunc(node)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", node, err))
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncHandler(key.(string))
+	c.handleErr(err, key)
+
+	return true
+}
+
+func (c *Controller) handleErr(err error, key interface{}) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	if c.queue.NumRequeues(key) < maxRetries {
+		c.logger.Infof("Error syncing node %v: %v", key, err)
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	utilruntime.HandleError(err)
+	c.logger.Infof("Dropping node %q out of the queue: %v", key, err)
+	c.queue.Forget(key)
+}
+
+// syncNode will sync the node with the given key.
+// This function is not meant to be invoked concurrently with the same key.
+func (c *Controller) syncNode(key string) error {
+	startTime := time.Now()
+	c.logger.WithField("key", key).Debug("syncing node")
+	defer func() {
+		c.logger.WithFields(log.Fields{
+			"key":      key,
+			"duration": time.Now().Sub(startTime),
+		}).Debug("finished syncing node")
+	}()
+
+	_, _, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	node, err := c.nodeLister.Get(key)
+	if errors.IsNotFound(err) {
+		c.logger.WithField("key", key).Info("node has been deleted")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return c.processNode(node)
+}
+func (c *Controller) processNode(node *corev1.Node) error {
+	nodeLog := c.logger.WithField("node", node.Name)
+	machineKey, ok := node.Annotations[machineAnnotationKey]
+	// No machine annotation, this is likely the first time we've seen the node,
+	// need to load all machines and search for one with matching IP.
+	var matchingMachine *capiv1.Machine
+	if ok {
+		var err error
+		namespace, machineName, err := cache.SplitMetaNamespaceKey(machineKey)
+		if err != nil {
+			nodeLog.Infof("machine annotation format is incorrect %v: %v\n", machineKey, err)
+			return err
+		}
+		matchingMachine, err = c.machinesLister.Machines(namespace).Get(machineName)
+		// If machine matching annotation is not found, we'll still try to find one via IP matching:
+		if err != nil {
+			if errors.IsNotFound(err) {
+				nodeLog.WithField("machine", machineKey).Warn("machine matching node has been deleted, will attempt to find new machine by IP")
+			} else {
+				return err
+			}
+		}
+	}
+
+	if matchingMachine == nil {
+		// Find this nodes internal IP so we can search for a matching machine:
+		var nodeInternalIP string
+		for _, a := range node.Status.Addresses {
+			if a.Type == corev1.NodeInternalIP {
+				nodeInternalIP = a.Address
+				break
+			}
+		}
+		if nodeInternalIP == "" {
+			nodeLog.Warnf("unable to find InternalIP for node")
+			return fmt.Errorf("unable to find InternalIP for node: %s", node.Name)
+		}
+
+		allMachines, err := c.machinesLister.Machines(kubeClusterNamespace).List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		nodeLog.Debugf("searching %d machines for IP match for node", len(allMachines))
+		for _, m := range allMachines {
+			for _, a := range m.Status.Addresses {
+				// Use the internal IP to look for matches:
+				if a.Type == corev1.NodeInternalIP && a.Address == nodeInternalIP {
+					matchingMachine = m
+					nodeLog.Infof("found matching machine: %s", matchingMachine.Name)
+					break
+				}
+			}
+		}
+	}
+
+	if matchingMachine == nil {
+		nodeLog.Warnf("no matching machine found for node")
+		return fmt.Errorf("no matching machine found for node: %s", node.Name)
+	}
+
+	modNode := node.DeepCopy()
+
+	modNode.Annotations["machine"] = fmt.Sprintf("%s/%s", matchingMachine.Namespace, matchingMachine.Name)
+
+	if modNode.Labels == nil {
+		modNode.Labels = map[string]string{}
+	}
+	for k, v := range matchingMachine.Spec.Labels {
+		nodeLog.Debugf("copying label %s = %s", k, v)
+		modNode.Labels[k] = v
+	}
+
+	// Taints are to be an authoritative list on the machine spec per cluster-api comments:
+	modNode.Spec.Taints = matchingMachine.Spec.Taints
+
+	if !reflect.DeepEqual(node, modNode) {
+		nodeLog.Debug("node has changed, updating")
+		_, err := c.kubeClient.CoreV1().Nodes().Update(modNode)
+		if err != nil {
+			nodeLog.Errorf("error updating node: %v", err)
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/nodelink/node_link_controller_test.go
+++ b/pkg/controller/nodelink/node_link_controller_test.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodelink
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	clustopv1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	"github.com/openshift/cluster-operator/pkg/controller"
+
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiclientfake "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
+	capiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+const (
+	testMachineName           = "testmachine"
+	testNamespace             = "test-namespace"
+	testClusterDeploymentName = "test-cluster-deployment"
+	testClusterDeploymentUUID = types.UID("test-cluster-deployment-uuid")
+	testClusterID             = "test-cluster-id"
+	testRegion                = "us-east-1"
+	testClusterVerName        = "v3-10"
+	testClusterVerNS          = "cluster-operator"
+	testClusterVerUID         = types.UID("test-cluster-version")
+	testImage                 = "testAMI"
+)
+
+func testTaint(key, value string) corev1.Taint {
+	return corev1.Taint{
+		Key:    key,
+		Value:  value,
+		Effect: corev1.TaintEffectNoExecute,
+	}
+}
+
+func TestNodeLinker(t *testing.T) {
+	cases := []struct {
+		name                string
+		nodeUpdatedExpected bool
+		machines            []*capiv1.Machine
+		node                *corev1.Node
+		expectedAnnotations map[string]string
+		expectedLabels      map[string]string
+		expectedError       string
+		expectedTaints      []corev1.Taint
+	}{
+		{
+			name:                "initial linking",
+			nodeUpdatedExpected: true,
+			machines: []*capiv1.Machine{
+				testMachine(1, "machine1", "10.0.0.1",
+					map[string]string{"a": "1"},
+					[]corev1.Taint{
+						testTaint("c", "3"),
+						testTaint("d", "4"),
+					}),
+				testMachine(1, "machine2", "10.0.0.2",
+					map[string]string{"b": "2"}, []corev1.Taint{}),
+			},
+			node: testNode("10.0.0.1", "", map[string]string{}, nil, map[string]string{}),
+			expectedAnnotations: map[string]string{
+				"machine": "kube-cluster/machine1",
+			},
+			expectedLabels: map[string]string{
+				"a": "1",
+			},
+			expectedTaints: []corev1.Taint{
+				testTaint("c", "3"),
+				testTaint("d", "4"),
+			},
+		},
+		{
+			name:                "no matching machine",
+			nodeUpdatedExpected: false,
+			machines: []*capiv1.Machine{
+				testMachine(1, "machine1", "10.0.0.1", map[string]string{}, []corev1.Taint{}),
+				testMachine(1, "machine2", "10.0.0.2", map[string]string{}, []corev1.Taint{}),
+			},
+			node:          testNode("10.0.0.5", "", map[string]string{}, nil, map[string]string{}),
+			expectedError: "no matching machine found for node",
+		},
+		{
+			// Not sure if this is possible but just in case we test that if a machine matching
+			// the nodes annotation is deleted, a new machine may match it's IP and should then
+			// be linked.
+			name:                "changed matching machine",
+			nodeUpdatedExpected: true,
+			machines: []*capiv1.Machine{
+				testMachine(1, "machine1", "10.0.0.1",
+					map[string]string{"a": "1"},
+					[]corev1.Taint{
+						testTaint("c", "3"),
+						testTaint("d", "4"),
+					}),
+				testMachine(1, "machine2", "10.0.0.2",
+					map[string]string{"b": "2"}, []corev1.Taint{}),
+			},
+			node: testNode("10.0.0.1", "", map[string]string{}, nil, map[string]string{"machine": "kube-cluster/sincedeletedmachine"}),
+			expectedAnnotations: map[string]string{
+				"machine": "kube-cluster/machine1",
+			},
+			expectedLabels: map[string]string{
+				"a": "1",
+			},
+			expectedTaints: []corev1.Taint{
+				testTaint("c", "3"),
+				testTaint("d", "4"),
+			},
+		},
+		{
+			// Not sure if this is possible but just in case we test that if a machine matching
+			// the nodes annotation is deleted, a new machine may match it's IP and should then
+			// be linked.
+			name:                "matching machine deleted",
+			nodeUpdatedExpected: false,
+			machines: []*capiv1.Machine{
+				testMachine(1, "machine1", "10.0.0.1",
+					map[string]string{"a": "1"},
+					[]corev1.Taint{
+						testTaint("c", "3"),
+						testTaint("d", "4"),
+					}),
+			},
+			node:          testNode("10.0.0.7", "", map[string]string{}, nil, map[string]string{"machine": "kube-cluster/sincedeletedmachine"}),
+			expectedError: "no matching machine found for node",
+		},
+		{
+			name:                "no changes required",
+			nodeUpdatedExpected: false,
+			machines: []*capiv1.Machine{
+				testMachine(1, "machine1", "10.0.0.1",
+					map[string]string{"a": "1"},
+					[]corev1.Taint{
+						testTaint("c", "3"),
+						testTaint("d", "4"),
+					}),
+				testMachine(1, "machine2", "10.0.0.2", map[string]string{}, []corev1.Taint{}),
+			},
+			node: testNode("10.0.0.1", "kube-cluster/machine1", map[string]string{"a": "1"},
+				[]corev1.Taint{
+					testTaint("c", "3"),
+					testTaint("d", "4"),
+				},
+				map[string]string{},
+			),
+		},
+		{
+			name:                "taints fully replaced",
+			nodeUpdatedExpected: true,
+			machines: []*capiv1.Machine{
+				testMachine(1, "machine1", "10.0.0.1",
+					map[string]string{"a": "1"},
+					[]corev1.Taint{
+						testTaint("c", "3"),
+						testTaint("d", "4"),
+					}),
+				testMachine(1, "machine2", "10.0.0.2",
+					map[string]string{"b": "2"}, []corev1.Taint{}),
+			},
+			node: testNode("10.0.0.1", "kube-cluster/machine1", map[string]string{},
+				[]corev1.Taint{
+					testTaint("e", "5"),
+				},
+				map[string]string{},
+			),
+			expectedAnnotations: map[string]string{
+				"machine": "kube-cluster/machine1",
+			},
+			expectedLabels: map[string]string{
+				"a": "1",
+			},
+			expectedTaints: []corev1.Taint{
+				testTaint("c", "3"),
+				testTaint("d", "4"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kubeClient := &clientgofake.Clientset{}
+			capiClient := &capiclientfake.Clientset{}
+			capiInformers := capiinformers.NewSharedInformerFactory(capiClient, 0)
+			coreInformers := informers.NewSharedInformerFactory(kubeClient, 0)
+			machineStore := capiInformers.Cluster().V1alpha1().Machines().Informer().GetStore()
+			for _, m := range tc.machines {
+				machineStore.Add(m)
+			}
+
+			ctrlr := NewController(coreInformers.Core().V1().Nodes(),
+				capiInformers.Cluster().V1alpha1().Machines(),
+				kubeClient, capiClient)
+
+			err := ctrlr.processNode(tc.node)
+			if tc.expectedError != "" {
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tc.nodeUpdatedExpected {
+				if assert.Equal(t, 1, len(kubeClient.Actions())) {
+					action := kubeClient.Actions()[0]
+					assert.Equal(t, "update", action.GetVerb())
+					updateAction, ok := action.(clientgotesting.UpdateAction)
+					assert.True(t, ok)
+					updatedObject := updateAction.GetObject()
+
+					node, ok := updatedObject.(*corev1.Node)
+					for k, v := range tc.expectedAnnotations {
+						assert.Equal(t, v, node.Annotations[k])
+					}
+					for k, v := range tc.expectedLabels {
+						assert.Equal(t, v, node.Labels[k])
+					}
+					if tc.expectedTaints != nil {
+						assert.ElementsMatch(t, tc.expectedTaints, node.Spec.Taints)
+					}
+				}
+			} else {
+				assert.Equal(t, 0, len(kubeClient.Actions()))
+			}
+
+		})
+	}
+}
+
+func testMachine(generation int64, name, internalIP string, labels map[string]string, taints []corev1.Taint) *capiv1.Machine {
+	testAMI := testImage
+	msSpec := clustopv1.MachineSetSpec{
+		MachineSetConfig: clustopv1.MachineSetConfig{
+			Infra:    false,
+			Size:     3,
+			NodeType: clustopv1.NodeTypeCompute,
+			Hardware: &clustopv1.MachineSetHardwareSpec{
+				AWS: &clustopv1.MachineSetAWSHardwareSpec{
+					InstanceType: "t2.micro",
+				},
+			},
+		},
+		ClusterHardware: clustopv1.ClusterHardwareSpec{
+			AWS: &clustopv1.AWSClusterSpec{
+				Region: testRegion,
+			},
+		},
+		VMImage: clustopv1.VMImage{
+			AWSImage: &testAMI,
+		},
+	}
+	rawProviderConfig, _ := controller.MachineProviderConfigFromMachineSetSpec(&msSpec)
+	machine := &capiv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  kubeClusterNamespace,
+			Generation: generation,
+			Labels: map[string]string{
+				clustopv1.ClusterNameLabel:       testClusterID,
+				clustopv1.ClusterDeploymentLabel: testClusterDeploymentName,
+			},
+		},
+		Spec: capiv1.MachineSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labels,
+			},
+			Taints: taints,
+			ProviderConfig: capiv1.ProviderConfig{
+				Value: rawProviderConfig,
+			},
+		},
+		Status: capiv1.MachineStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: internalIP,
+				},
+			},
+		},
+	}
+	return machine
+}
+
+func testNode(internalIP, machineAnnotation string, labels map[string]string, taints []corev1.Taint, annotations map[string]string) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testnode",
+			Annotations: map[string]string{},
+			Labels:      labels,
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: internalIP,
+				},
+			},
+		},
+	}
+	if machineAnnotation != "" {
+		node.Annotations["machine"] = machineAnnotation
+	}
+	if taints != nil {
+		node.Spec.Taints = taints
+	}
+	return node
+}
+
+// testClusterDeployment creates a new test ClusterDeployment
+func testClusterDeployment() *clustopv1.ClusterDeployment {
+	clusterDeployment := &clustopv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       testClusterDeploymentUUID,
+			Name:      testClusterDeploymentName,
+			Namespace: testNamespace,
+		},
+		Spec: clustopv1.ClusterDeploymentSpec{
+			ClusterName: testClusterID,
+			MachineSets: []clustopv1.ClusterMachineSet{
+				{
+					ShortName: "",
+					MachineSetConfig: clustopv1.MachineSetConfig{
+						Infra:    true,
+						Size:     1,
+						NodeType: clustopv1.NodeTypeMaster,
+					},
+				},
+				{
+					ShortName: "compute",
+					MachineSetConfig: clustopv1.MachineSetConfig{
+						Infra:    false,
+						Size:     1,
+						NodeType: clustopv1.NodeTypeCompute,
+					},
+				},
+			},
+			Hardware: clustopv1.ClusterHardwareSpec{
+				AWS: &clustopv1.AWSClusterSpec{
+					SSHUser:     "clusteroperator",
+					Region:      testRegion,
+					KeyPairName: "libra",
+				},
+			},
+			ClusterVersionRef: clustopv1.ClusterVersionReference{
+				Name:      testClusterVerName,
+				Namespace: testClusterVerNS,
+			},
+		},
+	}
+	return clusterDeployment
+}
+
+func testCluster(t *testing.T) *capiv1.Cluster {
+	clusterDeployment := testClusterDeployment()
+	cluster, err := controller.BuildCluster(clusterDeployment, testClusterVersion().Spec)
+	assert.NoError(t, err)
+	return cluster
+}
+
+// testClusterVersion will create a ClusterVersion resource.
+func testClusterVersion() *clustopv1.ClusterVersion {
+	cv := &clustopv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       testClusterVerUID,
+			Name:      testClusterVerName,
+			Namespace: testClusterVerNS,
+		},
+		Spec: clustopv1.ClusterVersionSpec{
+			Images: clustopv1.ClusterVersionImages{
+				ImageFormat: "openshift/origin-${component}:${version}",
+			},
+			VMImages: clustopv1.VMImages{
+				AWSImages: &clustopv1.AWSVMImages{
+					RegionAMIs: []clustopv1.AWSRegionAMIs{
+						{
+							Region: testRegion,
+							AMI:    "computeAMI_ID",
+						},
+					},
+				},
+			},
+		},
+	}
+	return cv
+}

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -19,6 +19,7 @@ package remotemachineset
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/golang/glog"
@@ -485,7 +486,13 @@ func (c *Controller) syncMachineSets(clusterDeployment *cov1.ClusterDeployment, 
 			if ms.Name == rMS.Name {
 				found = true
 				// TODO what other fields do we want to check for?
-				if *rMS.Spec.Replicas != *ms.Spec.Replicas {
+				// labels and taints
+				c.logger.Debugf("rMS labels: %v", rMS.Spec.Template.Spec.Labels)
+				c.logger.Debugf("ms labels: %v", ms.Spec.Template.Spec.Labels)
+
+				if *rMS.Spec.Replicas != *ms.Spec.Replicas ||
+					!reflect.DeepEqual(rMS.Spec.Template.Spec.Labels, ms.Spec.Template.Spec.Labels) ||
+					!reflect.DeepEqual(rMS.Spec.Template.Spec.Taints, ms.Spec.Template.Spec.Taints) {
 					machineSetsToUpdate = append(machineSetsToUpdate, ms)
 				}
 				break

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -217,7 +217,7 @@ func TestClusterSyncing(t *testing.T) {
 			// Mock that the informer's cache has a cluster api cluster object in it.
 			ctx.clusterStore.Add(&capiCluster)
 
-			// Mock that the informer's cache has a cluster opertaor cluster deployment in it.
+			// Mock that the informer's cache has a cluster operator cluster deployment in it.
 			ctx.clusterDeploymentStore.Add(tc.clusterDeployment)
 
 			// Act

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -631,12 +631,25 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"nodeTaints": {
+							SchemaProps: spec.SchemaProps{
+								Description: "NodeTaints specifies the taints that should be applied to nodes in this MachineSet. This list is authoritative and will always be reconciled to the node, fully replacing past values.",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: ref("k8s.io/api/core/v1.Taint"),
+										},
+									},
+								},
+							},
+						},
 					},
-					Required: []string{"shortName", "nodeType", "infra", "size", "nodeLabels"},
+					Required: []string{"shortName", "nodeType", "infra", "size", "nodeLabels", "nodeTaints"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "k8s.io/api/core/v1.Taint"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterProviderStatus": {
 			Schema: spec.Schema{
@@ -1131,12 +1144,25 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"nodeTaints": {
+							SchemaProps: spec.SchemaProps{
+								Description: "NodeTaints specifies the taints that should be applied to nodes in this MachineSet. This list is authoritative and will always be reconciled to the node, fully replacing past values.",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: ref("k8s.io/api/core/v1.Taint"),
+										},
+									},
+								},
+							},
+						},
 					},
-					Required: []string{"nodeType", "infra", "size", "nodeLabels"},
+					Required: []string{"nodeType", "infra", "size", "nodeLabels", "nodeTaints"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "k8s.io/api/core/v1.Taint"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec": {
 			Schema: spec.Schema{
@@ -1220,6 +1246,19 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"nodeTaints": {
+							SchemaProps: spec.SchemaProps{
+								Description: "NodeTaints specifies the taints that should be applied to nodes in this MachineSet. This list is authoritative and will always be reconciled to the node, fully replacing past values.",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: ref("k8s.io/api/core/v1.Taint"),
+										},
+									},
+								},
+							},
+						},
 						"clusterHardware": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ClusterHardware specifies the hardware that the cluster will run on. It is typically a copy of the clusters data and set automatically by controllers.",
@@ -1239,11 +1278,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef", "vmImage"},
+					Required: []string{"nodeType", "infra", "size", "nodeLabels", "nodeTaints", "clusterHardware", "clusterVersionRef", "vmImage"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.VMImage", "k8s.io/api/core/v1.ObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.VMImage", "k8s.io/api/core/v1.ObjectReference", "k8s.io/api/core/v1.Taint", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetSpec": {
 			Schema: spec.Schema{
@@ -1291,6 +1330,19 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"nodeTaints": {
+							SchemaProps: spec.SchemaProps{
+								Description: "NodeTaints specifies the taints that should be applied to nodes in this MachineSet. This list is authoritative and will always be reconciled to the node, fully replacing past values.",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: ref("k8s.io/api/core/v1.Taint"),
+										},
+									},
+								},
+							},
+						},
 						"clusterHardware": {
 							SchemaProps: spec.SchemaProps{
 								Description: "ClusterHardware specifies the hardware that the cluster will run on. It is typically a copy of the clusters data and set automatically by controllers.",
@@ -1310,11 +1362,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"nodeType", "infra", "size", "nodeLabels", "clusterHardware", "clusterVersionRef", "vmImage"},
+					Required: []string{"nodeType", "infra", "size", "nodeLabels", "nodeTaints", "clusterHardware", "clusterVersionRef", "vmImage"},
 				},
 			},
 			Dependencies: []string{
-				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.VMImage", "k8s.io/api/core/v1.ObjectReference"},
+				"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.ClusterHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.MachineSetHardwareSpec", "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.VMImage", "k8s.io/api/core/v1.ObjectReference", "k8s.io/api/core/v1.Taint"},
 		},
 		"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1.OpenShiftConfigVersion": {
 			Schema: spec.Schema{


### PR DESCRIPTION
- applies the machine annotation to the node
- applies the desired labels/taints to the node
- now runs the new controller in a "cluster-operator-remote-controllers" deployment in the target cluster.
- NOTE: changing labels on a machineset is not reflected on pre-existing machines, let alone their nodes. Issue filed upstream to see if this is desired: https://github.com/kubernetes-sigs/cluster-api/blob/master/pkg/apis/cluster/v1alpha1/machine_types.go#L52
- NOTE: labels will not be applied to masters as they are not created in-cluster, where the controller is running today.
