### PR TITLE
Use Red Hat base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ ALL_ARCH=amd64 arm arm64 ppc64le s390x
 PLATFORM?=linux
 ARCH?=amd64
 
-# TODO: Consider using busybox instead of debian
-BASEIMAGE?=gcr.io/google-containers/debian-base-$(ARCH):0.2
+BASEIMAGE?=centos:7
 
 GO_BUILD       = env GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
                    -ldflags "-X $(CLUSTER_OPERATOR_PKG)/pkg.VERSION=$(VERSION) $(BUILD_LDFLAGS)"

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:GO_VERSION
+FROM openshift/origin-release:golang-GO_VERSION
 
 # Avoid permission issues when glide pulls mercurial repos as root
 RUN printf "[trusted]\nusers = *\n" > /root/.hgrc

--- a/build/cluster-operator/Dockerfile
+++ b/build/cluster-operator/Dockerfile
@@ -14,11 +14,6 @@
 
 FROM BASEIMAGE
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install ca-certificates -y && \
-    rm -rf /var/lib/apt/lists/*
-
-ADD cluster-operator opt/services/
+COPY cluster-operator opt/services/
 
 ENTRYPOINT ["/opt/services/cluster-operator"]

--- a/build/fake-machine-controller/Dockerfile
+++ b/build/fake-machine-controller/Dockerfile
@@ -14,11 +14,6 @@
 
 FROM BASEIMAGE
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get install ca-certificates -y && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY fake-machine-controller opt/services/fake-machine-controller
 
 ENTRYPOINT ["/opt/services/fake-machine-controller"]

--- a/build/fake-openshift-ansible/Dockerfile
+++ b/build/fake-openshift-ansible/Dockerfile
@@ -15,6 +15,6 @@
 # If we're building this image, assuming canary mutable tag should exist:
 FROM cluster-operator-ansible:canary
 
-ADD fake-openshift-ansible /usr/local/bin
+COPY fake-openshift-ansible /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/fake-openshift-ansible"]

--- a/build/playbook-mock/Dockerfile
+++ b/build/playbook-mock/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.2
+FROM BASEIMAGE
 
-ADD coutil /usr/sbin
+COPY coutil /usr/sbin
 
 ENTRYPOINT ["/usr/sbin/coutil", "playbook-mock"]


### PR DESCRIPTION
Removes use of debian-based images in our image builds.
Switches from ADD to the more efficient COPY instruction in existing Dockerfiles