### PR TITLE
Add Etcd image field to ClusterVersion

### DIFF
--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -320,6 +320,9 @@ all:
 
     openshift_release: "[[ .Release ]]"
     oreg_url: "[[ .ImageFormat ]]"
+    [[ if .EtcdImage ]]
+    etcd_image: "[[ .EtcdImage ]]"
+    [[ end ]]
 `
 	DefaultInventory = `
 [OSEv3:children]
@@ -367,6 +370,7 @@ type clusterParams struct {
 type clusterVersionParams struct {
 	Release     string
 	ImageFormat string
+	EtcdImage   string
 }
 
 // GenerateClusterWideVars generates the vars to pass to the ansible playbook
@@ -502,6 +506,7 @@ func GenerateClusterWideVarsForMachineSetWithInfraSize(
 	params := &clusterVersionParams{
 		Release:     release,
 		ImageFormat: clusterVersion.Images.ImageFormat,
+		EtcdImage:   clusterVersion.Images.EtcdImage,
 	}
 
 	err = t.Execute(&buf, params)

--- a/pkg/apis/clusteroperator/types.go
+++ b/pkg/apis/clusteroperator/types.go
@@ -118,6 +118,11 @@ type ClusterVersionImages struct {
 	// (i.e. example.com/openshift3/ose-${component}:${version}")
 	ImageFormat string
 
+	// EtcdImage specifies the image that should be used for Etcd when installing OpenShift
+	// If left blank, the default image will be used.
+	// +optional
+	EtcdImage string
+
 	// OpenshiftAnsibleImage is the name of the image to use to run
 	// openshift-ansible playbooks.
 	// Defaults to openshift/origin-ansbile:{TAG}, where {TAG} is

--- a/pkg/apis/clusteroperator/v1alpha1/types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/types.go
@@ -118,6 +118,11 @@ type ClusterVersionImages struct {
 	// (i.e. example.com/openshift3/ose-${component}:${version}")
 	ImageFormat string `json:"imageFormat"`
 
+	// EtcdImage specifies the image that should be used for Etcd when installing OpenShift
+	// If left blank, the default image will be used.
+	// +optional
+	EtcdImage string `json:"etcdImage,omitempty"`
+
 	// OpenshiftAnsibleImage is the name of the image to use to run
 	// openshift-ansible playbooks.
 	// Defaults to openshift/origin-ansbile:{TAG}, where {TAG} is

--- a/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/clusteroperator/v1alpha1/zz_generated.conversion.go
@@ -620,6 +620,7 @@ func Convert_clusteroperator_ClusterVersion_To_v1alpha1_ClusterVersion(in *clust
 
 func autoConvert_v1alpha1_ClusterVersionImages_To_clusteroperator_ClusterVersionImages(in *ClusterVersionImages, out *clusteroperator.ClusterVersionImages, s conversion.Scope) error {
 	out.ImageFormat = in.ImageFormat
+	out.EtcdImage = in.EtcdImage
 	out.OpenshiftAnsibleImage = (*string)(unsafe.Pointer(in.OpenshiftAnsibleImage))
 	out.OpenshiftAnsibleImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.OpenshiftAnsibleImagePullPolicy))
 	out.ClusterAPIImage = (*string)(unsafe.Pointer(in.ClusterAPIImage))
@@ -636,6 +637,7 @@ func Convert_v1alpha1_ClusterVersionImages_To_clusteroperator_ClusterVersionImag
 
 func autoConvert_clusteroperator_ClusterVersionImages_To_v1alpha1_ClusterVersionImages(in *clusteroperator.ClusterVersionImages, out *ClusterVersionImages, s conversion.Scope) error {
 	out.ImageFormat = in.ImageFormat
+	out.EtcdImage = in.EtcdImage
 	out.OpenshiftAnsibleImage = (*string)(unsafe.Pointer(in.OpenshiftAnsibleImage))
 	out.OpenshiftAnsibleImagePullPolicy = (*v1.PullPolicy)(unsafe.Pointer(in.OpenshiftAnsibleImagePullPolicy))
 	out.ClusterAPIImage = (*string)(unsafe.Pointer(in.ClusterAPIImage))

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -955,6 +955,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"etcdImage": {
+							SchemaProps: spec.SchemaProps{
+								Description: "EtcdImage specifies the image that should be used for Etcd when installing OpenShift If left blank, the default image will be used.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 						"openshiftAnsibleImage": {
 							SchemaProps: spec.SchemaProps{
 								Description: "OpenshiftAnsibleImage is the name of the image to use to run openshift-ansible playbooks. Defaults to openshift/origin-ansbile:{TAG}, where {TAG} is the value from the Version field of this ClusterVersion.",


### PR DESCRIPTION
Adds an optional EtcdImage field to ClusterVersion. if specified, that field is passed to ansible. This allows specifying an etcd image that comes from a different registry as the rest of the openshift images.