### PR TITLE
Fix IAM role creation with openshift-ansible v3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ define build-cluster-operator-ansible-image #(dockerfile, repo, branch, imagenam
 	mkdir -p $(tmp_build_path)
 	cp $(build_path)/$1 $(tmp_build_path)/Dockerfile
 	cp $(build_path)/run $(tmp_build_path)
-	cp -r $(build_path)/playbooks $(tmp_build_path)
+	cp -r $(build_path)/playbooks* $(tmp_build_path)
 	cp -r $(build_path)/roles.v3_9 $(tmp_build_path)
 	cp $(tmp_build_path)/playbooks/cluster-api-prep/$6 $(tmp_build_path)/playbooks/cluster-api-prep/deploy-cluster-api.yaml
 	cp bin/cluster-operator $(tmp_build_path)/playbooks/cluster-api-prep/files

--- a/build/cluster-operator-ansible/Dockerfile
+++ b/build/cluster-operator-ansible/Dockerfile
@@ -41,4 +41,7 @@ RUN rm -rf /usr/share/ansible/openshift-ansible/playbooks/cluster-operator/
 # Copy in our playbooks and roles:
 COPY playbooks/cluster-operator ${CLONE_LOCATION}/playbooks/cluster-operator
 
+# Copy overrides for playbooks needed in openshift-ansible v3.11 and above
+COPY playbooks.v3_11/cluster-operator ${CLONE_LOCATION}/playbooks/cluster-operator
+
 USER 1001:0

--- a/build/cluster-operator-ansible/playbooks.v3_11/cluster-operator/aws/infrastructure.yml
+++ b/build/cluster-operator-ansible/playbooks.v3_11/cluster-operator/aws/infrastructure.yml
@@ -1,0 +1,51 @@
+---
+- name: Alert user to variables needed
+  hosts: localhost
+  tasks:
+  - name: Alert user to variables needed - clusterid
+    debug:
+      msg: "openshift_aws_clusterid={{ openshift_aws_clusterid | default('default') }}"
+
+  - name: Alert user to variables needed - region
+    debug:
+      msg: "openshift_aws_region={{ openshift_aws_region | default('us-east-1') }}"
+
+- import_playbook: ../../aws/openshift-cluster/provision_vpc.yml
+
+- import_playbook: ../../aws/openshift-cluster/provision_ssh_keypair.yml
+
+- import_playbook: ../../aws/openshift-cluster/provision_sec_group.yml
+
+- import_playbook: ../../aws/openshift-cluster/provision_s3.yml
+
+- import_playbook: ../../aws/openshift-cluster/provision_elb.yml
+
+
+- name: Create iam roles
+  hosts: localhost
+  roles:
+  - openshift_aws
+  post_tasks:
+  - include_role:
+      name: openshift_aws
+      tasks_from: iam_role
+    vars:
+      l_node_group_config: "{{ openshift_aws_node_group_config }}"
+      openshift_aws_iam_node_role_name: "openshift_node_describe_instances_{{ openshift_aws_clusterid }}"
+      openshift_aws_iam_node_role_policy_json: "{{ lookup('file', 'describeinstances.json') }}"
+      openshift_aws_iam_node_role_policy_name: "describe_instances"
+    loop_control:
+      loop_var: openshift_aws_node_group
+    with_items: "{{ openshift_aws_node_groups }}"
+  - include_role:
+      name: openshift_aws
+      tasks_from:  iam_role
+    vars:
+      l_node_group_config: 
+        master: "{{ openshift_aws_master_instance_config }}"
+      openshift_aws_iam_master_role_name: "openshift_master_launch_instances_{{ openshift_aws_clusterid }}"
+      openshift_aws_iam_master_role_policy_name: "launch_instances"
+      openshift_aws_iam_master_role_policy_json: "{{ lookup('template', 'launchinstances.json.j2') }}"
+    loop_control:
+      loop_var: openshift_aws_node_group
+    with_items: "{{ openshift_aws_master_group }}"


### PR DESCRIPTION
Fixes issue introduced by a change in openshift-ansible that removes the `openshift_aws_master_group_config` variable from the openshift_aws role.

The override will only be done for the cluster-operator-ansible image that's based on master and will not affect v3.9 or v3.10 builds.