### PR TITLE
Fix indent for cluster version vars

### DIFF
--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -276,13 +276,13 @@ all:
     openshift_aws_elb_infra_name: [[ .ELBInfraName ]]
     
     [[if .ClusterAPIImage]]
-    cluster_api_image: [[ .ClusterAPIImage ]]
+    cluster_api_image: "[[ .ClusterAPIImage ]]"
     [[end]]
     [[if .ClusterAPIImagePullPolicy]]
     cluster_api_image_pull_policy: [[ .ClusterAPIImagePullPolicy ]]
     [[end]]
     [[if .MachineControllerImage]]
-    machine_controller_image: [[ .MachineControllerImage ]]
+    machine_controller_image: "[[ .MachineControllerImage ]]"
     [[end]]
     [[if .MachineControllerImagePullPolicy]]
     machine_controller_image_pull_policy: [[ .MachineControllerImagePullPolicy ]]
@@ -314,13 +314,12 @@ all:
         Name: "{{ openshift_aws_clusterid }}-compute"
 `
 	clusterVersionVarsTemplate = `
+    # ------- #
+    # Version #
+    # ------- #
 
-# ------- #
-# Version #
-# ------- #
-
-openshift_release: "[[ .Release ]]"
-oreg_url: [[ .ImageFormat ]]
+    openshift_release: "[[ .Release ]]"
+    oreg_url: "[[ .ImageFormat ]]"
 `
 	DefaultInventory = `
 [OSEv3:children]


### PR DESCRIPTION
Current vars file generation results in a file that looks like:
```
---
all:
  vars:
    # Variables that are commented in this file are optional; uncommented variables
    # are mandatory.
    ...     
    openshift_aws_node_groups:
    - name: "{{ openshift_aws_clusterid }} infra group"
      group: infra
      tags:
        host-type: node
        sub-host-type: infra
        runtime: docker
        Name: "{{ openshift_aws_clusterid }}-infra"
    - name: "{{ openshift_aws_clusterid }} compute group"
      group: compute
      tags:
        host-type: node
        sub-host-type: compute
        runtime: docker
        Name: "{{ openshift_aws_clusterid }}-compute"


# ------- #
# Version #
# ------- #

openshift_release: "3.10"
oreg_url: openshift/origin-${component}:v3.10.0
```

which makes version vars not to get included under `all.vars` and ignored by ansible