### PR TITLE
Fix missing git in Ansible image

### DIFF
--- a/build/cluster-operator-ansible/Dockerfile
+++ b/build/cluster-operator-ansible/Dockerfile
@@ -20,6 +20,7 @@ ARG CLONE_LOCATION=/usr/share/ansible/openshift-ansible
 
 USER root
 
+RUN yum -y install git
 # Update the AWS client code so that operations like ec2_image work
 RUN pip install awscli botocore boto3 -U
 


### PR DESCRIPTION
Latest ansible image no longer has git in it. We need git to clone a specific version of the repo.