### PR TITLE
aws client setup refactor

### DIFF
--- a/pkg/clusterapi/aws/actuator_test.go
+++ b/pkg/clusterapi/aws/actuator_test.go
@@ -348,7 +348,7 @@ func TestCreateMachine(t *testing.T) {
 			}, nil)
 
 			actuator := NewActuator(kubeClient, capiClient, log.WithField("test", "TestActuator"), "us-east-1c")
-			actuator.clientBuilder = func(kubeClient kubernetes.Interface, mSpec *clustopv1.MachineSetSpec, namespace, region string) (Client, error) {
+			actuator.clientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (Client, error) {
 				return mockAWSClient, nil
 			}
 			actuator.userDataGenerator = func(master, infra bool) (string, error) {
@@ -454,7 +454,7 @@ func TestUpdate(t *testing.T) {
 			}
 
 			actuator := NewActuator(kubeClient, capiClient, log.WithField("test", "TestActuator"), "us-east-1c")
-			actuator.clientBuilder = func(kubeClient kubernetes.Interface, mSpec *clustopv1.MachineSetSpec, namespace, region string) (Client, error) {
+			actuator.clientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (Client, error) {
 				return mockAWSClient, nil
 			}
 
@@ -555,7 +555,7 @@ func TestDeleteMachine(t *testing.T) {
 			}
 
 			actuator := NewActuator(kubeClient, capiClient, log.WithField("test", "TestActuator"), "us-east-1c")
-			actuator.clientBuilder = func(kubeClient kubernetes.Interface, mSpec *clustopv1.MachineSetSpec, namespace, region string) (Client, error) {
+			actuator.clientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (Client, error) {
 				return mockAWSClient, nil
 			}
 

--- a/pkg/controller/awselb/aws_elb_controller.go
+++ b/pkg/controller/awselb/aws_elb_controller.go
@@ -123,7 +123,7 @@ type Controller struct {
 	queue workqueue.RateLimitingInterface
 
 	logger        log.FieldLogger
-	clientBuilder func(kubeClient kubernetes.Interface, mSpec *clustopv1.MachineSetSpec, namespace, region string) (clustopaws.Client, error)
+	clientBuilder func(kubeClient kubernetes.Interface, secretName, namespace, region string) (clustopaws.Client, error)
 }
 
 func (c *Controller) addMachine(obj interface{}) {
@@ -325,7 +325,12 @@ func (c *Controller) processMachine(machine *capiv1.Machine) error {
 		}
 	}
 
-	client, err := c.clientBuilder(c.kubeClient, coMachineSetSpec, machine.Namespace, region)
+	secretName, err := controller.GetSecretNameFromMachineSetSpec(coMachineSetSpec)
+	if err != nil {
+		return err
+	}
+
+	client, err := c.clientBuilder(c.kubeClient, secretName, machine.Namespace, region)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/awselb/aws_elb_controller_test.go
+++ b/pkg/controller/awselb/aws_elb_controller_test.go
@@ -127,7 +127,7 @@ func TestSyncMachine(t *testing.T) {
 
 			ctrlr := NewController(capiInformers.Cluster().V1alpha1().Machines(),
 				kubeClient, clustopClient, capiClient)
-			ctrlr.clientBuilder = func(kubeClient kubernetes.Interface, mSpec *clustopv1.MachineSetSpec, namespace, region string) (clustopaws.Client, error) {
+			ctrlr.clientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (clustopaws.Client, error) {
 				return mockAWSClient, nil
 			}
 

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -765,3 +765,18 @@ func DeleteFinalizer(object metav1.Object, finalizer string) {
 	finalizers.Delete(finalizer)
 	object.SetFinalizers(finalizers.List())
 }
+
+// GetSecretNameFromMachineSetSpec will retrieve the secret name holding AWS credentials
+// from a machcinesetspec if it exists. Otherwise it will return an empty string.
+func GetSecretNameFromMachineSetSpec(msSpec *clusteroperator.MachineSetSpec) (string, error) {
+	secretName := ""
+	if msSpec.ClusterHardware.AWS == nil {
+		return "", fmt.Errorf("no AWS cluster hardware set on machine spec")
+	}
+
+	if msSpec.ClusterHardware.AWS.AccountSecret.Name != "" {
+		secretName = msSpec.ClusterHardware.AWS.AccountSecret.Name
+	}
+
+	return secretName, nil
+}


### PR DESCRIPTION
redo the parameters needed to set up an aws client (needed for other stuff i'm working on) so that it doesn't need to know about the internals of machinesetspec objects.

update controllers and tests using the aws client accordingly