### PR TITLE
Use pre-built images instead of BuildConfig

### DIFF
--- a/contrib/ansible/deploy-playbook.yml
+++ b/contrib/ansible/deploy-playbook.yml
@@ -27,9 +27,6 @@
     # This CA will be generated once and then re-used for all certs. Will be created
     # in the cert dir defined above.
     apiserver_ca_name: ca
-    # Cluster operator git repository to build:
-    cluster_operator_git_repo: "https://github.com/openshift/cluster-operator"
-    cluster_operator_git_ref: master
     cluster_api_image_pull_policy: "Always"
 
     fake_deployment: False
@@ -152,8 +149,6 @@
       parameters:
         CLUSTER_OPERATOR_NAMESPACE: "{{ cluster_operator_namespace }}"
         SERVING_CA: "{{ l_serving_ca }}"
-        GIT_REPO: "{{ cluster_operator_git_repo }}"
-        GIT_REF: "{{ cluster_operator_git_ref }}"
     register: cluster_app_reg
 
   - name: deploy cluster operator

--- a/contrib/examples/cluster-api-controllers-template.yaml
+++ b/contrib/examples/cluster-api-controllers-template.yaml
@@ -20,6 +20,9 @@ objects:
   spec:
     selector:
       app: aws-machine-controller
+    test: false
+    strategy:
+      type: Recreate
     triggers:
       - type: "ConfigChange"
       - type: "ImageChange"
@@ -78,6 +81,9 @@ objects:
   spec:
     selector:
       app: cluster-api-controller-manager
+    test: false
+    strategy:
+      type: Recreate
     triggers:
       - type: "ConfigChange"
       - type: "ImageChange"

--- a/contrib/examples/cluster-operator-template.yaml
+++ b/contrib/examples/cluster-operator-template.yaml
@@ -90,7 +90,7 @@ objects:
           - http://localhost:2379
           - -v
           - "10"
-          image: cluster-operator:latest
+          image: " "
           ports:
           - containerPort: 6443
             protocol: TCP
@@ -126,7 +126,7 @@ objects:
           - "--tls-cert-file=/var/run/cluster-api-apiserver/apiserver.crt"
           - "--tls-private-key-file=/var/run/cluster-api-apiserver/apiserver.key"
           - "--secure-port=7443"
-          image: cluster-operator:latest
+          image: " "
           ports:
           - containerPort: 7443
             protocol: TCP

--- a/contrib/examples/cluster-operator-template.yaml
+++ b/contrib/examples/cluster-operator-template.yaml
@@ -58,6 +58,7 @@ objects:
       app: cluster-operator-apiserver
     replicas: 1
     revisionHistoryLimit: 4
+    test: false
     # NOTE: can't do Rolling here yet, the new etcd container can't come up due to a lock on the snap/db
     # in the persistent volume which is held by the running deployment.
     strategy:
@@ -225,6 +226,9 @@ objects:
   spec:
     selector:
       app: cluster-operator-controller-manager
+    test: false
+    strategy:
+      type: Recreate
     triggers:
       - type: "ConfigChange"
       - type: "ImageChange"

--- a/contrib/examples/cluster-operator-template.yaml
+++ b/contrib/examples/cluster-operator-template.yaml
@@ -22,12 +22,6 @@ parameters:
 # Namespace of kube-system. Do not change. Required due to oc process behavior.
 - name: KUBE_SYSTEM_NAMESPACE
   value: kube-system
-- name: GIT_REPO
-  description: Cluster Operator git repository the BuildConfig will use.
-  value: https://github.com/openshift/cluster-operator
-- name: GIT_REF
-  description: Cluster Operator git repository branch/tag/commit the BuildConfig will use.
-  value: master
 objects:
 - kind: PersistentVolumeClaim
   apiVersion: v1
@@ -50,35 +44,6 @@ objects:
   spec:
     lookupPolicy:
       local: true
-
-- kind: BuildConfig
-  apiVersion: build.openshift.io/v1
-  metadata:
-    name: cluster-operator
-    namespace: ${CLUSTER_OPERATOR_NAMESPACE}
-  spec:
-    source:
-      type: "Git"
-      git:
-        uri: ${GIT_REPO}
-        ref: ${GIT_REF}
-    strategy:
-      type: "Docker"
-      dockerStrategy:
-        from:
-          kind: DockerImage
-          name: golang:1.9
-        dockerfilePath:
-    output:
-      to:
-        kind: ImageStreamTag
-        name: cluster-operator:latest
-    triggers: []
-    nodeSelector: {}
-    successfulBuildsHistoryLimit: 3
-    failedBuildsHistoryLimit: 3
-  status:
-    lastVersion: 0
 
 # Deployment of the API Server pod
 - kind: DeploymentConfig


### PR DESCRIPTION
Currently the deployment playbook uses a `BuildConfig` to build the operator from source during deployment. This is no longer needed, because there are already pre-built images published, so this patch changes the playbook to use those pre-built images.
