### PR TITLE
Standardize common golang import path names

### DIFF
--- a/cmd/aws-machine-controller/app/machine-controller.go
+++ b/cmd/aws-machine-controller/app/machine-controller.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/controller/machine"
 	"sigs.k8s.io/cluster-api/pkg/controller/sharedinformers"
 
-	"github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+	coaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
 )
 
 const (
@@ -88,7 +88,7 @@ func (o *AWSMachineControllerOptions) Run(stopCh <-chan struct{}) error {
 	log.SetLevel(lvl)
 
 	logger := log.WithField("controller", controllerLogName)
-	actuator := aws.NewActuator(kubeClient, client, logger, o.DefaultAvailabilityZone)
+	actuator := coaws.NewActuator(kubeClient, client, logger, o.DefaultAvailabilityZone)
 	si := sharedinformers.NewSharedInformers(config, stopCh)
 	c := machine.NewMachineController(config, si, actuator)
 	c.Run(stopCh)

--- a/cmd/cluster-operator-apiserver/app/testing/server_test.go
+++ b/cmd/cluster-operator-apiserver/app/testing/server_test.go
@@ -21,7 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	clientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset/typed/clusteroperator/v1alpha1"
 )
 
@@ -36,26 +36,26 @@ func TestRun(t *testing.T) {
 
 	// test whether the server is really healthy after /healthz told us so
 	t.Logf("Creating ClusterDeployment directly after being healthy")
-	_, err = client.ClusterDeployments("default").Create(&clusteroperator.ClusterDeployment{
+	_, err = client.ClusterDeployments("default").Create(&cov1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster1",
 		},
-		Spec: clusteroperator.ClusterDeploymentSpec{
-			ClusterVersionRef: clusteroperator.ClusterVersionReference{
+		Spec: cov1.ClusterDeploymentSpec{
+			ClusterVersionRef: cov1.ClusterVersionReference{
 				Namespace: "openshift-cluster-operator",
 				Name:      "v3-9",
 			},
-			MachineSets: []clusteroperator.ClusterMachineSet{
+			MachineSets: []cov1.ClusterMachineSet{
 				{
-					MachineSetConfig: clusteroperator.MachineSetConfig{
-						NodeType: clusteroperator.NodeTypeMaster,
+					MachineSetConfig: cov1.MachineSetConfig{
+						NodeType: cov1.NodeTypeMaster,
 						Infra:    true,
 						Size:     1,
 					},
 				},
 			},
-			Hardware: clusteroperator.ClusterHardwareSpec{
-				AWS: &clusteroperator.AWSClusterSpec{},
+			Hardware: cov1.ClusterHardwareSpec{
+				AWS: &cov1.AWSClusterSpec{},
 			},
 		},
 	})

--- a/contrib/pkg/actuator/actuatortest.go
+++ b/contrib/pkg/actuator/actuatortest.go
@@ -35,10 +35,10 @@ import (
 	coapi "github.com/openshift/cluster-operator/pkg/api"
 	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	awsutil "github.com/aws/aws-sdk-go/aws"
-	"github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+	coaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
 )
 
 const instanceIDAnnotation = "cluster-operator.openshift.io/aws-instance-id"
@@ -49,7 +49,7 @@ func strptr(str string) *string {
 
 func createClusterMachine(name string) error {
 	cluster, machine := testClusterAPIResources(name)
-	actuator := aws.NewActuator(nil, nil, log.WithField("example", "create-machine"), "us-east-1c")
+	actuator := coaws.NewActuator(nil, nil, log.WithField("example", "create-machine"), "us-east-1c")
 	result, err := actuator.CreateMachine(cluster, machine)
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ func deleteClusterMachine(instanceID string) error {
 	machine.Annotations = map[string]string{
 		instanceIDAnnotation: instanceID,
 	}
-	actuator := aws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
+	actuator := coaws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
 	err := actuator.DeleteMachine(machine)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func clusterMachineExists(instanceID string) error {
 	machine.Annotations = map[string]string{
 		instanceIDAnnotation: instanceID,
 	}
-	actuator := aws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
+	actuator := coaws.NewActuator(nil, nil, log.WithField("example", "delete-machine"), "us-east-1c")
 	exists, err := actuator.Exists(cluster, machine)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func NewAWSActuatorTestCommand() *cobra.Command {
 	return cmd
 }
 
-func testClusterAPIResources(name string) (*clusterv1.Cluster, *clusterv1.Machine) {
+func testClusterAPIResources(name string) (*capiv1.Cluster, *capiv1.Machine) {
 	clusterProviderConfigSpec := &cov1.AWSClusterProviderConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "clusteroperator.openshift.io/v1alpha1",
@@ -179,13 +179,13 @@ func testClusterAPIResources(name string) (*clusterv1.Cluster, *clusterv1.Machin
 	//	}
 
 	// Now define cluster-api resources
-	cluster := clusterv1.Cluster{}
+	cluster := capiv1.Cluster{}
 	cluster.Name = name
 	cluster.Spec.ProviderConfig.Value = &runtime.RawExtension{
 		Raw: []byte(serializeCOResource(clusterProviderConfigSpec)),
 	}
 
-	machine := clusterv1.Machine{}
+	machine := capiv1.Machine{}
 	machine.Name = name + "-compute-machine-1"
 	machine.Spec.ProviderConfig.Value = &runtime.RawExtension{
 		Raw: []byte(serializeCOResource(machineSetProviderConfigSpec)),

--- a/pkg/ansible/generate.go
+++ b/pkg/ansible/generate.go
@@ -26,8 +26,8 @@ import (
 
 	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
-	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	"github.com/openshift/cluster-operator/pkg/controller"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
 )
 
 // varsTemplate contains some hardcoded variables that are constant for all clusters,
@@ -351,7 +351,7 @@ type clusterParams struct {
 	ELBMasterExternalName            string
 	ELBMasterInternalName            string
 	ELBInfraName                     string
-	DeploymentType                   coapi.ClusterDeploymentType
+	DeploymentType                   cov1.ClusterDeploymentType
 	InfraSize                        int
 	ClusterAPIImage                  string
 	ClusterAPIImagePullPolicy        corev1.PullPolicy
@@ -377,8 +377,8 @@ type clusterVersionParams struct {
 // that are set at the cluster level.
 func GenerateClusterWideVars(
 	clusterID string,
-	hardwareSpec coapi.AWSClusterSpec,
-	version coapi.OpenShiftConfigVersion,
+	hardwareSpec cov1.AWSClusterSpec,
+	version cov1.OpenShiftConfigVersion,
 	infraSize int,
 	sdnPluginName string,
 	serviceCIDRs capiv1.NetworkRanges,
@@ -399,9 +399,9 @@ func GenerateClusterWideVars(
 		SSHKeyName:            hardwareSpec.KeyPairName,
 		SSHUser:               hardwareSpec.SSHUser,
 		UninstallSSHKeyPair:   hardwareSpec.KeyPairName == clusterID, // only uninstall the cloud ssh keypair when it's unique to the cluster
-		ELBMasterExternalName: controller.ELBMasterExternalName(clusterID),
-		ELBMasterInternalName: controller.ELBMasterInternalName(clusterID),
-		ELBInfraName:          controller.ELBInfraName(clusterID),
+		ELBMasterExternalName: cocontroller.ELBMasterExternalName(clusterID),
+		ELBMasterInternalName: cocontroller.ELBMasterInternalName(clusterID),
+		ELBInfraName:          cocontroller.ELBInfraName(clusterID),
 		VPCDefaults:           vpcDefaults,
 		DeploymentType:        version.DeploymentType,
 		InfraSize:             infraSize,
@@ -432,7 +432,7 @@ func GenerateClusterWideVars(
 	if registryAccessKey != "" && registrySecretKey != "" {
 		params.RegistryAccessKey = registryAccessKey
 		params.RegistrySecretKey = registrySecretKey
-		params.RegistryObjectStoreName = controller.RegistryObjectStoreName(clusterID)
+		params.RegistryObjectStoreName = cocontroller.RegistryObjectStoreName(clusterID)
 	}
 
 	var buf bytes.Buffer
@@ -462,8 +462,8 @@ func convertVersionToRelease(version string) (string, error) {
 func GenerateClusterWideVarsForMachineSet(
 	isMaster bool,
 	clusterID string,
-	clusterHardware coapi.AWSClusterSpec,
-	clusterVersion coapi.OpenShiftConfigVersion,
+	clusterHardware cov1.AWSClusterSpec,
+	clusterVersion cov1.OpenShiftConfigVersion,
 	sdnPluginName string,
 	serviceCIDRs capiv1.NetworkRanges,
 	podCIDRs capiv1.NetworkRanges,
@@ -478,8 +478,8 @@ func GenerateClusterWideVarsForMachineSet(
 func GenerateClusterWideVarsForMachineSetWithInfraSize(
 	isMaster bool,
 	clusterID string,
-	clusterHardware coapi.AWSClusterSpec,
-	clusterVersion coapi.OpenShiftConfigVersion,
+	clusterHardware cov1.AWSClusterSpec,
+	clusterVersion cov1.OpenShiftConfigVersion,
 	infraSize int,
 	sdnPluginName string,
 	serviceCIDRs capiv1.NetworkRanges,

--- a/pkg/ansible/generate_test.go
+++ b/pkg/ansible/generate_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
@@ -31,10 +31,10 @@ const (
 	testRegistrySecretAccessKey = "TESTREGISTRYSECRETACCESSKEY"
 )
 
-func testClusterSpec(sshKeyPairName string) *coapi.ClusterDeploymentSpec {
-	return &coapi.ClusterDeploymentSpec{
-		Hardware: coapi.ClusterHardwareSpec{
-			AWS: &coapi.AWSClusterSpec{
+func testClusterSpec(sshKeyPairName string) *cov1.ClusterDeploymentSpec {
+	return &cov1.ClusterDeploymentSpec{
+		Hardware: cov1.ClusterHardwareSpec{
+			AWS: &cov1.AWSClusterSpec{
 				Region:      "us-east-1",
 				KeyPairName: sshKeyPairName,
 				SSHUser:     "centos",
@@ -43,12 +43,12 @@ func testClusterSpec(sshKeyPairName string) *coapi.ClusterDeploymentSpec {
 	}
 }
 
-func testClusterVersion() *coapi.OpenShiftConfigVersion {
-	return &coapi.OpenShiftConfigVersion{
-		Images: coapi.ClusterVersionImages{
+func testClusterVersion() *cov1.OpenShiftConfigVersion {
+	return &cov1.OpenShiftConfigVersion{
+		Images: cov1.ClusterVersionImages{
 			ImageFormat: imageFormat,
 		},
-		DeploymentType: coapi.ClusterDeploymentTypeOrigin,
+		DeploymentType: cov1.ClusterDeploymentTypeOrigin,
 		Version:        "v3.10.0",
 	}
 }
@@ -57,9 +57,9 @@ func TestGenerateClusterWideVars(t *testing.T) {
 	tests := []struct {
 		name             string
 		clusterID        string
-		clusterSpec      *coapi.ClusterDeploymentSpec
+		clusterSpec      *cov1.ClusterDeploymentSpec
 		infraSize        int
-		clusterVersion   *coapi.OpenShiftConfigVersion
+		clusterVersion   *cov1.OpenShiftConfigVersion
 		sdnPluginName    string
 		serviceCIDRs     capiv1.NetworkRanges
 		podCIDRs         capiv1.NetworkRanges

--- a/pkg/ansible/image.go
+++ b/pkg/ansible/image.go
@@ -21,7 +21,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 
-	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 const (
@@ -30,7 +30,7 @@ const (
 
 // GetAnsibleImageForClusterVersion gets the openshift-ansible image and pull
 // policy to use for clusters that use the specified ClusterVersion.
-func GetAnsibleImageForClusterVersion(cv coapi.OpenShiftConfigVersion) (string, kapi.PullPolicy) {
+func GetAnsibleImageForClusterVersion(cv cov1.OpenShiftConfigVersion) (string, kapi.PullPolicy) {
 	image := fmt.Sprintf("%s:%s", defaultImageName, cv.Version)
 	if cv.Images.OpenshiftAnsibleImage != nil {
 		image = *cv.Images.OpenshiftAnsibleImage

--- a/pkg/ansible/image_test.go
+++ b/pkg/ansible/image_test.go
@@ -21,7 +21,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 
-	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 func TestGetAnsibleImageForClusterVersion(t *testing.T) {
@@ -51,9 +51,9 @@ func TestGetAnsibleImageForClusterVersion(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		cv := coapi.OpenShiftConfigVersion{
+		cv := cov1.OpenShiftConfigVersion{
 			Version: "latest",
-			Images: coapi.ClusterVersionImages{
+			Images: cov1.ClusterVersionImages{
 				OpenshiftAnsibleImage:           tc.image,
 				OpenshiftAnsibleImagePullPolicy: tc.pullPolicy,
 			},

--- a/pkg/ansible/jobgenerator.go
+++ b/pkg/ansible/jobgenerator.go
@@ -27,7 +27,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 const (
@@ -54,7 +54,7 @@ type JobGenerator interface {
 	//   openshift-ansible image
 	GeneratePlaybookJob(
 		name string,
-		hardware clusteroperator.AWSClusterSpec,
+		hardware cov1.AWSClusterSpec,
 		playbook string,
 		inventory string,
 		vars string,
@@ -67,7 +67,7 @@ type JobGenerator interface {
 	// serviceAccount - ServiceAccount object to apply to job/pod
 	GeneratePlaybookJobWithServiceAccount(
 		name string,
-		hardware clusteroperator.AWSClusterSpec,
+		hardware cov1.AWSClusterSpec,
 		playbook string,
 		inventory string,
 		vars string,
@@ -92,7 +92,7 @@ type JobGenerator interface {
 	//   openshift-ansible image
 	GeneratePlaybooksJob(
 		name string,
-		hardware clusteroperator.AWSClusterSpec,
+		hardware cov1.AWSClusterSpec,
 		playbooks []string,
 		inventory,
 		vars,
@@ -116,7 +116,7 @@ type JobGenerator interface {
 	// serviceAccount - (optional) serviceaccount object to attach to the job/pod
 	GeneratePlaybooksJobWithServiceAccount(
 		name string,
-		hardware clusteroperator.AWSClusterSpec,
+		hardware cov1.AWSClusterSpec,
 		playbooks []string,
 		inventory string,
 		vars string,
@@ -152,14 +152,14 @@ func (r *jobGenerator) generateInventoryConfigMap(name, inventory, vars string, 
 	return cfgMap
 }
 
-func (r *jobGenerator) GeneratePlaybookJob(name string, hardware clusteroperator.AWSClusterSpec, playbook, inventory, vars, openshiftAnsibleImage string, openshiftAnsibleImagePullPolicy kapi.PullPolicy) (*kbatch.Job, *kapi.ConfigMap) {
+func (r *jobGenerator) GeneratePlaybookJob(name string, hardware cov1.AWSClusterSpec, playbook, inventory, vars, openshiftAnsibleImage string, openshiftAnsibleImagePullPolicy kapi.PullPolicy) (*kbatch.Job, *kapi.ConfigMap) {
 	return r.GeneratePlaybooksJobWithServiceAccount(name, hardware, []string{playbook},
 		inventory, vars, openshiftAnsibleImage, openshiftAnsibleImagePullPolicy, nil)
 }
 
 func (r *jobGenerator) GeneratePlaybookJobWithServiceAccount(
 	name string,
-	hardware clusteroperator.AWSClusterSpec,
+	hardware cov1.AWSClusterSpec,
 	playbook string,
 	inventory,
 	vars,
@@ -172,7 +172,7 @@ func (r *jobGenerator) GeneratePlaybookJobWithServiceAccount(
 
 func (r *jobGenerator) GeneratePlaybooksJob(
 	name string,
-	hardware clusteroperator.AWSClusterSpec,
+	hardware cov1.AWSClusterSpec,
 	playbooks []string,
 	inventory,
 	vars,
@@ -184,7 +184,7 @@ func (r *jobGenerator) GeneratePlaybooksJob(
 
 func (r *jobGenerator) GeneratePlaybooksJobWithServiceAccount(
 	name string,
-	hardware clusteroperator.AWSClusterSpec,
+	hardware cov1.AWSClusterSpec,
 	playbooks []string,
 	inventory,
 	vars,

--- a/pkg/ansible/jobgenerator_test.go
+++ b/pkg/ansible/jobgenerator_test.go
@@ -24,7 +24,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	testHardware = &clusteroperator.ClusterHardwareSpec{}
+	testHardware = &cov1.ClusterHardwareSpec{}
 )
 
 func TestGeneratePlaybooksJob(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGeneratePlaybooksJob(t *testing.T) {
 	}
 	for _, tc := range cases {
 		generator := NewJobGenerator()
-		job, configmap := generator.GeneratePlaybooksJob(testJobName, clusteroperator.AWSClusterSpec{}, tc.playbooks, testInventory, testVars, "image-name", kapi.PullAlways)
+		job, configmap := generator.GeneratePlaybooksJob(testJobName, cov1.AWSClusterSpec{}, tc.playbooks, testInventory, testVars, "image-name", kapi.PullAlways)
 		if assert.Equal(t, len(tc.playbooks), len(job.Spec.Template.Spec.Containers)) {
 			for i, playbook := range tc.playbooks {
 				assert.Equal(t, playbook, job.Spec.Template.Spec.Containers[i].Name)

--- a/pkg/ansible/jobgeneratorexecutor.go
+++ b/pkg/ansible/jobgeneratorexecutor.go
@@ -20,7 +20,7 @@ import (
 	kbatch "k8s.io/api/batch/v1"
 	kapi "k8s.io/api/core/v1"
 
-	clustop "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 type registryStorageCreds struct {
@@ -33,8 +33,8 @@ type registryStorageCreds struct {
 type JobGeneratorExecutor struct {
 	jobGenerator        JobGenerator
 	playbooks           []string
-	cluster             *clustop.CombinedCluster
-	clusterVersion      clustop.OpenShiftConfigVersion
+	cluster             *cov1.CombinedCluster
+	clusterVersion      cov1.OpenShiftConfigVersion
 	forCluster          bool
 	forMasterMachineSet bool
 	infraSize           *int
@@ -44,7 +44,7 @@ type JobGeneratorExecutor struct {
 
 // NewJobGeneratorExecutorForCluster creates a JobGeneratorExecutor
 // that creates a job for the cluster.
-func NewJobGeneratorExecutorForCluster(jobGenerator JobGenerator, playbooks []string, cluster *clustop.CombinedCluster, clusterVersion clustop.OpenShiftConfigVersion, infraSize int) *JobGeneratorExecutor {
+func NewJobGeneratorExecutorForCluster(jobGenerator JobGenerator, playbooks []string, cluster *cov1.CombinedCluster, clusterVersion cov1.OpenShiftConfigVersion, infraSize int) *JobGeneratorExecutor {
 	return &JobGeneratorExecutor{
 		jobGenerator:   jobGenerator,
 		playbooks:      playbooks,
@@ -57,7 +57,7 @@ func NewJobGeneratorExecutorForCluster(jobGenerator JobGenerator, playbooks []st
 
 // NewJobGeneratorExecutorForMasterMachineSet creates a JobGeneratorExecutor
 // that creates a job for the master machine set of a cluster.
-func NewJobGeneratorExecutorForMasterMachineSet(jobGenerator JobGenerator, playbooks []string, cluster *clustop.CombinedCluster, clusterVersion clustop.OpenShiftConfigVersion) *JobGeneratorExecutor {
+func NewJobGeneratorExecutorForMasterMachineSet(jobGenerator JobGenerator, playbooks []string, cluster *cov1.CombinedCluster, clusterVersion cov1.OpenShiftConfigVersion) *JobGeneratorExecutor {
 	return &JobGeneratorExecutor{
 		jobGenerator:        jobGenerator,
 		playbooks:           playbooks,

--- a/pkg/api/meta/deletion_test.go
+++ b/pkg/api/meta/deletion_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDeletionTimestampExists(t *testing.T) {
-	obj := &clusteroperator.ClusterDeployment{
+	obj := &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{},
 	}
 	exists, err := DeletionTimestampExists(obj)
@@ -49,7 +49,7 @@ func TestDeletionTimestampExists(t *testing.T) {
 func TestRoundTripDeletionTimestamp(t *testing.T) {
 	t1 := metav1.NewTime(time.Now())
 	t2 := metav1.NewTime(time.Now().Add(1 * time.Hour))
-	obj := &clusteroperator.ClusterDeployment{
+	obj := &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			DeletionTimestamp: &t1,
 		},

--- a/pkg/api/meta/finalizers_test.go
+++ b/pkg/api/meta/finalizers_test.go
@@ -19,7 +19,7 @@ package meta
 import (
 	"testing"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,7 +28,7 @@ const (
 )
 
 func TestGetFinalizers(t *testing.T) {
-	obj := &clusteroperator.ClusterDeployment{
+	obj := &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{Finalizers: []string{testFinalizer}},
 	}
 	finalizers, err := GetFinalizers(obj)
@@ -44,7 +44,7 @@ func TestGetFinalizers(t *testing.T) {
 }
 
 func TestAddFinalizer(t *testing.T) {
-	obj := &clusteroperator.ClusterDeployment{
+	obj := &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{},
 	}
 	if err := AddFinalizer(obj, testFinalizer); err != nil {
@@ -59,7 +59,7 @@ func TestAddFinalizer(t *testing.T) {
 }
 
 func TestRemoveFinalizer(t *testing.T) {
-	obj := &clusteroperator.ClusterDeployment{
+	obj := &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{Finalizers: []string{testFinalizer}},
 	}
 	newFinalizers, err := RemoveFinalizer(obj, testFinalizer+"-noexist")

--- a/pkg/api/meta/namespace_test.go
+++ b/pkg/api/meta/namespace_test.go
@@ -19,13 +19,13 @@ package meta
 import (
 	"testing"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetNamespace(t *testing.T) {
 	const namespace = "testns"
-	obj := &clusteroperator.ClusterDeployment{
+	obj := &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 		},

--- a/pkg/apis/clusterapi/validation/machine.go
+++ b/pkg/apis/clusterapi/validation/machine.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster"
+	capicluster "sigs.k8s.io/cluster-api/pkg/apis/cluster"
 )
 
 // MachineStrategy is the strategy that the API server will use for Machine
@@ -37,7 +37,7 @@ type MachineStrategy struct {
 func (m MachineStrategy) Validate(ctx request.Context, obj runtime.Object) field.ErrorList {
 	errors := field.ErrorList{}
 	errors = append(errors, m.StorageBuilder.Validate(ctx, obj)...)
-	machine := obj.(*cluster.Machine)
+	machine := obj.(*capicluster.Machine)
 	glog.Infof("Custom validation of Machine %s", machine.Name)
 	return errors
 }

--- a/pkg/apis/clusterapi/validation/validation.go
+++ b/pkg/apis/clusterapi/validation/validation.go
@@ -18,7 +18,7 @@ package validation
 
 import (
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
-	cav1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // ReplaceStorageBuilder replaces the storage builder in the API group builder
@@ -29,7 +29,7 @@ func ReplaceStorageBuilder(
 	replaceBuilder func(builders.StorageBuilder) builders.StorageBuilder,
 ) {
 	for _, version := range apiGroupBuilder.Versions {
-		if version.GroupVersion != cav1alpha1.SchemeGroupVersion {
+		if version.GroupVersion != capiv1.SchemeGroupVersion {
 			continue
 		}
 		for _, kind := range version.Kinds {

--- a/pkg/apis/clusteroperator/install/install.go
+++ b/pkg/apis/clusteroperator/install/install.go
@@ -23,21 +23,21 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 // Install registers the API group and adds types to a scheme
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  clusteroperator.GroupName,
-			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version},
+			GroupName:                  coapi.GroupName,
+			VersionPreferenceOrder:     []string{cov1.SchemeGroupVersion.Version},
 			RootScopedKinds:            sets.NewString(),
-			AddInternalObjectsToScheme: clusteroperator.AddToScheme,
+			AddInternalObjectsToScheme: coapi.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{
-			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
+			cov1.SchemeGroupVersion.Version: cov1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/apis/clusteroperator/validation/clusterdeployment.go
+++ b/pkg/apis/clusteroperator/validation/clusterdeployment.go
@@ -21,14 +21,14 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // ValidateClusterDeploymentName validates the name of a cluster.
 var ValidateClusterDeploymentName = apivalidation.ValidateClusterName
 
 // ValidateClusterDeployment validates a cluster being created.
-func ValidateClusterDeployment(cluster *clusteroperator.ClusterDeployment) field.ErrorList {
+func ValidateClusterDeployment(cluster *coapi.ClusterDeployment) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	for _, msg := range ValidateClusterDeploymentName(cluster.Name, false) {
@@ -41,7 +41,7 @@ func ValidateClusterDeployment(cluster *clusteroperator.ClusterDeployment) field
 }
 
 // validateClusterDeploymentSpec validates the spec of a cluster.
-func validateClusterDeploymentSpec(spec *clusteroperator.ClusterDeploymentSpec, fldPath *field.Path) field.ErrorList {
+func validateClusterDeploymentSpec(spec *coapi.ClusterDeploymentSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if spec.ClusterName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("clusterName"), "ClusterName must be set"))
@@ -54,7 +54,7 @@ func validateClusterDeploymentSpec(spec *clusteroperator.ClusterDeploymentSpec, 
 	for i := range spec.MachineSets {
 		machineSet := spec.MachineSets[i]
 		allErrs = append(allErrs, validateClusterMachineSet(&machineSet, machineSetsPath.Index(i))...)
-		if machineSet.NodeType == clusteroperator.NodeTypeMaster {
+		if machineSet.NodeType == coapi.NodeTypeMaster {
 			masterCount++
 			if masterCount > 1 {
 				allErrs = append(allErrs, field.Invalid(machineSetsPath.Index(i).Child("type"), machineSet.NodeType, "can only have one master machineset"))
@@ -120,14 +120,14 @@ func validateClusterDeploymentSpec(spec *clusteroperator.ClusterDeploymentSpec, 
 	return allErrs
 }
 
-func validateClusterMachineSet(machineSet *clusteroperator.ClusterMachineSet, fldPath *field.Path) field.ErrorList {
+func validateClusterMachineSet(machineSet *coapi.ClusterMachineSet, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if machineSet.NodeType == clusteroperator.NodeTypeMaster {
+	if machineSet.NodeType == coapi.NodeTypeMaster {
 		if len(machineSet.ShortName) > 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("shortName"), machineSet.ShortName, "short name must not be specified for master machineset"))
 		}
 	} else {
-		if machineSet.ShortName == clusteroperator.MasterMachineSetName {
+		if machineSet.ShortName == coapi.MasterMachineSetName {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("shortName"), machineSet.ShortName, "short name cannot be reserved name"))
 		}
 		for _, msg := range apivalidation.NameIsDNSLabel(machineSet.ShortName, false) {
@@ -139,7 +139,7 @@ func validateClusterMachineSet(machineSet *clusteroperator.ClusterMachineSet, fl
 }
 
 // validateClusterDeploymentStatus validates the status of a cluster.
-func validateClusterDeploymentStatus(status *clusteroperator.ClusterDeploymentStatus, fldPath *field.Path) field.ErrorList {
+func validateClusterDeploymentStatus(status *coapi.ClusterDeploymentStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
@@ -157,7 +157,7 @@ func validateSecretRef(ref *corev1.LocalObjectReference, fldPath *field.Path) fi
 }
 
 // ValidateClusterDeploymentUpdate validates an update to the spec of a cluster.
-func ValidateClusterDeploymentUpdate(new *clusteroperator.ClusterDeployment, old *clusteroperator.ClusterDeployment) field.ErrorList {
+func ValidateClusterDeploymentUpdate(new *coapi.ClusterDeployment, old *coapi.ClusterDeployment) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateClusterDeploymentSpec(&new.Spec, field.NewPath("spec"))...)
@@ -171,7 +171,7 @@ func ValidateClusterDeploymentUpdate(new *clusteroperator.ClusterDeployment, old
 }
 
 // ValidateClusterDeploymentStatusUpdate validates an update to the status of a cluster.
-func ValidateClusterDeploymentStatusUpdate(new *clusteroperator.ClusterDeployment, old *clusteroperator.ClusterDeployment) field.ErrorList {
+func ValidateClusterDeploymentStatusUpdate(new *coapi.ClusterDeployment, old *coapi.ClusterDeployment) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateClusterDeploymentStatus(&new.Status, field.NewPath("status"))...)

--- a/pkg/apis/clusteroperator/validation/clusterdeployment_test.go
+++ b/pkg/apis/clusteroperator/validation/clusterdeployment_test.go
@@ -23,13 +23,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // getValidClusterDeployment gets a cluster deployment that passes all validity checks.
-func getValidClusterDeployment() *clusteroperator.ClusterDeployment {
-	return &clusteroperator.ClusterDeployment{
+func getValidClusterDeployment() *coapi.ClusterDeployment {
+	return &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
@@ -37,19 +37,19 @@ func getValidClusterDeployment() *clusteroperator.ClusterDeployment {
 	}
 }
 
-func getValidClusterDeploymentSpec() clusteroperator.ClusterDeploymentSpec {
-	return clusteroperator.ClusterDeploymentSpec{
+func getValidClusterDeploymentSpec() coapi.ClusterDeploymentSpec {
+	return coapi.ClusterDeploymentSpec{
 		ClusterName: "cluster-name",
-		MachineSets: []clusteroperator.ClusterMachineSet{
+		MachineSets: []coapi.ClusterMachineSet{
 			{
-				MachineSetConfig: clusteroperator.MachineSetConfig{
-					NodeType: clusteroperator.NodeTypeMaster,
+				MachineSetConfig: coapi.MachineSetConfig{
+					NodeType: coapi.NodeTypeMaster,
 					Infra:    true,
 					Size:     1,
 				},
 			},
 		},
-		ClusterVersionRef: clusteroperator.ClusterVersionReference{
+		ClusterVersionRef: coapi.ClusterVersionReference{
 			Name: "v3-9",
 		},
 		NetworkConfig: capiv1.ClusterNetworkingConfig{
@@ -57,7 +57,7 @@ func getValidClusterDeploymentSpec() clusteroperator.ClusterDeploymentSpec {
 			Services:      capiv1.NetworkRanges{CIDRBlocks: []string{"172.50.1.1/16"}},
 			Pods:          capiv1.NetworkRanges{CIDRBlocks: []string{"10.140.5.5/14"}},
 		},
-		Config: clusteroperator.ClusterConfigSpec{
+		Config: coapi.ClusterConfigSpec{
 			SDNPluginName: "redhat/openshift-ovs-multitenant",
 		},
 	}
@@ -72,14 +72,14 @@ func getClusterVersionReference() corev1.ObjectReference {
 }
 
 // getTestMachineSet gets a ClusterMachineSet initialized with either compute or master node type
-func getTestMachineSet(size int, shortName string, master bool, infra bool) clusteroperator.ClusterMachineSet {
-	nodeType := clusteroperator.NodeTypeCompute
+func getTestMachineSet(size int, shortName string, master bool, infra bool) coapi.ClusterMachineSet {
+	nodeType := coapi.NodeTypeCompute
 	if master {
-		nodeType = clusteroperator.NodeTypeMaster
+		nodeType = coapi.NodeTypeMaster
 	}
-	return clusteroperator.ClusterMachineSet{
+	return coapi.ClusterMachineSet{
 		ShortName: shortName,
-		MachineSetConfig: clusteroperator.MachineSetConfig{
+		MachineSetConfig: coapi.MachineSetConfig{
 			NodeType: nodeType,
 			Size:     size,
 			Infra:    infra,
@@ -91,7 +91,7 @@ func getTestMachineSet(size int, shortName string, master bool, infra bool) clus
 func TestValidateClusterDeployment(t *testing.T) {
 	cases := []struct {
 		name              string
-		clusterDeployment *clusteroperator.ClusterDeployment
+		clusterDeployment *coapi.ClusterDeployment
 		valid             bool
 	}{
 		{
@@ -101,7 +101,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		},
 		{
 			name: "invalid name",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Name = "###"
 				return c
@@ -110,7 +110,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		},
 		{
 			name: "invalid spec",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.MachineSets[0].Size = 0
 				return c
@@ -119,7 +119,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		},
 		{
 			name: "missing service network CIDRs",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.NetworkConfig.Services = capiv1.NetworkRanges{CIDRBlocks: []string{}}
 				return c
@@ -128,7 +128,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		},
 		{
 			name: "missing pod network CIDRs",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.NetworkConfig.Pods = capiv1.NetworkRanges{CIDRBlocks: []string{}}
 				return c
@@ -138,7 +138,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		{
 			// NOTE: this isn't supported yet
 			name: "multiple service network CIDRs",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.NetworkConfig.Services = capiv1.NetworkRanges{CIDRBlocks: []string{"192.168.1.1/10", "196.168.1.2/20"}}
 				return c
@@ -148,7 +148,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		{
 			// NOTE: this isn't supported yet
 			name: "multiple pod network CIDRs",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.NetworkConfig.Pods = capiv1.NetworkRanges{CIDRBlocks: []string{"192.168.1.1/10", "196.168.1.2/20"}}
 				return c
@@ -157,7 +157,7 @@ func TestValidateClusterDeployment(t *testing.T) {
 		},
 		{
 			name: "missing SDN plugin name",
-			clusterDeployment: func() *clusteroperator.ClusterDeployment {
+			clusterDeployment: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.Config.SDNPluginName = ""
 				return c
@@ -181,8 +181,8 @@ func TestValidateClusterDeployment(t *testing.T) {
 func TestValidateClusterDeploymentUpdate(t *testing.T) {
 	cases := []struct {
 		name  string
-		old   *clusteroperator.ClusterDeployment
-		new   *clusteroperator.ClusterDeployment
+		old   *coapi.ClusterDeployment
+		new   *coapi.ClusterDeployment
 		valid bool
 	}{
 		{
@@ -194,7 +194,7 @@ func TestValidateClusterDeploymentUpdate(t *testing.T) {
 		{
 			name: "invalid spec",
 			old:  getValidClusterDeployment(),
-			new: func() *clusteroperator.ClusterDeployment {
+			new: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.MachineSets[0].Size = 0
 				return c
@@ -204,7 +204,7 @@ func TestValidateClusterDeploymentUpdate(t *testing.T) {
 		{
 			name: "mutated ClusterName",
 			old:  getValidClusterDeployment(),
-			new: func() *clusteroperator.ClusterDeployment {
+			new: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.ClusterName = "mutated-cluster-name"
 				return c
@@ -214,7 +214,7 @@ func TestValidateClusterDeploymentUpdate(t *testing.T) {
 		{
 			name: "mutated service network CIDR",
 			old:  getValidClusterDeployment(),
-			new: func() *clusteroperator.ClusterDeployment {
+			new: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.NetworkConfig.Services = capiv1.NetworkRanges{CIDRBlocks: []string{"172.60.0.0/16"}}
 				return c
@@ -224,7 +224,7 @@ func TestValidateClusterDeploymentUpdate(t *testing.T) {
 		{
 			name: "mutated pod network CIDR",
 			old:  getValidClusterDeployment(),
-			new: func() *clusteroperator.ClusterDeployment {
+			new: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.NetworkConfig.Pods = capiv1.NetworkRanges{CIDRBlocks: []string{"172.60.0.0/16"}}
 				return c
@@ -234,7 +234,7 @@ func TestValidateClusterDeploymentUpdate(t *testing.T) {
 		{
 			name: "mutated SDN plugin name",
 			old:  getValidClusterDeployment(),
-			new: func() *clusteroperator.ClusterDeployment {
+			new: func() *coapi.ClusterDeployment {
 				c := getValidClusterDeployment()
 				c.Spec.Config.SDNPluginName = "newplugin"
 				return c
@@ -258,12 +258,12 @@ func TestValidateClusterDeploymentUpdate(t *testing.T) {
 func TestValidateClusterDeploymentSpec(t *testing.T) {
 	cases := []struct {
 		name  string
-		spec  *clusteroperator.ClusterDeploymentSpec
+		spec  *coapi.ClusterDeploymentSpec
 		valid bool
 	}{
 		{
 			name: "missing clusterID",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
 				cs.ClusterName = ""
 				return &cs
@@ -272,7 +272,7 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "valid master only",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
 				return &cs
 			}(),
@@ -280,9 +280,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "invalid master size",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(0, "", true, true),
 				}
 				return &cs
@@ -291,9 +291,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "valid single compute",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, false),
 					getTestMachineSet(1, "one", false, true),
 				}
@@ -303,9 +303,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "valid multiple computes",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, true),
 					getTestMachineSet(1, "one", false, false),
 					getTestMachineSet(5, "two", false, false),
@@ -317,9 +317,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "invalid compute name",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, true),
 					getTestMachineSet(1, "one", false, false),
 					getTestMachineSet(5, "", false, false),
@@ -331,9 +331,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "invalid compute size",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, true),
 					getTestMachineSet(1, "one", false, false),
 					getTestMachineSet(0, "two", false, false),
@@ -345,9 +345,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "invalid duplicate compute name",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, true),
 					getTestMachineSet(1, "one", false, false),
 					getTestMachineSet(5, "one", false, false),
@@ -359,9 +359,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "no master machineset",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "one", false, true),
 					getTestMachineSet(5, "two", false, false),
 					getTestMachineSet(2, "three", false, false),
@@ -372,9 +372,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "no infra machineset",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, false),
 					getTestMachineSet(1, "one", false, false),
 					getTestMachineSet(5, "one", false, false),
@@ -386,9 +386,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "more than one master",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, true),
 					getTestMachineSet(1, "", true, false),
 					getTestMachineSet(5, "one", false, false),
@@ -400,9 +400,9 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "more than one infra",
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
-				cs.MachineSets = []clusteroperator.ClusterMachineSet{
+				cs.MachineSets = []coapi.ClusterMachineSet{
 					getTestMachineSet(1, "", true, false),
 					getTestMachineSet(1, "one", false, true),
 					getTestMachineSet(5, "two", false, true),
@@ -414,7 +414,7 @@ func TestValidateClusterDeploymentSpec(t *testing.T) {
 		},
 		{
 			name: "missing cluster version name", // namespace is optional
-			spec: func() *clusteroperator.ClusterDeploymentSpec {
+			spec: func() *coapi.ClusterDeploymentSpec {
 				cs := getValidClusterDeploymentSpec()
 				cs.ClusterVersionRef.Name = ""
 				return &cs

--- a/pkg/apis/clusteroperator/validation/clusterversion.go
+++ b/pkg/apis/clusteroperator/validation/clusterversion.go
@@ -24,13 +24,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // validDeploymentTypes is a map containing an entry for every valid DeploymentType value.
-var validDeploymentTypes = map[clusteroperator.ClusterDeploymentType]bool{
-	clusteroperator.ClusterDeploymentTypeOrigin:     true,
-	clusteroperator.ClusterDeploymentTypeEnterprise: true,
+var validDeploymentTypes = map[coapi.ClusterDeploymentType]bool{
+	coapi.ClusterDeploymentTypeOrigin:     true,
+	coapi.ClusterDeploymentTypeEnterprise: true,
 }
 
 // validDeploymentTypeValues is an array of every valid DeploymentType value.
@@ -66,7 +66,7 @@ var validPullPolicyValues = func() []string {
 }()
 
 // ValidateClusterVersion validates a cluster version being created.
-func ValidateClusterVersion(cv *clusteroperator.ClusterVersion) field.ErrorList {
+func ValidateClusterVersion(cv *coapi.ClusterVersion) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateClusterVersionSpec(&cv.Spec, field.NewPath("spec"))...)
@@ -75,7 +75,7 @@ func ValidateClusterVersion(cv *clusteroperator.ClusterVersion) field.ErrorList 
 }
 
 // ValidateClusterVersionUpdate validates that a spec update of a clusterversion.
-func ValidateClusterVersionUpdate(newCV *clusteroperator.ClusterVersion, oldCV *clusteroperator.ClusterVersion) field.ErrorList {
+func ValidateClusterVersionUpdate(newCV *coapi.ClusterVersion, oldCV *coapi.ClusterVersion) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// For now updating cluster versions is not supported. In the future this may change if deemed useful.
 	// In the meantime it will be necessary to create a new cluster version and trigger an upgrade if modifications
@@ -86,7 +86,7 @@ func ValidateClusterVersionUpdate(newCV *clusteroperator.ClusterVersion, oldCV *
 }
 
 // ValidateClusterVersionStatusUpdate validates an update to the status of a clusterversion.
-func ValidateClusterVersionStatusUpdate(new *clusteroperator.ClusterVersion, old *clusteroperator.ClusterVersion) field.ErrorList {
+func ValidateClusterVersionStatusUpdate(new *coapi.ClusterVersion, old *coapi.ClusterVersion) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// No validation required yet as the status struct is currently just a placeholder.
@@ -95,7 +95,7 @@ func ValidateClusterVersionStatusUpdate(new *clusteroperator.ClusterVersion, old
 }
 
 // ValidateClusterVersionSpec validates the spec of a ClusterVersion.
-func ValidateClusterVersionSpec(spec *clusteroperator.ClusterVersionSpec, fldPath *field.Path) field.ErrorList {
+func ValidateClusterVersionSpec(spec *coapi.ClusterVersionSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if spec.Images.ImageFormat == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("imageFormat"), "must define image format"))
@@ -131,7 +131,7 @@ func ValidateClusterVersionSpec(spec *clusteroperator.ClusterVersionSpec, fldPat
 }
 
 // ValidateVMImages validates the provided image data for each cloud provider.
-func ValidateVMImages(vmImages clusteroperator.VMImages, fldPath *field.Path) field.ErrorList {
+func ValidateVMImages(vmImages coapi.VMImages, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// This can be dropped when additional providers are supported, but we should then verify
 	// at least one cloud provider has images specified.
@@ -160,7 +160,7 @@ func ValidateVMImages(vmImages clusteroperator.VMImages, fldPath *field.Path) fi
 }
 
 // ValidateRegionAMIs validates that an AMI is properly defined.
-func ValidateRegionAMIs(regionAMIs *clusteroperator.AWSRegionAMIs, fldPath *field.Path) field.ErrorList {
+func ValidateRegionAMIs(regionAMIs *coapi.AWSRegionAMIs, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if regionAMIs.Region == "" {

--- a/pkg/apis/clusteroperator/validation/clusterversion_test.go
+++ b/pkg/apis/clusteroperator/validation/clusterversion_test.go
@@ -22,23 +22,23 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // getValidClusterVersion gets a cluster version that passes all validity checks.
-func getValidClusterVersion() *clusteroperator.ClusterVersion {
+func getValidClusterVersion() *coapi.ClusterVersion {
 	masterAMIID := "masterAMI_ID"
-	return &clusteroperator.ClusterVersion{
+	return &coapi.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster-version",
 		},
-		Spec: clusteroperator.ClusterVersionSpec{
-			Images: clusteroperator.ClusterVersionImages{
+		Spec: coapi.ClusterVersionSpec{
+			Images: coapi.ClusterVersionImages{
 				ImageFormat: "openshift/origin-${component}:${version}",
 			},
-			VMImages: clusteroperator.VMImages{
-				AWSImages: &clusteroperator.AWSVMImages{
-					RegionAMIs: []clusteroperator.AWSRegionAMIs{
+			VMImages: coapi.VMImages{
+				AWSImages: &coapi.AWSVMImages{
+					RegionAMIs: []coapi.AWSRegionAMIs{
 						{
 							Region:    "us-east-1",
 							AMI:       "computeAMI_ID",
@@ -47,7 +47,7 @@ func getValidClusterVersion() *clusteroperator.ClusterVersion {
 					},
 				},
 			},
-			DeploymentType: clusteroperator.ClusterDeploymentTypeOrigin,
+			DeploymentType: coapi.ClusterDeploymentTypeOrigin,
 			Version:        "3.7.0",
 		},
 	}
@@ -57,7 +57,7 @@ func getValidClusterVersion() *clusteroperator.ClusterVersion {
 func TestValidateClusterVersion(t *testing.T) {
 	cases := []struct {
 		name           string
-		clusterVersion *clusteroperator.ClusterVersion
+		clusterVersion *coapi.ClusterVersion
 		valid          bool
 	}{
 		{
@@ -67,7 +67,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "missing image format",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.ImageFormat = ""
 				return c
@@ -76,9 +76,9 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "missing VM images",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
-				c.Spec.VMImages = clusteroperator.VMImages{}
+				c.Spec.VMImages = coapi.VMImages{}
 				return c
 			}(),
 			valid: false,
@@ -87,7 +87,7 @@ func TestValidateClusterVersion(t *testing.T) {
 			// This test is only valid until we start supporting mutliple clusters, in which case
 			// it should instead verify at least one cloud provider has images defined:
 			name: "missing AWS VM images",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.VMImages.AWSImages = nil
 				return c
@@ -96,16 +96,16 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "no region AMIs",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
-				c.Spec.VMImages.AWSImages.RegionAMIs = []clusteroperator.AWSRegionAMIs{}
+				c.Spec.VMImages.AWSImages.RegionAMIs = []coapi.AWSRegionAMIs{}
 				return c
 			}(),
 			valid: false,
 		},
 		{
 			name: "missing AMI region",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.VMImages.AWSImages.RegionAMIs[0].Region = ""
 				return c
@@ -114,7 +114,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "missing AMI ID",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.VMImages.AWSImages.RegionAMIs[0].AMI = ""
 				return c
@@ -123,7 +123,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "empty master AMI ID",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				var emptyStr string
 				c.Spec.VMImages.AWSImages.RegionAMIs[0].MasterAMI = &emptyStr
@@ -133,17 +133,17 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "duplicate region AMIs",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.VMImages.AWSImages.RegionAMIs = append(c.Spec.VMImages.AWSImages.RegionAMIs,
-					clusteroperator.AWSRegionAMIs{Region: "us-east-1", AMI: "fakecompute"})
+					coapi.AWSRegionAMIs{Region: "us-east-1", AMI: "fakecompute"})
 				return c
 			}(),
 			valid: false,
 		},
 		{
 			name: "missing deployment type",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.DeploymentType = ""
 				return c
@@ -152,7 +152,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid deployment type",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.DeploymentType = "badtype"
 				return c
@@ -161,7 +161,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "missing version",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = ""
 				return c
@@ -170,7 +170,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "valid version without leading v",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "3.10.0.whatever"
 				return c
@@ -179,7 +179,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "valid version 2",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "3.10"
 				return c
@@ -188,7 +188,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "valid version 3",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "3.9"
 				return c
@@ -197,7 +197,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid version 1",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "x3.10.0.whatever"
 				return c
@@ -206,7 +206,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid version 2",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "v3"
 				return c
@@ -215,7 +215,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid version 3",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "va3.10.0"
 				return c
@@ -224,7 +224,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid version 4",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "verybadversion"
 				return c
@@ -233,7 +233,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid version 5",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "v30"
 				return c
@@ -242,7 +242,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "invalid version 6",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Version = "30"
 				return c
@@ -251,7 +251,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "ansible pull policy - nil",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.OpenshiftAnsibleImagePullPolicy = nil
 				return c
@@ -260,7 +260,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "ansible pull policy - always",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullAlways)
 				return c
@@ -269,7 +269,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "ansible pull policy - if not present",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullIfNotPresent)
 				return c
@@ -278,7 +278,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "ansible pull policy - never",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullNever)
 				return c
@@ -287,7 +287,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "ansible pull policy - bad",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullPolicy("bad"))
 				return c
@@ -296,7 +296,7 @@ func TestValidateClusterVersion(t *testing.T) {
 		},
 		{
 			name: "ansible pull policy - empty",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.OpenshiftAnsibleImagePullPolicy = func(s kapi.PullPolicy) *kapi.PullPolicy { return &s }(kapi.PullPolicy(""))
 				return c
@@ -321,8 +321,8 @@ func TestValidateClusterVersion(t *testing.T) {
 func TestValidateClusterVersionUpdate(t *testing.T) {
 	cases := []struct {
 		name  string
-		old   *clusteroperator.ClusterVersion
-		new   *clusteroperator.ClusterVersion
+		old   *coapi.ClusterVersion
+		new   *coapi.ClusterVersion
 		valid bool
 	}{
 		{
@@ -334,7 +334,7 @@ func TestValidateClusterVersionUpdate(t *testing.T) {
 		{
 			name: "modified image format",
 			old:  getValidClusterVersion(),
-			new: func() *clusteroperator.ClusterVersion {
+			new: func() *coapi.ClusterVersion {
 				c := getValidClusterVersion()
 				c.Spec.Images.ImageFormat = "abc"
 				return c

--- a/pkg/apis/clusteroperator/validation/dnszone.go
+++ b/pkg/apis/clusteroperator/validation/dnszone.go
@@ -21,11 +21,11 @@ import (
 	dnsvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // ValidateDNSZone validates a cluster version being created.
-func ValidateDNSZone(dnsZone *clusteroperator.DNSZone) field.ErrorList {
+func ValidateDNSZone(dnsZone *coapi.DNSZone) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateDNSZoneSpec(&dnsZone.Spec, field.NewPath("spec"))...)
@@ -34,7 +34,7 @@ func ValidateDNSZone(dnsZone *clusteroperator.DNSZone) field.ErrorList {
 }
 
 // ValidateDNSZoneUpdate validates that a spec update of a DNSZone.
-func ValidateDNSZoneUpdate(new *clusteroperator.DNSZone, old *clusteroperator.DNSZone) field.ErrorList {
+func ValidateDNSZoneUpdate(new *coapi.DNSZone, old *coapi.DNSZone) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// For now updating cluster versions is not supported. In the future this may change if deemed useful.
 	// In the meantime it will be necessary to create a new cluster version and trigger an upgrade if modifications
@@ -45,14 +45,14 @@ func ValidateDNSZoneUpdate(new *clusteroperator.DNSZone, old *clusteroperator.DN
 }
 
 // ValidateDNSZoneStatusUpdate validates an update to the status of a DNSZone.
-func ValidateDNSZoneStatusUpdate(new *clusteroperator.DNSZone, old *clusteroperator.DNSZone) field.ErrorList {
+func ValidateDNSZoneStatusUpdate(new *coapi.DNSZone, old *coapi.DNSZone) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
 // ValidateDNSZoneSpec validates the spec of a DNSZone.
-func ValidateDNSZoneSpec(spec *clusteroperator.DNSZoneSpec, fldPath *field.Path) field.ErrorList {
+func ValidateDNSZoneSpec(spec *coapi.DNSZoneSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Make sure the DNS zone is specified.

--- a/pkg/apis/clusteroperator/validation/dnszone_test.go
+++ b/pkg/apis/clusteroperator/validation/dnszone_test.go
@@ -22,42 +22,42 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 var (
-	validZone = &clusteroperator.DNSZone{
+	validZone = &coapi.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-dns-zone",
 		},
-		Spec: clusteroperator.DNSZoneSpec{
+		Spec: coapi.DNSZoneSpec{
 			Zone: "valid.aws.example.com",
 		},
 	}
 
-	invalidZoneEmptyString = &clusteroperator.DNSZone{
+	invalidZoneEmptyString = &coapi.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "invalid-dns-zone-empty-string",
 		},
-		Spec: clusteroperator.DNSZoneSpec{
+		Spec: coapi.DNSZoneSpec{
 			Zone: "",
 		},
 	}
 
-	invalidZoneChars = &clusteroperator.DNSZone{
+	invalidZoneChars = &coapi.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "invalid-dns-zone-chars",
 		},
-		Spec: clusteroperator.DNSZoneSpec{
+		Spec: coapi.DNSZoneSpec{
 			Zone: "%.example.com",
 		},
 	}
 
-	invalidZoneLength = &clusteroperator.DNSZone{
+	invalidZoneLength = &coapi.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "invalid-dns-zone-length",
 		},
-		Spec: clusteroperator.DNSZoneSpec{
+		Spec: coapi.DNSZoneSpec{
 			Zone: "this.is.a.very.long.dns.name.that.makes.it.invalid.zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.example.com",
 		},
 	}
@@ -67,7 +67,7 @@ var (
 func TestValidateDNSZone(t *testing.T) {
 	cases := []struct {
 		name           string
-		dnszone        *clusteroperator.DNSZone
+		dnszone        *coapi.DNSZone
 		errorAssertion func(assert.TestingT, interface{}, ...interface{}) bool
 	}{
 		{
@@ -108,8 +108,8 @@ func TestValidateDNSZone(t *testing.T) {
 func TestValidateDNSZoneUpdate(t *testing.T) {
 	cases := []struct {
 		name           string
-		old            *clusteroperator.DNSZone
-		new            *clusteroperator.DNSZone
+		old            *coapi.DNSZone
+		new            *coapi.DNSZone
 		errorAssertion func(assert.TestingT, interface{}, ...interface{}) bool
 	}{
 		{
@@ -121,7 +121,7 @@ func TestValidateDNSZoneUpdate(t *testing.T) {
 		{
 			name: "modified zone name",
 			old:  validZone.DeepCopy(),
-			new: func() *clusteroperator.DNSZone {
+			new: func() *coapi.DNSZone {
 				c := validZone.DeepCopy()
 				c.Spec.Zone = "some.different.dns.zone.com"
 				return c

--- a/pkg/apis/clusteroperator/validation/machineset.go
+++ b/pkg/apis/clusteroperator/validation/machineset.go
@@ -19,11 +19,11 @@ package validation
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // validateMachineSetConfig validates the configuration of a machine set
-func validateMachineSetConfig(config *clusteroperator.MachineSetConfig, fldPath *field.Path) field.ErrorList {
+func validateMachineSetConfig(config *coapi.MachineSetConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateNodeType(config.NodeType, fldPath.Child("nodeType"))...)

--- a/pkg/apis/clusteroperator/validation/machineset_test.go
+++ b/pkg/apis/clusteroperator/validation/machineset_test.go
@@ -21,35 +21,35 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // TestValidateMachineSetConfig tests the validateMachineSetConfig function.
 func TestValidateMachineSetConfig(t *testing.T) {
 	cases := []struct {
 		name   string
-		config *clusteroperator.MachineSetConfig
+		config *coapi.MachineSetConfig
 		valid  bool
 	}{
 		{
 			name: "valid",
-			config: &clusteroperator.MachineSetConfig{
-				NodeType: clusteroperator.NodeTypeMaster,
+			config: &coapi.MachineSetConfig{
+				NodeType: coapi.NodeTypeMaster,
 				Size:     1,
 			},
 			valid: true,
 		},
 		{
 			name: "invalid node type",
-			config: &clusteroperator.MachineSetConfig{
-				NodeType: clusteroperator.NodeType(""),
+			config: &coapi.MachineSetConfig{
+				NodeType: coapi.NodeType(""),
 				Size:     1,
 			},
 		},
 		{
 			name: "invalid size",
-			config: &clusteroperator.MachineSetConfig{
-				NodeType: clusteroperator.NodeTypeMaster,
+			config: &coapi.MachineSetConfig{
+				NodeType: coapi.NodeTypeMaster,
 				Size:     0,
 			},
 		},

--- a/pkg/apis/clusteroperator/validation/validation.go
+++ b/pkg/apis/clusteroperator/validation/validation.go
@@ -19,13 +19,13 @@ package validation
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // validNodeTypes is a map containing an entry for every valid NodeType value.
-var validNodeTypes = map[clusteroperator.NodeType]bool{
-	clusteroperator.NodeTypeMaster:  true,
-	clusteroperator.NodeTypeCompute: true,
+var validNodeTypes = map[coapi.NodeType]bool{
+	coapi.NodeTypeMaster:  true,
+	coapi.NodeTypeCompute: true,
 }
 
 // validNodeTypeValues is an array of every valid NodeType value.
@@ -41,7 +41,7 @@ var validNodeTypeValues = func() []string {
 
 // validateNodeType validates that the specified node type has a valid
 // NodeType value.
-func validateNodeType(nodeType clusteroperator.NodeType, fldPath *field.Path) field.ErrorList {
+func validateNodeType(nodeType coapi.NodeType, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if !validNodeTypes[nodeType] {

--- a/pkg/apis/clusteroperator/validation/validation_test.go
+++ b/pkg/apis/clusteroperator/validation/validation_test.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // TestValidateNodeType validates the validateNodeType function.
@@ -49,7 +49,7 @@ func TestValidateNodeType(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		errs := validateNodeType(clusteroperator.NodeType(tc.nodeType), field.NewPath("nodeType"))
+		errs := validateNodeType(coapi.NodeType(tc.nodeType), field.NewPath("nodeType"))
 		if len(errs) != 0 && tc.valid {
 			t.Errorf("%v: unexpected error: %v", tc.nodeType, errs)
 			continue

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
-	cov1alpha1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 )
@@ -37,7 +37,7 @@ func (s ClusterOperatorAPIServer) PrepareRun() RunnableServer {
 func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 	ret := serverstorage.NewResourceConfig()
 	ret.EnableVersions(
-		cov1alpha1.SchemeGroupVersion,
+		cov1.SchemeGroupVersion,
 	)
 
 	return ret

--- a/pkg/clusterapi/aws/utils.go
+++ b/pkg/clusterapi/aws/utils.go
@@ -21,7 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -73,7 +73,7 @@ func chooseNewest(instance1, instance2 *ec2.Instance) *ec2.Instance {
 
 // GetInstance returns the AWS instance for a given machine. If multiple instances match our machine,
 // the most recently launched will be returned. If no instance exists, an error will be returned.
-func GetInstance(machine *clusterv1.Machine, client Client) (*ec2.Instance, error) {
+func GetInstance(machine *capiv1.Machine, client Client) (*ec2.Instance, error) {
 	instances, err := GetRunningInstances(machine, client)
 	if err != nil {
 		return nil, err
@@ -88,21 +88,21 @@ func GetInstance(machine *clusterv1.Machine, client Client) (*ec2.Instance, erro
 
 // GetRunningInstances returns all running instances that have a tag matching our machine name,
 // and cluster ID.
-func GetRunningInstances(machine *clusterv1.Machine, client Client) ([]*ec2.Instance, error) {
+func GetRunningInstances(machine *capiv1.Machine, client Client) ([]*ec2.Instance, error) {
 	runningInstanceStateFilter := []*string{aws.String(ec2.InstanceStateNameRunning), aws.String(ec2.InstanceStateNamePending)}
 	return GetInstances(machine, client, runningInstanceStateFilter)
 }
 
 // GetStoppedInstances returns all stopped instances that have a tag matching our machine name,
 // and cluster ID.
-func GetStoppedInstances(machine *clusterv1.Machine, client Client) ([]*ec2.Instance, error) {
+func GetStoppedInstances(machine *capiv1.Machine, client Client) ([]*ec2.Instance, error) {
 	stoppedInstanceStateFilter := []*string{aws.String(ec2.InstanceStateNameStopped), aws.String(ec2.InstanceStateNameStopping)}
 	return GetInstances(machine, client, stoppedInstanceStateFilter)
 }
 
 // GetInstances returns all instances that have a tag matching our machine name,
 // and cluster ID.
-func GetInstances(machine *clusterv1.Machine, client Client, instanceStateFilter []*string) ([]*ec2.Instance, error) {
+func GetInstances(machine *capiv1.Machine, client Client, instanceStateFilter []*string) ([]*ec2.Instance, error) {
 
 	machineName := machine.Name
 

--- a/pkg/clusterapi/fake/actuator.go
+++ b/pkg/clusterapi/fake/actuator.go
@@ -22,9 +22,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
-	clustoplog "github.com/openshift/cluster-operator/pkg/logging"
+	cologging "github.com/openshift/cluster-operator/pkg/logging"
 )
 
 // Actuator is a fake actuator
@@ -42,22 +42,22 @@ func NewActuator(logger *log.Entry) *Actuator {
 }
 
 // Create logs a create call
-func (a *Actuator) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("creating machine %#v", machine)
+func (a *Actuator) Create(cluster *capiv1.Cluster, machine *capiv1.Machine) error {
+	cologging.WithMachine(cologging.WithCluster(a.logger, cluster), machine).Infof("creating machine %#v", machine)
 	a.machines.LoadOrStore(machineKey(machine), true)
 	return nil
 }
 
 // Delete logs a delete call
-func (a *Actuator) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("deleting machine %#v", machine)
+func (a *Actuator) Delete(cluster *capiv1.Cluster, machine *capiv1.Machine) error {
+	cologging.WithMachine(cologging.WithCluster(a.logger, cluster), machine).Infof("deleting machine %#v", machine)
 	a.machines.Delete(machineKey(machine))
 	return nil
 }
 
 // Update logs an update call
-func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
-	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("updating machine %#v", machine)
+func (a *Actuator) Update(cluster *capiv1.Cluster, machine *capiv1.Machine) error {
+	cologging.WithMachine(cologging.WithCluster(a.logger, cluster), machine).Infof("updating machine %#v", machine)
 	if _, ok := a.machines.Load(machineKey(machine)); !ok {
 		return fmt.Errorf("machine not found")
 	}
@@ -65,12 +65,12 @@ func (a *Actuator) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine
 }
 
 // Exists logs the exists call and returns true
-func (a *Actuator) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
-	clustoplog.WithMachine(clustoplog.WithCluster(a.logger, cluster), machine).Infof("checking if machine exists")
+func (a *Actuator) Exists(cluster *capiv1.Cluster, machine *capiv1.Machine) (bool, error) {
+	cologging.WithMachine(cologging.WithCluster(a.logger, cluster), machine).Infof("checking if machine exists")
 	_, ok := a.machines.Load(machineKey(machine))
 	return ok, nil
 }
 
-func machineKey(machine *clusterv1.Machine) string {
+func machineKey(machine *capiv1.Machine) string {
 	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
 }

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -20,7 +20,7 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 
-	"github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	coclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
 	clusterclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
 	"github.com/golang/glog"
@@ -33,15 +33,15 @@ type ClientBuilder interface {
 	// ConfigOrDie return a new restclient.Config with the given user agent
 	// name, or logs a fatal error.
 	ConfigOrDie(name string) *restclient.Config
-	// Client returns a new clientset.Interface with the given user agent
+	// Client returns a new coclientset.Interface with the given user agent
 	// name.
-	Client(name string) (clientset.Interface, error)
+	Client(name string) (coclientset.Interface, error)
 	// ClusterAPIClient returns a new cluster API clientset.Interface
 	// with the given user agent name.
 	ClusterAPIClient(name string) (clusterclientset.Interface, error)
-	// ClientOrDie returns a new clientset.Interface with the given user agent
+	// ClientOrDie returns a new coclientset.Interface with the given user agent
 	// name or logs a fatal error.
-	ClientOrDie(name string) clientset.Interface
+	ClientOrDie(name string) coclientset.Interface
 	// KubeClientOrDie returns a new kubeclientset.Interface with the given
 	// user agent name or logs a fatal error.
 	KubeClientOrDie(name string) kubeclientset.Interface
@@ -74,17 +74,17 @@ func (b SimpleClientBuilder) ConfigOrDie(name string) *restclient.Config {
 
 // Client returns a new clientset.Interface with the given user agent
 // name.
-func (b SimpleClientBuilder) Client(name string) (clientset.Interface, error) {
+func (b SimpleClientBuilder) Client(name string) (coclientset.Interface, error) {
 	clientConfig, err := b.Config(name)
 	if err != nil {
 		return nil, err
 	}
-	return clientset.NewForConfig(clientConfig)
+	return coclientset.NewForConfig(clientConfig)
 }
 
 // ClientOrDie returns a new clientset.Interface with the given user agent
 // name or logs a fatal error.
-func (b SimpleClientBuilder) ClientOrDie(name string) clientset.Interface {
+func (b SimpleClientBuilder) ClientOrDie(name string) coclientset.Interface {
 	client, err := b.Client(name)
 	if err != nil {
 		glog.Fatal(err)

--- a/pkg/controller/clusterinstall/installstrategy.go
+++ b/pkg/controller/clusterinstall/installstrategy.go
@@ -19,10 +19,10 @@ package clusterinstall
 import (
 	batchv1 "k8s.io/api/batch/v1"
 
-	"github.com/openshift/cluster-operator/pkg/ansible"
-	clustop "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	"github.com/openshift/cluster-operator/pkg/controller"
-	capi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	coansible "github.com/openshift/cluster-operator/pkg/ansible"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // InstallStrategy is the strategy that a controller installing in a
@@ -30,11 +30,11 @@ import (
 // Implement JobSyncReprocessStrategy if successful installation jobs should be
 // reprocessed at regular intervals.
 type InstallStrategy interface {
-	ReadyToInstall(cluster *clustop.CombinedCluster, masterMachineSet *capi.MachineSet) bool
+	ReadyToInstall(cluster *cov1.CombinedCluster, masterMachineSet *capiv1.MachineSet) bool
 
-	OnInstall(succeeded bool, cluster *clustop.CombinedCluster, masterMachineSet *capi.MachineSet, job *batchv1.Job)
+	OnInstall(succeeded bool, cluster *cov1.CombinedCluster, masterMachineSet *capiv1.MachineSet, job *batchv1.Job)
 
-	ConvertJobSyncConditionType(conditionType controller.JobSyncConditionType) clustop.ClusterConditionType
+	ConvertJobSyncConditionType(conditionType cocontroller.JobSyncConditionType) cov1.ClusterConditionType
 }
 
 // InstallJobDecorationStrategy is an interface that can be added to
@@ -43,5 +43,5 @@ type InstallStrategy interface {
 type InstallJobDecorationStrategy interface {
 	// DecorateJobGeneratorExecutor decorates the executor that will be used
 	// to create the job for the specified cluster.
-	DecorateJobGeneratorExecutor(executor *ansible.JobGeneratorExecutor, cluster *clustop.CombinedCluster) error
+	DecorateJobGeneratorExecutor(executor *coansible.JobGeneratorExecutor, cluster *cov1.CombinedCluster) error
 }

--- a/pkg/controller/combinedcluster.go
+++ b/pkg/controller/combinedcluster.go
@@ -21,13 +21,13 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // CombinedClusterForClusterAPICluster creates a CombinedCluster
 // for the specified cluster-api Cluster.
-func CombinedClusterForClusterAPICluster(cluster *clusterapi.Cluster) (*clusteroperator.CombinedCluster, error) {
+func CombinedClusterForClusterAPICluster(cluster *capiv1.Cluster) (*cov1.CombinedCluster, error) {
 	awsSpec, err := AWSClusterProviderConfigFromCluster(cluster)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func CombinedClusterForClusterAPICluster(cluster *clusterapi.Cluster) (*clustero
 	if err != nil {
 		return nil, err
 	}
-	return &clusteroperator.CombinedCluster{
+	return &cov1.CombinedCluster{
 		TypeMeta:                 cluster.TypeMeta,
 		ObjectMeta:               cluster.ObjectMeta,
 		AWSClusterProviderConfig: awsSpec,
@@ -51,8 +51,8 @@ func CombinedClusterForClusterAPICluster(cluster *clusterapi.Cluster) (*clustero
 // If ignoreChanges is true, then the ProviderStatus will not be modified with
 // the cluster-operator ClusterStatus. This is useful for re-creating the original
 // cluster-api Cluster that was used to create the CombinedCluster.
-func ClusterAPIClusterForCombinedCluster(cluster *clusteroperator.CombinedCluster, ignoreChanges bool) (*clusterapi.Cluster, error) {
-	newCluster := &clusterapi.Cluster{
+func ClusterAPIClusterForCombinedCluster(cluster *cov1.CombinedCluster, ignoreChanges bool) (*capiv1.Cluster, error) {
+	newCluster := &capiv1.Cluster{
 		TypeMeta:   cluster.TypeMeta,
 		ObjectMeta: cluster.ObjectMeta,
 		Spec:       *cluster.ClusterSpec,
@@ -73,11 +73,11 @@ func ClusterAPIClusterForCombinedCluster(cluster *clusteroperator.CombinedCluste
 // ConvertToCombinedCluster converts a Cluster object, that is either a
 // cluster-operator Cluster, a cluster-api Cluster, or a CombinedCluster, into
 // a CombinedCluster object.
-func ConvertToCombinedCluster(cluster metav1.Object) (*clusteroperator.CombinedCluster, error) {
+func ConvertToCombinedCluster(cluster metav1.Object) (*cov1.CombinedCluster, error) {
 	switch c := cluster.(type) {
-	case *clusteroperator.CombinedCluster:
+	case *cov1.CombinedCluster:
 		return c, nil
-	case *clusterapi.Cluster:
+	case *capiv1.Cluster:
 		return CombinedClusterForClusterAPICluster(c)
 	default:
 		return nil, fmt.Errorf("unknown type %T", c)

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -37,9 +37,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/cluster-operator/pkg/api"
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clustoplister "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	colisters "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	capilister "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
 )
 
@@ -58,9 +58,9 @@ var (
 	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
 	// ClusterDeploymentKind is the GVK for a ClusterDeployment.
-	ClusterDeploymentKind = clusteroperator.SchemeGroupVersion.WithKind("ClusterDeployment")
+	ClusterDeploymentKind = cov1.SchemeGroupVersion.WithKind("ClusterDeployment")
 
-	clusterKind = clusterapi.SchemeGroupVersion.WithKind("Cluster")
+	clusterKind = capiv1.SchemeGroupVersion.WithKind("Cluster")
 )
 
 // WaitForCacheSync is a wrapper around cache.WaitForCacheSync that generates log messages
@@ -121,20 +121,20 @@ func shouldUpdateCondition(
 // 1) Requested status is different than existing status.
 // 2) The updateConditionCheck function returns true.
 func SetClusterCondition(
-	conditions []clusteroperator.ClusterCondition,
-	conditionType clusteroperator.ClusterConditionType,
+	conditions []cov1.ClusterCondition,
+	conditionType cov1.ClusterConditionType,
 	status corev1.ConditionStatus,
 	reason string,
 	message string,
 	updateConditionCheck UpdateConditionCheck,
-) []clusteroperator.ClusterCondition {
+) []cov1.ClusterCondition {
 	now := metav1.Now()
 	existingCondition := FindClusterCondition(conditions, conditionType)
 	if existingCondition == nil {
 		if status == corev1.ConditionTrue {
 			conditions = append(
 				conditions,
-				clusteroperator.ClusterCondition{
+				cov1.ClusterCondition{
 					Type:               conditionType,
 					Status:             status,
 					Reason:             reason,
@@ -164,7 +164,7 @@ func SetClusterCondition(
 
 // FindClusterCondition finds in the cluster the condition that has the
 // specified condition type. If none exists, then returns nil.
-func FindClusterCondition(conditions []clusteroperator.ClusterCondition, conditionType clusteroperator.ClusterConditionType) *clusteroperator.ClusterCondition {
+func FindClusterCondition(conditions []cov1.ClusterCondition, conditionType cov1.ClusterConditionType) *cov1.ClusterCondition {
 	for i, condition := range conditions {
 		if condition.Type == conditionType {
 			return &conditions[i]
@@ -183,20 +183,20 @@ func FindClusterCondition(conditions []clusteroperator.ClusterCondition, conditi
 // 1) Requested status is different than existing status.
 // 2) The updateConditionCheck function returns true.
 func SetClusterDeploymentCondition(
-	conditions []clusteroperator.ClusterDeploymentCondition,
-	conditionType clusteroperator.ClusterDeploymentConditionType,
+	conditions []cov1.ClusterDeploymentCondition,
+	conditionType cov1.ClusterDeploymentConditionType,
 	status corev1.ConditionStatus,
 	reason string,
 	message string,
 	updateConditionCheck UpdateConditionCheck,
-) []clusteroperator.ClusterDeploymentCondition {
+) []cov1.ClusterDeploymentCondition {
 	now := metav1.Now()
 	existingCondition := FindClusterDeploymentCondition(conditions, conditionType)
 	if existingCondition == nil {
 		if status == corev1.ConditionTrue {
 			conditions = append(
 				conditions,
-				clusteroperator.ClusterDeploymentCondition{
+				cov1.ClusterDeploymentCondition{
 					Type:               conditionType,
 					Status:             status,
 					Reason:             reason,
@@ -226,7 +226,7 @@ func SetClusterDeploymentCondition(
 
 // FindClusterDeploymentCondition finds in the cluster deployment the condition that has the
 // specified condition type. If none exists, then returns nil.
-func FindClusterDeploymentCondition(conditions []clusteroperator.ClusterDeploymentCondition, conditionType clusteroperator.ClusterDeploymentConditionType) *clusteroperator.ClusterDeploymentCondition {
+func FindClusterDeploymentCondition(conditions []cov1.ClusterDeploymentCondition, conditionType cov1.ClusterDeploymentConditionType) *cov1.ClusterDeploymentCondition {
 	for i, condition := range conditions {
 		if condition.Type == conditionType {
 			return &conditions[i]
@@ -245,20 +245,20 @@ func FindClusterDeploymentCondition(conditions []clusteroperator.ClusterDeployme
 // 1) Requested status is different than existing status.
 // 2) The updateConditionCheck function returns true.
 func SetAWSMachineCondition(
-	conditions []clusteroperator.AWSMachineCondition,
-	conditionType clusteroperator.AWSMachineConditionType,
+	conditions []cov1.AWSMachineCondition,
+	conditionType cov1.AWSMachineConditionType,
 	status corev1.ConditionStatus,
 	reason string,
 	message string,
 	updateConditionCheck UpdateConditionCheck,
-) []clusteroperator.AWSMachineCondition {
+) []cov1.AWSMachineCondition {
 	now := metav1.Now()
 	existingCondition := FindAWSMachineCondition(conditions, conditionType)
 	if existingCondition == nil {
 		if status == corev1.ConditionTrue {
 			conditions = append(
 				conditions,
-				clusteroperator.AWSMachineCondition{
+				cov1.AWSMachineCondition{
 					Type:               conditionType,
 					Status:             status,
 					Reason:             reason,
@@ -288,7 +288,7 @@ func SetAWSMachineCondition(
 
 // FindAWSMachineCondition finds in the machine the condition that has the
 // specified condition type. If none exists, then returns nil.
-func FindAWSMachineCondition(conditions []clusteroperator.AWSMachineCondition, conditionType clusteroperator.AWSMachineConditionType) *clusteroperator.AWSMachineCondition {
+func FindAWSMachineCondition(conditions []cov1.AWSMachineCondition, conditionType cov1.AWSMachineConditionType) *cov1.AWSMachineCondition {
 	for i, condition := range conditions {
 		if condition.Type == conditionType {
 			return &conditions[i]
@@ -329,21 +329,21 @@ func GetObjectController(
 }
 
 // ClusterForMachineSet retrieves the cluster to which a machine set belongs.
-func ClusterForMachineSet(machineSet *clusterapi.MachineSet, clusterLister capilister.ClusterLister) (*clusterapi.Cluster, error) {
+func ClusterForMachineSet(machineSet *capiv1.MachineSet, clusterLister capilister.ClusterLister) (*capiv1.Cluster, error) {
 	if machineSet.Labels == nil {
-		return nil, fmt.Errorf("missing %s label", clusteroperator.ClusterNameLabel)
+		return nil, fmt.Errorf("missing %s label", cov1.ClusterNameLabel)
 	}
-	clusterName, ok := machineSet.Labels[clusteroperator.ClusterNameLabel]
+	clusterName, ok := machineSet.Labels[cov1.ClusterNameLabel]
 	if !ok {
-		return nil, fmt.Errorf("missing %s label", clusteroperator.ClusterNameLabel)
+		return nil, fmt.Errorf("missing %s label", cov1.ClusterNameLabel)
 	}
 	return clusterLister.Clusters(machineSet.Namespace).Get(clusterName)
 }
 
 // MachineSetsForCluster retrieves the machinesets associated with the
 // specified cluster name.
-func MachineSetsForCluster(namespace string, clusterName string, machineSetsLister capilister.MachineSetLister) ([]*clusterapi.MachineSet, error) {
-	requirement, err := labels.NewRequirement(clusteroperator.ClusterNameLabel, selection.Equals, []string{clusterName})
+func MachineSetsForCluster(namespace string, clusterName string, machineSetsLister capilister.MachineSetLister) ([]*capiv1.MachineSet, error) {
+	requirement, err := labels.NewRequirement(cov1.ClusterNameLabel, selection.Equals, []string{clusterName})
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func MachineSetsForCluster(namespace string, clusterName string, machineSetsList
 }
 
 // ClusterDeploymentForCluster retrieves the cluster deployment that owns the cluster.
-func ClusterDeploymentForCluster(cluster *clusterapi.Cluster, clusterDeploymentsLister clustoplister.ClusterDeploymentLister) (*clusteroperator.ClusterDeployment, error) {
+func ClusterDeploymentForCluster(cluster *capiv1.Cluster, clusterDeploymentsLister colisters.ClusterDeploymentLister) (*cov1.ClusterDeployment, error) {
 	controller, err := GetObjectController(
 		cluster,
 		ClusterDeploymentKind,
@@ -365,7 +365,7 @@ func ClusterDeploymentForCluster(cluster *clusterapi.Cluster, clusterDeployments
 	if controller == nil {
 		return nil, nil
 	}
-	clusterDeployment, ok := controller.(*clusteroperator.ClusterDeployment)
+	clusterDeployment, ok := controller.(*cov1.ClusterDeployment)
 	if !ok {
 		return nil, fmt.Errorf("Could not convert controller into a ClusterDeployment")
 	}
@@ -373,7 +373,7 @@ func ClusterDeploymentForCluster(cluster *clusterapi.Cluster, clusterDeployments
 }
 
 // ClusterDeploymentForMachineSet retrieves the cluster deployment that owns the machine set.
-func ClusterDeploymentForMachineSet(machineSet *clusterapi.MachineSet, clusterDeploymentsLister clustoplister.ClusterDeploymentLister) (*clusteroperator.ClusterDeployment, error) {
+func ClusterDeploymentForMachineSet(machineSet *capiv1.MachineSet, clusterDeploymentsLister colisters.ClusterDeploymentLister) (*cov1.ClusterDeployment, error) {
 	controller, err := GetObjectController(
 		machineSet,
 		ClusterDeploymentKind,
@@ -387,7 +387,7 @@ func ClusterDeploymentForMachineSet(machineSet *clusterapi.MachineSet, clusterDe
 	if controller == nil {
 		return nil, nil
 	}
-	clusterDeployment, ok := controller.(*clusteroperator.ClusterDeployment)
+	clusterDeployment, ok := controller.(*cov1.ClusterDeployment)
 	if !ok {
 		return nil, fmt.Errorf("Could not convert controller into a ClusterDeployment")
 	}
@@ -400,8 +400,8 @@ func ClusterDeploymentForMachineSet(machineSet *clusterapi.MachineSet, clusterDe
 // cluster-operator Cluster, and cluster-api Cluster, or a CombinedCluster.
 func JobLabelsForClusterController(cluster metav1.Object, jobType string) map[string]string {
 	return map[string]string{
-		clusteroperator.ClusterNameLabel: cluster.GetName(),
-		JobTypeLabel:                     jobType,
+		cov1.ClusterNameLabel: cluster.GetName(),
+		JobTypeLabel:          jobType,
 	}
 }
 
@@ -419,15 +419,15 @@ func AddLabels(obj metav1.Object, additionalLabels map[string]string) {
 
 // AWSClusterProviderConfigFromCluster gets the AWSClusterProviderConfig from the
 // specified cluster-api Cluster.
-func AWSClusterProviderConfigFromCluster(cluster *clusterapi.Cluster) (*clusteroperator.AWSClusterProviderConfig, error) {
+func AWSClusterProviderConfigFromCluster(cluster *capiv1.Cluster) (*cov1.AWSClusterProviderConfig, error) {
 	if cluster.Spec.ProviderConfig.Value == nil {
 		return nil, fmt.Errorf("No Value in ProviderConfig")
 	}
-	obj, gvk, err := api.Codecs.UniversalDecoder(clusteroperator.SchemeGroupVersion).Decode([]byte(cluster.Spec.ProviderConfig.Value.Raw), nil, nil)
+	obj, gvk, err := api.Codecs.UniversalDecoder(cov1.SchemeGroupVersion).Decode([]byte(cluster.Spec.ProviderConfig.Value.Raw), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode ProviderConfig: %v", err)
 	}
-	spec, ok := obj.(*clusteroperator.AWSClusterProviderConfig)
+	spec, ok := obj.(*cov1.AWSClusterProviderConfig)
 	if !ok {
 		return nil, fmt.Errorf("Unexpected object: %#v", gvk)
 	}
@@ -436,15 +436,15 @@ func AWSClusterProviderConfigFromCluster(cluster *clusterapi.Cluster) (*clustero
 
 // ClusterProviderStatusFromCluster gets the cluster-operator provider status from the
 // specified cluster-api Cluster.
-func ClusterProviderStatusFromCluster(cluster *clusterapi.Cluster) (*clusteroperator.ClusterProviderStatus, error) {
+func ClusterProviderStatusFromCluster(cluster *capiv1.Cluster) (*cov1.ClusterProviderStatus, error) {
 	if cluster.Status.ProviderStatus == nil {
-		return &clusteroperator.ClusterProviderStatus{}, nil
+		return &cov1.ClusterProviderStatus{}, nil
 	}
-	obj, gvk, err := api.Codecs.UniversalDecoder(clusteroperator.SchemeGroupVersion).Decode([]byte(cluster.Status.ProviderStatus.Raw), nil, nil)
+	obj, gvk, err := api.Codecs.UniversalDecoder(cov1.SchemeGroupVersion).Decode([]byte(cluster.Status.ProviderStatus.Raw), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode ProviderStatus: %v", err)
 	}
-	status, ok := obj.(*clusteroperator.ClusterProviderStatus)
+	status, ok := obj.(*cov1.ClusterProviderStatus)
 	if !ok {
 		return nil, fmt.Errorf("Unexpected object: %#v", gvk)
 	}
@@ -453,20 +453,20 @@ func ClusterProviderStatusFromCluster(cluster *clusterapi.Cluster) (*clusteroper
 
 // BuildAWSClusterProviderConfig returns an encoded cloud provider specific RawExtension
 // for use in the cluster spec's ProviderConfig.
-func BuildAWSClusterProviderConfig(clusterDeploymentSpec *clusteroperator.ClusterDeploymentSpec, cv clusteroperator.ClusterVersionSpec) (*runtime.RawExtension, error) {
+func BuildAWSClusterProviderConfig(clusterDeploymentSpec *cov1.ClusterDeploymentSpec, cv cov1.ClusterVersionSpec) (*runtime.RawExtension, error) {
 	// TODO: drop this error when we're ready to support other clouds
 	if clusterDeploymentSpec.Hardware.AWS == nil {
 		return nil, fmt.Errorf("no AWS hardware was defined")
 	}
-	clusterProviderConfigSpec := &clusteroperator.AWSClusterProviderConfig{
+	clusterProviderConfigSpec := &cov1.AWSClusterProviderConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: clusteroperator.SchemeGroupVersion.String(),
+			APIVersion: cov1.SchemeGroupVersion.String(),
 			Kind:       "AWSClusterProviderConfig",
 		},
 		Hardware: *clusterDeploymentSpec.Hardware.AWS,
-		OpenShiftConfig: clusteroperator.OpenShiftDistributionConfig{
+		OpenShiftConfig: cov1.OpenShiftDistributionConfig{
 			ClusterConfigSpec: clusterDeploymentSpec.Config,
-			Version: clusteroperator.OpenShiftConfigVersion{
+			Version: cov1.OpenShiftConfigVersion{
 				DeploymentType: cv.DeploymentType,
 				Version:        cv.Version,
 				Images:         cv.Images,
@@ -489,9 +489,9 @@ func BuildAWSClusterProviderConfig(clusterDeploymentSpec *clusteroperator.Cluste
 
 // EncodeClusterProviderStatus gets the cluster-api ProviderStatus
 // storing the cluster-operator ClusterStatus.
-func EncodeClusterProviderStatus(clusterProviderStatus *clusteroperator.ClusterProviderStatus) (*runtime.RawExtension, error) {
+func EncodeClusterProviderStatus(clusterProviderStatus *cov1.ClusterProviderStatus) (*runtime.RawExtension, error) {
 	clusterProviderStatus.TypeMeta = metav1.TypeMeta{
-		APIVersion: clusteroperator.SchemeGroupVersion.String(),
+		APIVersion: cov1.SchemeGroupVersion.String(),
 		Kind:       "ClusterProviderStatus",
 	}
 
@@ -508,15 +508,15 @@ func EncodeClusterProviderStatus(clusterProviderStatus *clusteroperator.ClusterP
 
 // MachineSetSpecFromClusterAPIMachineSpec gets the cluster-operator MachineSetSpec from the
 // specified cluster-api MachineSet.
-func MachineSetSpecFromClusterAPIMachineSpec(ms *clusterapi.MachineSpec) (*clusteroperator.MachineSetSpec, error) {
+func MachineSetSpecFromClusterAPIMachineSpec(ms *capiv1.MachineSpec) (*cov1.MachineSetSpec, error) {
 	if ms.ProviderConfig.Value == nil {
 		return nil, fmt.Errorf("No Value in ProviderConfig")
 	}
-	obj, gvk, err := api.Codecs.UniversalDecoder(clusteroperator.SchemeGroupVersion).Decode([]byte(ms.ProviderConfig.Value.Raw), nil, nil)
+	obj, gvk, err := api.Codecs.UniversalDecoder(cov1.SchemeGroupVersion).Decode([]byte(ms.ProviderConfig.Value.Raw), nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	spec, ok := obj.(*clusteroperator.MachineSetProviderConfigSpec)
+	spec, ok := obj.(*cov1.MachineSetProviderConfigSpec)
 	if !ok {
 		return nil, fmt.Errorf("Unexpected object: %#v", gvk)
 	}
@@ -524,8 +524,8 @@ func MachineSetSpecFromClusterAPIMachineSpec(ms *clusterapi.MachineSpec) (*clust
 }
 
 // BuildCluster builds a cluster for the given cluster deployment.
-func BuildCluster(clusterDeployment *clusteroperator.ClusterDeployment, cv clusteroperator.ClusterVersionSpec) (*clusterapi.Cluster, error) {
-	cluster := &clusterapi.Cluster{}
+func BuildCluster(clusterDeployment *cov1.ClusterDeployment, cv cov1.ClusterVersionSpec) (*capiv1.Cluster, error) {
+	cluster := &capiv1.Cluster{}
 	cluster.Name = clusterDeployment.Spec.ClusterName
 	cluster.Labels = clusterDeployment.Labels
 	cluster.Annotations = clusterDeployment.Annotations
@@ -536,7 +536,7 @@ func BuildCluster(clusterDeployment *clusteroperator.ClusterDeployment, cv clust
 	if cluster.Annotations == nil {
 		cluster.Annotations = make(map[string]string)
 	}
-	cluster.Labels[clusteroperator.ClusterDeploymentLabel] = clusterDeployment.Name
+	cluster.Labels[cov1.ClusterDeploymentLabel] = clusterDeployment.Name
 	blockOwnerDeletion := false
 	controllerRef := metav1.NewControllerRef(clusterDeployment, ClusterDeploymentKind)
 	controllerRef.BlockOwnerDeletion = &blockOwnerDeletion
@@ -554,10 +554,10 @@ func BuildCluster(clusterDeployment *clusteroperator.ClusterDeployment, cv clust
 
 // MachineProviderConfigFromMachineSetSpec gets the cluster-api ProviderConfig for a Machine template
 // to store the cluster-operator MachineSetSpec.
-func MachineProviderConfigFromMachineSetSpec(machineSetSpec *clusteroperator.MachineSetSpec) (*runtime.RawExtension, error) {
-	msProviderConfigSpec := &clusteroperator.MachineSetProviderConfigSpec{
+func MachineProviderConfigFromMachineSetSpec(machineSetSpec *cov1.MachineSetSpec) (*runtime.RawExtension, error) {
+	msProviderConfigSpec := &cov1.MachineSetProviderConfigSpec{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: clusteroperator.SchemeGroupVersion.String(),
+			APIVersion: cov1.SchemeGroupVersion.String(),
 			Kind:       "MachineSetProviderConfigSpec",
 		},
 		MachineSetSpec: *machineSetSpec,
@@ -575,21 +575,21 @@ func MachineProviderConfigFromMachineSetSpec(machineSetSpec *clusteroperator.Mac
 
 // AWSMachineProviderStatusFromClusterAPIMachine gets the cluster-operator MachineSetSpec from the
 // specified cluster-api MachineSet.
-func AWSMachineProviderStatusFromClusterAPIMachine(m *clusterapi.Machine) (*clusteroperator.AWSMachineProviderStatus, error) {
+func AWSMachineProviderStatusFromClusterAPIMachine(m *capiv1.Machine) (*cov1.AWSMachineProviderStatus, error) {
 	return AWSMachineProviderStatusFromMachineStatus(&m.Status)
 }
 
 // AWSMachineProviderStatusFromMachineStatus gets the cluster-operator AWSMachineProviderStatus from the
 // specified cluster-api MachineStatus.
-func AWSMachineProviderStatusFromMachineStatus(s *clusterapi.MachineStatus) (*clusteroperator.AWSMachineProviderStatus, error) {
+func AWSMachineProviderStatusFromMachineStatus(s *capiv1.MachineStatus) (*cov1.AWSMachineProviderStatus, error) {
 	if s.ProviderStatus == nil {
-		return &clusteroperator.AWSMachineProviderStatus{}, nil
+		return &cov1.AWSMachineProviderStatus{}, nil
 	}
-	obj, gvk, err := api.Codecs.UniversalDecoder(clusteroperator.SchemeGroupVersion).Decode([]byte(s.ProviderStatus.Raw), nil, nil)
+	obj, gvk, err := api.Codecs.UniversalDecoder(cov1.SchemeGroupVersion).Decode([]byte(s.ProviderStatus.Raw), nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	status, ok := obj.(*clusteroperator.AWSMachineProviderStatus)
+	status, ok := obj.(*cov1.AWSMachineProviderStatus)
 	if !ok {
 		return nil, fmt.Errorf("Unexpected object: %#v", gvk)
 	}
@@ -598,9 +598,9 @@ func AWSMachineProviderStatusFromMachineStatus(s *clusterapi.MachineStatus) (*cl
 
 // EncodeAWSMachineProviderStatus gets the cluster-api ProviderConfig for a Machine template
 // to store the cluster-operator MachineSetSpec.
-func EncodeAWSMachineProviderStatus(awsStatus *clusteroperator.AWSMachineProviderStatus) (*runtime.RawExtension, error) {
+func EncodeAWSMachineProviderStatus(awsStatus *cov1.AWSMachineProviderStatus) (*runtime.RawExtension, error) {
 	awsStatus.TypeMeta = metav1.TypeMeta{
-		APIVersion: clusteroperator.SchemeGroupVersion.String(),
+		APIVersion: cov1.SchemeGroupVersion.String(),
 		Kind:       "AWSMachineProviderStatus",
 	}
 	serializer := jsonserializer.NewSerializer(jsonserializer.DefaultMetaFactory, api.Scheme, api.Scheme, false)
@@ -615,8 +615,8 @@ func EncodeAWSMachineProviderStatus(awsStatus *clusteroperator.AWSMachineProvide
 }
 
 // MachineProviderConfigFromMachineSetConfig returns a RawExtension with a machine ProviderConfig from a MachineSetConfig
-func MachineProviderConfigFromMachineSetConfig(machineSetConfig *clusteroperator.MachineSetConfig, clusterDeploymentSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion *clusteroperator.ClusterVersion) (*runtime.RawExtension, error) {
-	msSpec := &clusteroperator.MachineSetSpec{
+func MachineProviderConfigFromMachineSetConfig(machineSetConfig *cov1.MachineSetConfig, clusterDeploymentSpec *cov1.ClusterDeploymentSpec, clusterVersion *cov1.ClusterVersion) (*runtime.RawExtension, error) {
+	msSpec := &cov1.MachineSetSpec{
 		MachineSetConfig: *machineSetConfig,
 	}
 	vmImage, err := getImage(clusterDeploymentSpec, clusterVersion)
@@ -639,7 +639,7 @@ func MachineProviderConfigFromMachineSetConfig(machineSetConfig *clusteroperator
 }
 
 // getImage returns a specific image for the given machine and cluster version.
-func getImage(clusterSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion *clusteroperator.ClusterVersion) (*clusteroperator.VMImage, error) {
+func getImage(clusterSpec *cov1.ClusterDeploymentSpec, clusterVersion *cov1.ClusterVersion) (*cov1.VMImage, error) {
 	if clusterSpec.Hardware.AWS == nil {
 		return nil, fmt.Errorf("no AWS hardware defined for cluster")
 	}
@@ -651,7 +651,7 @@ func getImage(clusterSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion
 	for _, regionAMI := range clusterVersion.Spec.VMImages.AWSImages.RegionAMIs {
 		if regionAMI.Region == clusterSpec.Hardware.AWS.Region {
 			ami := regionAMI.AMI
-			return &clusteroperator.VMImage{
+			return &cov1.VMImage{
 				AWSImage: &ami,
 			}, nil
 		}
@@ -661,7 +661,7 @@ func getImage(clusterSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion
 }
 
 // ApplyDefaultMachineSetHardwareSpec merges the cluster-wide hardware defaults with the machineset specific hardware specified.
-func ApplyDefaultMachineSetHardwareSpec(machineSetHardwareSpec, defaultHardwareSpec *clusteroperator.MachineSetHardwareSpec) (*clusteroperator.MachineSetHardwareSpec, error) {
+func ApplyDefaultMachineSetHardwareSpec(machineSetHardwareSpec, defaultHardwareSpec *cov1.MachineSetHardwareSpec) (*cov1.MachineSetHardwareSpec, error) {
 	if defaultHardwareSpec == nil {
 		return machineSetHardwareSpec, nil
 	}
@@ -674,7 +674,7 @@ func ApplyDefaultMachineSetHardwareSpec(machineSetHardwareSpec, defaultHardwareS
 		return nil, err
 	}
 	merged, err := strategicpatch.StrategicMergePatch(defaultHwSpecJSON, specificHwSpecJSON, machineSetHardwareSpec)
-	mergedSpec := &clusteroperator.MachineSetHardwareSpec{}
+	mergedSpec := &cov1.MachineSetHardwareSpec{}
 	if err = json.Unmarshal(merged, mergedSpec); err != nil {
 		return nil, err
 	}
@@ -682,7 +682,7 @@ func ApplyDefaultMachineSetHardwareSpec(machineSetHardwareSpec, defaultHardwareS
 }
 
 // GetInfraSize gets the size of the infra machine set for the cluster.
-func GetInfraSize(cluster *clusteroperator.CombinedCluster) (int, error) {
+func GetInfraSize(cluster *cov1.CombinedCluster) (int, error) {
 	return 1, nil
 	/*
 		for _, ms := range cluster.ClusterDeploymentSpec.MachineSets {
@@ -695,7 +695,7 @@ func GetInfraSize(cluster *clusteroperator.CombinedCluster) (int, error) {
 }
 
 // GetMasterMachineSet gets the master machine set for the cluster.
-func GetMasterMachineSet(cluster *clusteroperator.CombinedCluster, machineSetLister capilister.MachineSetLister) (*clusterapi.MachineSet, error) {
+func GetMasterMachineSet(cluster *cov1.CombinedCluster, machineSetLister capilister.MachineSetLister) (*capiv1.MachineSet, error) {
 	machineSets, err := MachineSetsForCluster(cluster.Namespace, cluster.Name, machineSetLister)
 	if err != nil {
 		return nil, err
@@ -711,16 +711,16 @@ func GetMasterMachineSet(cluster *clusteroperator.CombinedCluster, machineSetLis
 }
 
 // MachineIsMaster returns true if the machine is part of a cluster's control plane
-func MachineIsMaster(machine *clusterapi.Machine) (bool, error) {
+func MachineIsMaster(machine *capiv1.Machine) (bool, error) {
 	coMachineSetSpec, err := MachineSetSpecFromClusterAPIMachineSpec(&machine.Spec)
 	if err != nil {
 		return false, err
 	}
-	return coMachineSetSpec.NodeType == clusteroperator.NodeTypeMaster, nil
+	return coMachineSetSpec.NodeType == cov1.NodeTypeMaster, nil
 }
 
 // MachineIsInfra returns true if the machine is part of a cluster's control plane
-func MachineIsInfra(machine *clusterapi.Machine) (bool, error) {
+func MachineIsInfra(machine *capiv1.Machine) (bool, error) {
 	coMachineSetSpec, err := MachineSetSpecFromClusterAPIMachineSpec(&machine.Spec)
 	if err != nil {
 		return false, err
@@ -768,17 +768,17 @@ func trimForELBBasename(s string, maxLen int) string {
 
 // BuildMachineSet returns a clusterapi.MachineSet from the combination of various clusteroperator
 // objects (ClusterMachineSet/ClusterDeploymentSpec/ClusterVersion) in the provided 'namespace'
-func BuildMachineSet(ms *clusteroperator.ClusterMachineSet, clusterDeploymentSpec *clusteroperator.ClusterDeploymentSpec, clusterVersion *clusteroperator.ClusterVersion, namespace string) (*clusterapi.MachineSet, error) {
+func BuildMachineSet(ms *cov1.ClusterMachineSet, clusterDeploymentSpec *cov1.ClusterDeploymentSpec, clusterVersion *cov1.ClusterVersion, namespace string) (*capiv1.MachineSet, error) {
 	machineSetName := fmt.Sprintf("%s-%s", clusterDeploymentSpec.ClusterName, ms.ShortName)
-	capiMachineSet := clusterapi.MachineSet{}
+	capiMachineSet := capiv1.MachineSet{}
 	capiMachineSet.Name = machineSetName
 	capiMachineSet.Namespace = namespace
 	replicas := int32(ms.Size)
 	capiMachineSet.Spec.Replicas = &replicas
-	machineTemplate := clusterapi.MachineTemplateSpec{}
+	machineTemplate := capiv1.MachineTemplateSpec{}
 	labels := map[string]string{
-		clusteroperator.MachineSetNameLabel: machineSetName,
-		clusteroperator.ClusterNameLabel:    clusterDeploymentSpec.ClusterName,
+		cov1.MachineSetNameLabel: machineSetName,
+		cov1.ClusterNameLabel:    clusterDeploymentSpec.ClusterName,
 	}
 	capiMachineSet.Labels = labels
 	// Assign the same set of labels for the machine template and the selector:
@@ -844,7 +844,7 @@ func DeleteFinalizer(object metav1.Object, finalizer string) {
 
 // GetSecretNameFromMachineSetSpec will retrieve the secret name holding AWS credentials
 // from a machcinesetspec if it exists. Otherwise it will return an empty string.
-func GetSecretNameFromMachineSetSpec(msSpec *clusteroperator.MachineSetSpec) (string, error) {
+func GetSecretNameFromMachineSetSpec(msSpec *cov1.MachineSetSpec) (string, error) {
 	secretName := ""
 	if msSpec.ClusterHardware.AWS == nil {
 		return "", fmt.Errorf("no AWS cluster hardware set on machine spec")

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -30,9 +30,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 const (
@@ -158,14 +158,14 @@ func TestUpdateConditionIfReasonOrMessageChange(t *testing.T) {
 }
 
 func newClusterCondition(
-	conditionType clusteroperator.ClusterConditionType,
+	conditionType cov1.ClusterConditionType,
 	status corev1.ConditionStatus,
 	reason string,
 	message string,
 	lastTransitionTime metav1.Time,
 	lastProbeTime metav1.Time,
-) clusteroperator.ClusterCondition {
-	return clusteroperator.ClusterCondition{
+) cov1.ClusterCondition {
+	return cov1.ClusterCondition{
 		Type:               conditionType,
 		Status:             status,
 		Reason:             reason,
@@ -179,89 +179,89 @@ func newClusterCondition(
 func TestSetClusterCondition(t *testing.T) {
 	cases := []struct {
 		name               string
-		existingConditions []clusteroperator.ClusterCondition
-		conditionType      clusteroperator.ClusterConditionType
+		existingConditions []cov1.ClusterCondition
+		conditionType      cov1.ClusterConditionType
 		status             corev1.ConditionStatus
 		reason             string
 		message            string
 		updateCondition    bool
-		expectedConditions []clusteroperator.ClusterCondition
+		expectedConditions []cov1.ClusterCondition
 		expectedOldReason  string
 		expectedOldMessage string
 	}{
 		{
 			name:          "new condition",
-			conditionType: clusteroperator.ClusterReady,
+			conditionType: cov1.ClusterReady,
 			status:        corev1.ConditionTrue,
 			reason:        "reason",
 			message:       "message",
-			expectedConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "reason", "message", metav1.Now(), metav1.Now()),
+			expectedConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "reason", "message", metav1.Now(), metav1.Now()),
 			},
 		},
 		{
 			name: "new condition with existing conditions",
-			existingConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterInfraProvisioning, corev1.ConditionTrue, "other reason", "other message", metav1.Time{}, metav1.Time{}),
+			existingConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterInfraProvisioning, corev1.ConditionTrue, "other reason", "other message", metav1.Time{}, metav1.Time{}),
 			},
-			conditionType: clusteroperator.ClusterReady,
+			conditionType: cov1.ClusterReady,
 			status:        corev1.ConditionTrue,
 			reason:        "reason",
 			message:       "message",
-			expectedConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterInfraProvisioning, corev1.ConditionTrue, "other reason", "other message", metav1.Time{}, metav1.Time{}),
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "reason", "message", metav1.Now(), metav1.Now()),
+			expectedConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterInfraProvisioning, corev1.ConditionTrue, "other reason", "other message", metav1.Time{}, metav1.Time{}),
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "reason", "message", metav1.Now(), metav1.Now()),
 			},
 		},
 		{
 			name:          "false condition not created",
-			conditionType: clusteroperator.ClusterReady,
+			conditionType: cov1.ClusterReady,
 			status:        corev1.ConditionFalse,
 			reason:        "reason",
 			message:       "message",
 		},
 		{
 			name: "condition not updated",
-			existingConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
+			existingConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
 			},
-			conditionType: clusteroperator.ClusterReady,
+			conditionType: cov1.ClusterReady,
 			status:        corev1.ConditionTrue,
 			reason:        "reason",
 			message:       "message",
-			expectedConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
+			expectedConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
 			},
 			expectedOldReason:  "old reason",
 			expectedOldMessage: "old message",
 		},
 		{
 			name: "condition status changed",
-			existingConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
+			existingConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
 			},
-			conditionType: clusteroperator.ClusterReady,
+			conditionType: cov1.ClusterReady,
 			status:        corev1.ConditionFalse,
 			reason:        "reason",
 			message:       "message",
-			expectedConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionFalse, "reason", "message", metav1.Now(), metav1.Now()),
+			expectedConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionFalse, "reason", "message", metav1.Now(), metav1.Now()),
 			},
 			expectedOldReason:  "old reason",
 			expectedOldMessage: "old message",
 		},
 		{
 			name: "condition changed due to update check",
-			existingConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
+			existingConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "old reason", "old message", metav1.Time{}, metav1.Time{}),
 			},
-			conditionType:   clusteroperator.ClusterReady,
+			conditionType:   cov1.ClusterReady,
 			status:          corev1.ConditionTrue,
 			reason:          "reason",
 			message:         "message",
 			updateCondition: true,
-			expectedConditions: []clusteroperator.ClusterCondition{
-				newClusterCondition(clusteroperator.ClusterReady, corev1.ConditionTrue, "reason", "message", metav1.Time{}, metav1.Now()),
+			expectedConditions: []cov1.ClusterCondition{
+				newClusterCondition(cov1.ClusterReady, corev1.ConditionTrue, "reason", "message", metav1.Time{}, metav1.Now()),
 			},
 			expectedOldReason:  "old reason",
 			expectedOldMessage: "old message",
@@ -318,67 +318,67 @@ func TestSetClusterCondition(t *testing.T) {
 func TestFindClusterCondition(t *testing.T) {
 	cases := []struct {
 		name                   string
-		conditions             []clusteroperator.ClusterCondition
-		conditionType          clusteroperator.ClusterConditionType
+		conditions             []cov1.ClusterCondition
+		conditionType          cov1.ClusterConditionType
 		expectedConditionIndex int
 	}{
 		{
 			name:                   "no conditions",
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: -1,
 		},
 		{
 			name: "only condition",
-			conditions: []clusteroperator.ClusterCondition{
-				{Type: clusteroperator.ClusterReady},
+			conditions: []cov1.ClusterCondition{
+				{Type: cov1.ClusterReady},
 			},
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: 0,
 		},
 		{
 			name: "first condition",
-			conditions: []clusteroperator.ClusterCondition{
-				{Type: clusteroperator.ClusterReady},
-				{Type: clusteroperator.ClusterInfraProvisioning},
+			conditions: []cov1.ClusterCondition{
+				{Type: cov1.ClusterReady},
+				{Type: cov1.ClusterInfraProvisioning},
 			},
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: 0,
 		},
 		{
 			name: "last condition",
-			conditions: []clusteroperator.ClusterCondition{
-				{Type: clusteroperator.ClusterInfraProvisioning},
-				{Type: clusteroperator.ClusterReady},
+			conditions: []cov1.ClusterCondition{
+				{Type: cov1.ClusterInfraProvisioning},
+				{Type: cov1.ClusterReady},
 			},
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: 1,
 		},
 		{
 			name: "middle condition",
-			conditions: []clusteroperator.ClusterCondition{
-				{Type: clusteroperator.ClusterInfraProvisioning},
-				{Type: clusteroperator.ClusterReady},
-				{Type: clusteroperator.ClusterInfraProvisioned},
+			conditions: []cov1.ClusterCondition{
+				{Type: cov1.ClusterInfraProvisioning},
+				{Type: cov1.ClusterReady},
+				{Type: cov1.ClusterInfraProvisioned},
 			},
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: 1,
 		},
 		{
 			name: "single non-matching condition",
-			conditions: []clusteroperator.ClusterCondition{
-				{Type: clusteroperator.ClusterInfraProvisioning},
+			conditions: []cov1.ClusterCondition{
+				{Type: cov1.ClusterInfraProvisioning},
 			},
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: -1,
 		},
 		{
 			name: "multiple non-matching conditions",
-			conditions: []clusteroperator.ClusterCondition{
-				{Type: clusteroperator.ClusterInfraProvisioning},
-				{Type: clusteroperator.ClusterInfraProvisioned},
-				{Type: clusteroperator.ClusterInfraProvisioningFailed},
+			conditions: []cov1.ClusterCondition{
+				{Type: cov1.ClusterInfraProvisioning},
+				{Type: cov1.ClusterInfraProvisioned},
+				{Type: cov1.ClusterInfraProvisioningFailed},
 			},
-			conditionType:          clusteroperator.ClusterReady,
+			conditionType:          cov1.ClusterReady,
 			expectedConditionIndex: -1,
 		},
 	}
@@ -638,7 +638,7 @@ kind: Machine
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cluster := &clusterapi.Cluster{}
+			cluster := &capiv1.Cluster{}
 			if tc.providerConfig != "" {
 				cluster.Spec.ProviderConfig.Value = &runtime.RawExtension{
 					Raw: []byte(tc.providerConfig),
@@ -690,7 +690,7 @@ kind: Machine
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cluster := &clusterapi.Cluster{}
+			cluster := &capiv1.Cluster{}
 			if tc.providerStatus != "" {
 				cluster.Status.ProviderStatus = &runtime.RawExtension{
 					Raw: []byte(tc.providerStatus),
@@ -714,7 +714,7 @@ kind: Machine
 }
 
 func TestClusterAPIProviderStatusFromClusterStatus(t *testing.T) {
-	clusterStatus := &clusteroperator.ClusterProviderStatus{
+	clusterStatus := &cov1.ClusterProviderStatus{
 		ControlPlaneInstalled:    true,
 		ProvisionedJobGeneration: 5,
 	}
@@ -737,8 +737,8 @@ func TestClusterAPIProviderStatusFromClusterStatus(t *testing.T) {
 func TestGetImage(t *testing.T) {
 	cases := []struct {
 		name             string
-		clusterVersion   *clusteroperator.ClusterVersion
-		clusterSpec      *clusteroperator.ClusterDeploymentSpec
+		clusterVersion   *cov1.ClusterVersion
+		clusterSpec      *cov1.ClusterDeploymentSpec
 		expectedErrorMsg string
 	}{
 		{
@@ -749,7 +749,7 @@ func TestGetImage(t *testing.T) {
 		{
 			name:           "cluster has no AWS hardware",
 			clusterVersion: newClusterVersion("origin-v3-10"),
-			clusterSpec: func() *clusteroperator.ClusterDeploymentSpec {
+			clusterSpec: func() *cov1.ClusterDeploymentSpec {
 				cs := newClusterSpec(testRegion, defaultInstanceType)
 				cs.Hardware.AWS = nil
 				return cs
@@ -758,7 +758,7 @@ func TestGetImage(t *testing.T) {
 		},
 		{
 			name: "cluster version has no AWS images",
-			clusterVersion: func() *clusteroperator.ClusterVersion {
+			clusterVersion: func() *cov1.ClusterVersion {
 				cv := newClusterVersion("origin-v3-10")
 				cv.Spec.VMImages.AWSImages = nil
 				return cv
@@ -769,7 +769,7 @@ func TestGetImage(t *testing.T) {
 		{
 			name:           "no matching region",
 			clusterVersion: newClusterVersion("origin-v3-10"),
-			clusterSpec: func() *clusteroperator.ClusterDeploymentSpec {
+			clusterSpec: func() *cov1.ClusterDeploymentSpec {
 				cs := newClusterSpec(testRegion, defaultInstanceType)
 				cs.Hardware.AWS.Region = "us-west-notreal"
 				return cs
@@ -791,35 +791,35 @@ func TestGetImage(t *testing.T) {
 	}
 }
 
-func newClusterSpec(region, instanceType string) *clusteroperator.ClusterDeploymentSpec {
-	return &clusteroperator.ClusterDeploymentSpec{
-		Hardware: clusteroperator.ClusterHardwareSpec{
-			AWS: &clusteroperator.AWSClusterSpec{
+func newClusterSpec(region, instanceType string) *cov1.ClusterDeploymentSpec {
+	return &cov1.ClusterDeploymentSpec{
+		Hardware: cov1.ClusterHardwareSpec{
+			AWS: &cov1.AWSClusterSpec{
 				Region: testRegion,
 			},
 		},
-		DefaultHardwareSpec: &clusteroperator.MachineSetHardwareSpec{
-			AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+		DefaultHardwareSpec: &cov1.MachineSetHardwareSpec{
+			AWS: &cov1.MachineSetAWSHardwareSpec{
 				InstanceType: instanceType,
 			},
 		},
 	}
 }
 
-func newClusterVersion(name string) *clusteroperator.ClusterVersion {
-	cv := &clusteroperator.ClusterVersion{
+func newClusterVersion(name string) *cov1.ClusterVersion {
+	cv := &cov1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "testuid",
 			Name:      name,
 			Namespace: "testns",
 		},
-		Spec: clusteroperator.ClusterVersionSpec{
-			Images: clusteroperator.ClusterVersionImages{
+		Spec: cov1.ClusterVersionSpec{
+			Images: cov1.ClusterVersionImages{
 				ImageFormat: "openshift/origin-${component}:${version}",
 			},
-			VMImages: clusteroperator.VMImages{
-				AWSImages: &clusteroperator.AWSVMImages{
-					RegionAMIs: []clusteroperator.AWSRegionAMIs{
+			VMImages: cov1.VMImages{
+				AWSImages: &cov1.AWSVMImages{
+					RegionAMIs: []cov1.AWSRegionAMIs{
 						{
 							Region: testRegion,
 							AMI:    testAMI,
@@ -832,21 +832,21 @@ func newClusterVersion(name string) *clusteroperator.ClusterVersion {
 	return cv
 }
 
-func newMachineSpec(msSpec *clusteroperator.MachineSetSpec) clusterapi.MachineSpec {
-	ms := clusterapi.MachineSpec{}
+func newMachineSpec(msSpec *cov1.MachineSetSpec) capiv1.MachineSpec {
+	ms := capiv1.MachineSpec{}
 	providerConfig, _ := MachineProviderConfigFromMachineSetSpec(msSpec)
 	ms.ProviderConfig.Value = providerConfig
 	return ms
 }
 
-func newMachineSetSpec(instanceType, vmImage string) *clusteroperator.MachineSetSpec {
-	msSpec := &clusteroperator.MachineSetSpec{
-		VMImage: clusteroperator.VMImage{
+func newMachineSetSpec(instanceType, vmImage string) *cov1.MachineSetSpec {
+	msSpec := &cov1.MachineSetSpec{
+		VMImage: cov1.VMImage{
 			AWSImage: &vmImage,
 		},
 	}
-	msSpec.Hardware = &clusteroperator.MachineSetHardwareSpec{
-		AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+	msSpec.Hardware = &cov1.MachineSetHardwareSpec{
+		AWS: &cov1.MachineSetAWSHardwareSpec{
 			InstanceType: instanceType,
 		},
 	}
@@ -857,18 +857,18 @@ func newMachineSetSpec(instanceType, vmImage string) *clusteroperator.MachineSet
 // machine set
 func TestApplyDefaultMachineSetHardwareSpec(t *testing.T) {
 
-	awsSpec := func(amiName, instanceType string) *clusteroperator.MachineSetHardwareSpec {
-		return &clusteroperator.MachineSetHardwareSpec{
-			AWS: &clusteroperator.MachineSetAWSHardwareSpec{
+	awsSpec := func(amiName, instanceType string) *cov1.MachineSetHardwareSpec {
+		return &cov1.MachineSetHardwareSpec{
+			AWS: &cov1.MachineSetAWSHardwareSpec{
 				InstanceType: instanceType,
 			},
 		}
 	}
 	cases := []struct {
 		name        string
-		defaultSpec *clusteroperator.MachineSetHardwareSpec
-		specific    *clusteroperator.MachineSetHardwareSpec
-		expected    *clusteroperator.MachineSetHardwareSpec
+		defaultSpec *cov1.MachineSetHardwareSpec
+		specific    *cov1.MachineSetHardwareSpec
+		expected    *cov1.MachineSetHardwareSpec
 	}{
 		{
 			name:        "no default",
@@ -879,7 +879,7 @@ func TestApplyDefaultMachineSetHardwareSpec(t *testing.T) {
 		{
 			name:        "only default",
 			defaultSpec: awsSpec("base-ami", "small-instance"),
-			specific:    &clusteroperator.MachineSetHardwareSpec{},
+			specific:    &cov1.MachineSetHardwareSpec{},
 			expected:    awsSpec("base-ami", "small-instance"),
 		},
 		{

--- a/pkg/controller/deployclusterapi/deployclusterapi_controller.go
+++ b/pkg/controller/deployclusterapi/deployclusterapi_controller.go
@@ -23,11 +23,11 @@ import (
 	batchinformers "k8s.io/client-go/informers/batch/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 
-	clustop "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clustopclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
-	"github.com/openshift/cluster-operator/pkg/controller"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	coclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
 	clusterinstallcontroller "github.com/openshift/cluster-operator/pkg/controller/clusterinstall"
-	capi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	capiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 	capiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions/cluster/v1alpha1"
 )
@@ -48,7 +48,7 @@ func NewController(
 	machineSetInformer capiinformers.MachineSetInformer,
 	jobInformer batchinformers.JobInformer,
 	kubeClient kubeclientset.Interface,
-	clustopClient clustopclientset.Interface,
+	clustopClient coclientset.Interface,
 	capiClient capiclientset.Interface,
 ) *clusterinstallcontroller.Controller {
 	return clusterinstallcontroller.NewController(
@@ -66,7 +66,7 @@ func NewController(
 
 type installStrategy struct{}
 
-func (s *installStrategy) ReadyToInstall(cluster *clustop.CombinedCluster, masterMachineSet *capi.MachineSet) bool {
+func (s *installStrategy) ReadyToInstall(cluster *cov1.CombinedCluster, masterMachineSet *capiv1.MachineSet) bool {
 	if !cluster.ClusterProviderStatus.ControlPlaneInstalled {
 		return false
 	}
@@ -78,23 +78,23 @@ func (s *installStrategy) IncludeInfraSizeInAnsibleVars() bool {
 	return false
 }
 
-func (s *installStrategy) OnInstall(succeeded bool, cluster *clustop.CombinedCluster, masterMachineSet *capi.MachineSet, job *batchv1.Job) {
+func (s *installStrategy) OnInstall(succeeded bool, cluster *cov1.CombinedCluster, masterMachineSet *capiv1.MachineSet, job *batchv1.Job) {
 	cluster.ClusterProviderStatus.ClusterAPIInstalled = succeeded
 	cluster.ClusterProviderStatus.ClusterAPIInstalledJobClusterGeneration = cluster.Generation
 	cluster.ClusterProviderStatus.ClusterAPIInstalledJobMachineSetGeneration = masterMachineSet.GetGeneration()
 	cluster.ClusterProviderStatus.ClusterAPIInstalledTime = job.Status.CompletionTime
 }
 
-func (s *installStrategy) ConvertJobSyncConditionType(conditionType controller.JobSyncConditionType) clustop.ClusterConditionType {
+func (s *installStrategy) ConvertJobSyncConditionType(conditionType cocontroller.JobSyncConditionType) cov1.ClusterConditionType {
 	switch conditionType {
-	case controller.JobSyncProcessing:
-		return clustop.ClusterAPIInstalling
-	case controller.JobSyncProcessed:
-		return clustop.ClusterAPIInstalled
-	case controller.JobSyncProcessingFailed:
-		return clustop.ClusterAPIInstallationFailed
+	case cocontroller.JobSyncProcessing:
+		return cov1.ClusterAPIInstalling
+	case cocontroller.JobSyncProcessed:
+		return cov1.ClusterAPIInstalled
+	case cocontroller.JobSyncProcessingFailed:
+		return cov1.ClusterAPIInstallationFailed
 	default:
-		return clustop.ClusterConditionType("")
+		return cov1.ClusterConditionType("")
 	}
 }
 
@@ -102,7 +102,7 @@ func (s *installStrategy) GetReprocessInterval() time.Duration {
 	return configManagementInterval
 }
 
-func (s *installStrategy) GetLastJobSuccess(cluster *clustop.CombinedCluster) *time.Time {
+func (s *installStrategy) GetLastJobSuccess(cluster *cov1.CombinedCluster) *time.Time {
 	if cluster.ClusterProviderStatus.ClusterAPIInstalledTime == nil {
 		return nil
 	}

--- a/pkg/controller/infra/infra_controller_test.go
+++ b/pkg/controller/infra/infra_controller_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	clusteroperatorclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset/fake"
-	"github.com/openshift/cluster-operator/pkg/controller"
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	clusterapiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
 	clusterapiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions"
 
@@ -100,7 +100,7 @@ func (r *fakeAnsibleRunner) RunPlaybook(namespace, clusterName, jobPrefix, playb
 // getKey gets the key for the cluster to use when checking expectations
 // set on a cluster.
 func getKey(cluster metav1.Object, t *testing.T) string {
-	key, err := controller.KeyFunc(cluster)
+	key, err := cocontroller.KeyFunc(cluster)
 	if err != nil {
 		t.Errorf("Unexpected error getting key for Cluster %v: %v", cluster.GetName(), err)
 		return ""
@@ -108,7 +108,7 @@ func getKey(cluster metav1.Object, t *testing.T) string {
 	return key
 }
 
-func newCluster() *clusterapi.Cluster {
+func newCluster() *capiv1.Cluster {
 	encodedClusterProviderConfigSpec := `
 apiVersion: "clusteroperator.openshift.io/v1alpha1"
 kind: "AWSClusterProviderConfig"
@@ -117,14 +117,14 @@ machineSets:
   infra: true
   size: 3
 `
-	cluster := &clusterapi.Cluster{
+	cluster := &capiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       testClusterUUID,
 			Name:      testClusterName,
 			Namespace: testNamespace,
 		},
-		Spec: clusterapi.ClusterSpec{
-			ProviderConfig: clusterapi.ProviderConfig{
+		Spec: capiv1.ClusterSpec{
+			ProviderConfig: capiv1.ProviderConfig{
 				Value: &runtime.RawExtension{
 					Raw: []byte(encodedClusterProviderConfigSpec),
 				},

--- a/pkg/controller/jobcontrol.go
+++ b/pkg/controller/jobcontrol.go
@@ -36,7 +36,7 @@ import (
 	batchlisters "k8s.io/client-go/listers/batch/v1"
 	"k8s.io/client-go/tools/cache"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 )
 
 //go:generate mockgen -source=./jobcontrol.go -destination=./mockjobcontrol_generated_test.go -package=controller
@@ -436,7 +436,7 @@ func (c *jobControl) createJob(ownerKey string, owner metav1.Object, extraJobIde
 	if job.Annotations == nil {
 		job.Annotations = map[string]string{}
 	}
-	job.Annotations[clusteroperator.OwnerGenerationAnnotation] = fmt.Sprintf("%d", owner.GetGeneration())
+	job.Annotations[cov1.OwnerGenerationAnnotation] = fmt.Sprintf("%d", owner.GetGeneration())
 
 	cleanUpConfigMap := true
 	if configMap != nil {
@@ -541,7 +541,7 @@ func jobOwnerGeneration(job *kbatch.Job) int64 {
 	if job.Annotations == nil {
 		return 0
 	}
-	generationStr, ok := job.Annotations[clusteroperator.OwnerGenerationAnnotation]
+	generationStr, ok := job.Annotations[cov1.OwnerGenerationAnnotation]
 	if !ok {
 		return 0
 	}

--- a/pkg/controller/jobcontrol_test.go
+++ b/pkg/controller/jobcontrol_test.go
@@ -38,7 +38,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	"github.com/openshift/cluster-operator/test"
 )
 
@@ -141,7 +141,7 @@ func newTestControlledJob(namePrefix, nameEnding string, owner metav1.Object, ow
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            namePrefix + nameEnding,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(owner, ownerKind)},
-			Annotations:     map[string]string{clusteroperator.OwnerGenerationAnnotation: strconv.FormatInt(generation, 10)},
+			Annotations:     map[string]string{cov1.OwnerGenerationAnnotation: strconv.FormatInt(generation, 10)},
 		},
 	}
 }
@@ -152,7 +152,7 @@ func newTestControlledSuccessfulJob(namePrefix, nameEnding string, owner metav1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            namePrefix + nameEnding,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(owner, ownerKind)},
-			Annotations:     map[string]string{clusteroperator.OwnerGenerationAnnotation: strconv.FormatInt(generation, 10)},
+			Annotations:     map[string]string{cov1.OwnerGenerationAnnotation: strconv.FormatInt(generation, 10)},
 		},
 		Status: kbatch.JobStatus{
 			CompletionTime: &tempTime,

--- a/pkg/controller/nodeconfig/nodeconfig_controller_test.go
+++ b/pkg/controller/nodeconfig/nodeconfig_controller_test.go
@@ -21,8 +21,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	co "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	capi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -95,18 +95,18 @@ func TestStrategyReadyToInstall(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			strat := &installStrategy{}
 
-			cluster := &co.CombinedCluster{
+			cluster := &cov1.CombinedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: tc.clusterGeneration,
 				},
-				ClusterProviderStatus: &co.ClusterProviderStatus{
+				ClusterProviderStatus: &cov1.ClusterProviderStatus{
 					ControlPlaneInstalled:                      tc.controlPlaneInstalled,
 					NodeConfigInstalledJobClusterGeneration:    tc.nodeConfigInstalledClusterGeneration,
 					NodeConfigInstalledJobMachineSetGeneration: tc.nodeConfigInstalledMachineSetGeneration,
 				},
 			}
 
-			ms := &capi.MachineSet{
+			ms := &capiv1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: tc.machineSetGeneration,
 				},

--- a/pkg/controller/nodelink/node_link_controller_test.go
+++ b/pkg/controller/nodelink/node_link_controller_test.go
@@ -23,8 +23,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	clustopv1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	"github.com/openshift/cluster-operator/pkg/controller"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
 
 	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	capiclientfake "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
@@ -259,35 +259,35 @@ func TestNodeLinker(t *testing.T) {
 
 func testMachine(generation int64, name, internalIP string, labels map[string]string, taints []corev1.Taint) *capiv1.Machine {
 	testAMI := testImage
-	msSpec := clustopv1.MachineSetSpec{
-		MachineSetConfig: clustopv1.MachineSetConfig{
+	msSpec := cov1.MachineSetSpec{
+		MachineSetConfig: cov1.MachineSetConfig{
 			Infra:    false,
 			Size:     3,
-			NodeType: clustopv1.NodeTypeCompute,
-			Hardware: &clustopv1.MachineSetHardwareSpec{
-				AWS: &clustopv1.MachineSetAWSHardwareSpec{
+			NodeType: cov1.NodeTypeCompute,
+			Hardware: &cov1.MachineSetHardwareSpec{
+				AWS: &cov1.MachineSetAWSHardwareSpec{
 					InstanceType: "t2.micro",
 				},
 			},
 		},
-		ClusterHardware: clustopv1.ClusterHardwareSpec{
-			AWS: &clustopv1.AWSClusterSpec{
+		ClusterHardware: cov1.ClusterHardwareSpec{
+			AWS: &cov1.AWSClusterSpec{
 				Region: testRegion,
 			},
 		},
-		VMImage: clustopv1.VMImage{
+		VMImage: cov1.VMImage{
 			AWSImage: &testAMI,
 		},
 	}
-	rawProviderConfig, _ := controller.MachineProviderConfigFromMachineSetSpec(&msSpec)
+	rawProviderConfig, _ := cocontroller.MachineProviderConfigFromMachineSetSpec(&msSpec)
 	machine := &capiv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
 			Namespace:  kubeClusterNamespace,
 			Generation: generation,
 			Labels: map[string]string{
-				clustopv1.ClusterNameLabel:       testClusterID,
-				clustopv1.ClusterDeploymentLabel: testClusterDeploymentName,
+				cov1.ClusterNameLabel:       testClusterID,
+				cov1.ClusterDeploymentLabel: testClusterDeploymentName,
 			},
 		},
 		Spec: capiv1.MachineSpec{
@@ -337,41 +337,41 @@ func testNode(internalIP, machineAnnotation string, labels map[string]string, ta
 }
 
 // testClusterDeployment creates a new test ClusterDeployment
-func testClusterDeployment() *clustopv1.ClusterDeployment {
-	clusterDeployment := &clustopv1.ClusterDeployment{
+func testClusterDeployment() *cov1.ClusterDeployment {
+	clusterDeployment := &cov1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       testClusterDeploymentUUID,
 			Name:      testClusterDeploymentName,
 			Namespace: testNamespace,
 		},
-		Spec: clustopv1.ClusterDeploymentSpec{
+		Spec: cov1.ClusterDeploymentSpec{
 			ClusterName: testClusterID,
-			MachineSets: []clustopv1.ClusterMachineSet{
+			MachineSets: []cov1.ClusterMachineSet{
 				{
 					ShortName: "",
-					MachineSetConfig: clustopv1.MachineSetConfig{
+					MachineSetConfig: cov1.MachineSetConfig{
 						Infra:    true,
 						Size:     1,
-						NodeType: clustopv1.NodeTypeMaster,
+						NodeType: cov1.NodeTypeMaster,
 					},
 				},
 				{
 					ShortName: "compute",
-					MachineSetConfig: clustopv1.MachineSetConfig{
+					MachineSetConfig: cov1.MachineSetConfig{
 						Infra:    false,
 						Size:     1,
-						NodeType: clustopv1.NodeTypeCompute,
+						NodeType: cov1.NodeTypeCompute,
 					},
 				},
 			},
-			Hardware: clustopv1.ClusterHardwareSpec{
-				AWS: &clustopv1.AWSClusterSpec{
+			Hardware: cov1.ClusterHardwareSpec{
+				AWS: &cov1.AWSClusterSpec{
 					SSHUser:     "clusteroperator",
 					Region:      testRegion,
 					KeyPairName: "libra",
 				},
 			},
-			ClusterVersionRef: clustopv1.ClusterVersionReference{
+			ClusterVersionRef: cov1.ClusterVersionReference{
 				Name:      testClusterVerName,
 				Namespace: testClusterVerNS,
 			},
@@ -382,26 +382,26 @@ func testClusterDeployment() *clustopv1.ClusterDeployment {
 
 func testCluster(t *testing.T) *capiv1.Cluster {
 	clusterDeployment := testClusterDeployment()
-	cluster, err := controller.BuildCluster(clusterDeployment, testClusterVersion().Spec)
+	cluster, err := cocontroller.BuildCluster(clusterDeployment, testClusterVersion().Spec)
 	assert.NoError(t, err)
 	return cluster
 }
 
 // testClusterVersion will create a ClusterVersion resource.
-func testClusterVersion() *clustopv1.ClusterVersion {
-	cv := &clustopv1.ClusterVersion{
+func testClusterVersion() *cov1.ClusterVersion {
+	cv := &cov1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       testClusterVerUID,
 			Name:      testClusterVerName,
 			Namespace: testClusterVerNS,
 		},
-		Spec: clustopv1.ClusterVersionSpec{
-			Images: clustopv1.ClusterVersionImages{
+		Spec: cov1.ClusterVersionSpec{
+			Images: cov1.ClusterVersionImages{
 				ImageFormat: "openshift/origin-${component}:${version}",
 			},
-			VMImages: clustopv1.VMImages{
-				AWSImages: &clustopv1.AWSVMImages{
-					RegionAMIs: []clustopv1.AWSRegionAMIs{
+			VMImages: cov1.VMImages{
+				AWSImages: &cov1.AWSVMImages{
+					RegionAMIs: []cov1.AWSRegionAMIs{
 						{
 							Region: testRegion,
 							AMI:    "computeAMI_ID",

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	"github.com/openshift/cluster-operator/pkg/controller"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +33,7 @@ import (
 	clusteropclientfake "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset/fake"
 	clusteropinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions"
 
-	clusterapiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	clusterapiclient "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 	clusterapiclientfake "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
 	clusterapiinformers "sigs.k8s.io/cluster-api/pkg/client/informers_generated/externalversions"
@@ -109,7 +109,7 @@ func TestClusterSyncing(t *testing.T) {
 		unexpectedActions      []expectedAction
 		expectedClustopActions []expectedAction
 		clusterDeployment      *cov1.ClusterDeployment
-		remoteClusters         func(*testing.T, *cov1.ClusterDeployment) []clusterapiv1.Cluster
+		remoteClusters         func(*testing.T, *cov1.ClusterDeployment) []capiv1.Cluster
 	}{
 		{
 			name: "no-op cluster already exists",
@@ -117,18 +117,18 @@ func TestClusterSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "create",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("clusters"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("clusters"),
 				},
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "update",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("clusters"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("clusters"),
 				},
 			},
 			clusterDeployment: newTestClusterDeployment(),
 			controlPlaneReady: true,
-			remoteClusters: func(t *testing.T, clusterDeployment *cov1.ClusterDeployment) []clusterapiv1.Cluster {
-				clusters := []clusterapiv1.Cluster{}
+			remoteClusters: func(t *testing.T, clusterDeployment *cov1.ClusterDeployment) []capiv1.Cluster {
+				clusters := []capiv1.Cluster{}
 				cluster := newCapiCluster(t, clusterDeployment, true)
 				cluster.Namespace = remoteClusterAPINamespace
 
@@ -142,7 +142,7 @@ func TestClusterSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "create",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("clusters"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("clusters"),
 				},
 			},
 			clusterDeployment: newTestClusterDeployment(),
@@ -154,14 +154,14 @@ func TestClusterSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "update",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("clusters"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("clusters"),
 				},
 			},
 			clusterDeployment: newTestClusterDeployment(),
 			controlPlaneReady: true,
-			remoteClusters: func(t *testing.T, clusterDeployment *cov1.ClusterDeployment) []clusterapiv1.Cluster {
+			remoteClusters: func(t *testing.T, clusterDeployment *cov1.ClusterDeployment) []capiv1.Cluster {
 
-				clusterList := []clusterapiv1.Cluster{}
+				clusterList := []capiv1.Cluster{}
 				cluster := newCapiCluster(t, clusterDeployment, true)
 				cluster.Namespace = remoteClusterAPINamespace
 
@@ -250,8 +250,8 @@ func TestMachineSetSyncing(t *testing.T) {
 		expectedActions   []expectedAction
 		unexpectedActions []expectedAction
 		clusterDeployment *cov1.ClusterDeployment
-		remoteMachineSets []clusterapiv1.MachineSet
-		remoteClusters    []clusterapiv1.Cluster
+		remoteMachineSets []capiv1.MachineSet
+		remoteClusters    []capiv1.Cluster
 	}{
 		{
 			name: "no-op when control plane not yet ready",
@@ -259,7 +259,7 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "create",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 			clusterDeployment: newTestClusterDeployment(),
@@ -271,7 +271,7 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "create",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 			clusterDeployment: newTestClusterWithCompute(),
@@ -283,18 +283,18 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "create",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 			clusterDeployment: newTestClusterWithCompute(),
 			controlPlaneReady: true,
-			remoteMachineSets: []clusterapiv1.MachineSet{
+			remoteMachineSets: []capiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testClusterName + "-compute",
 						Namespace: remoteClusterAPINamespace,
 					},
-					Spec: clusterapiv1.MachineSetSpec{
+					Spec: capiv1.MachineSetSpec{
 						Replicas: func() *int32 { x := int32(1); return &x }(),
 					},
 				},
@@ -306,18 +306,18 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "update",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 			clusterDeployment: newTestClusterWithCompute(),
 			controlPlaneReady: true,
-			remoteMachineSets: []clusterapiv1.MachineSet{
+			remoteMachineSets: []capiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testClusterName + "-compute",
 						Namespace: remoteClusterAPINamespace,
 					},
-					Spec: clusterapiv1.MachineSetSpec{
+					Spec: capiv1.MachineSetSpec{
 						Replicas: func() *int32 { x := int32(2); return &x }(),
 					},
 				},
@@ -329,7 +329,7 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "create",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 			clusterDeployment: func() *cov1.ClusterDeployment {
@@ -338,13 +338,13 @@ func TestMachineSetSyncing(t *testing.T) {
 				return cluster
 			}(),
 			controlPlaneReady: true,
-			remoteMachineSets: []clusterapiv1.MachineSet{
+			remoteMachineSets: []capiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "compute",
 						Namespace: remoteClusterAPINamespace,
 					},
-					Spec: clusterapiv1.MachineSetSpec{
+					Spec: capiv1.MachineSetSpec{
 						Replicas: func() *int32 { x := int32(2); return &x }(),
 					},
 				},
@@ -356,12 +356,12 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "delete",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 			clusterDeployment: newTestClusterWithCompute(),
 			controlPlaneReady: true,
-			remoteMachineSets: []clusterapiv1.MachineSet{
+			remoteMachineSets: []capiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testClusterName + "-compute",
@@ -371,7 +371,7 @@ func TestMachineSetSyncing(t *testing.T) {
 							"clusteroperator.openshift.io/machineset": testClusterName + "-compute",
 						},
 					},
-					Spec: clusterapiv1.MachineSetSpec{
+					Spec: capiv1.MachineSetSpec{
 						Replicas: func() *int32 { x := int32(1); return &x }(),
 					},
 				},
@@ -384,7 +384,7 @@ func TestMachineSetSyncing(t *testing.T) {
 							"clusteroperator.openshift.io/machineset": testClusterName + "-compute2",
 						},
 					},
-					Spec: clusterapiv1.MachineSetSpec{
+					Spec: capiv1.MachineSetSpec{
 						Replicas: func() *int32 { x := int32(1); return &x }(),
 					},
 				},
@@ -394,7 +394,7 @@ func TestMachineSetSyncing(t *testing.T) {
 			name:              "delete remote machinesets",
 			clusterDeployment: newDeletedTestClusterWithFinalizer(),
 			controlPlaneReady: true,
-			remoteMachineSets: []clusterapiv1.MachineSet{
+			remoteMachineSets: []capiv1.MachineSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      testClusterName + "-compute",
@@ -404,7 +404,7 @@ func TestMachineSetSyncing(t *testing.T) {
 							"clusteroperator.openshift.io/machineset": testClusterName + "-compute",
 						},
 					},
-					Spec: clusterapiv1.MachineSetSpec{
+					Spec: capiv1.MachineSetSpec{
 						Replicas: func() *int32 { x := int32(1); return &x }(),
 					},
 				},
@@ -413,7 +413,7 @@ func TestMachineSetSyncing(t *testing.T) {
 				{
 					namespace: remoteClusterAPINamespace,
 					verb:      "delete-collection",
-					gvr:       clusterapiv1.SchemeGroupVersion.WithResource("machinesets"),
+					gvr:       capiv1.SchemeGroupVersion.WithResource("machinesets"),
 				},
 			},
 		},
@@ -527,7 +527,7 @@ type expectedAction struct {
 }
 
 func getKey(clusterDeployment *cov1.ClusterDeployment, t *testing.T) string {
-	key, err := controller.KeyFunc(clusterDeployment)
+	key, err := cocontroller.KeyFunc(clusterDeployment)
 	if err != nil {
 		t.Errorf("Unexpected error getting key for clusterdeployment %v: %v", clusterDeployment.Name, err)
 		return ""
@@ -535,19 +535,19 @@ func getKey(clusterDeployment *cov1.ClusterDeployment, t *testing.T) string {
 	return key
 }
 
-func newCapiCluster(t *testing.T, clusterDeployment *cov1.ClusterDeployment, controlPlaneReady bool) clusterapiv1.Cluster {
-	cluster := clusterapiv1.Cluster{
+func newCapiCluster(t *testing.T, clusterDeployment *cov1.ClusterDeployment, controlPlaneReady bool) capiv1.Cluster {
+	cluster := capiv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterDeployment.Spec.ClusterName,
 			Namespace: clusterDeployment.Namespace,
 		},
-		Spec: clusterapiv1.ClusterSpec{
-			ClusterNetwork: clusterapiv1.ClusterNetworkingConfig{
-				Services: clusterapiv1.NetworkRanges{
+		Spec: capiv1.ClusterSpec{
+			ClusterNetwork: capiv1.ClusterNetworkingConfig{
+				Services: capiv1.NetworkRanges{
 					CIDRBlocks: []string{"172.30.0.0/16"},
 				},
 				ServiceDomain: "svc.clsuter.local",
-				Pods: clusterapiv1.NetworkRanges{
+				Pods: capiv1.NetworkRanges{
 					CIDRBlocks: []string{"10.128.0.0/14"},
 				},
 			},
@@ -558,14 +558,14 @@ func newCapiCluster(t *testing.T, clusterDeployment *cov1.ClusterDeployment, con
 		ClusterAPIInstalled:   controlPlaneReady,
 		ControlPlaneInstalled: controlPlaneReady,
 	}
-	providerStatus, err := controller.EncodeClusterProviderStatus(status)
+	providerStatus, err := cocontroller.EncodeClusterProviderStatus(status)
 	if err != nil {
 		t.Fatalf("error getting provider status from clusterdeployment: %v", err)
 	}
 	cluster.Status.ProviderStatus = providerStatus
 
 	cv := newClusterVer(testClusterVerNS, testClusterVerName, testClusterVerUID)
-	providerConfig, err := controller.BuildAWSClusterProviderConfig(&clusterDeployment.Spec, cv.Spec)
+	providerConfig, err := cocontroller.BuildAWSClusterProviderConfig(&clusterDeployment.Spec, cv.Spec)
 	if err != nil {
 		t.Fatalf("error getting provider config from clusterdeployment: %v", err)
 	}
@@ -574,14 +574,14 @@ func newCapiCluster(t *testing.T, clusterDeployment *cov1.ClusterDeployment, con
 	return cluster
 }
 
-func testClusterAPISpec() clusterapiv1.ClusterSpec {
-	clusterSpec := clusterapiv1.ClusterSpec{
-		ClusterNetwork: clusterapiv1.ClusterNetworkingConfig{
-			Services: clusterapiv1.NetworkRanges{
+func testClusterAPISpec() capiv1.ClusterSpec {
+	clusterSpec := capiv1.ClusterSpec{
+		ClusterNetwork: capiv1.ClusterNetworkingConfig{
+			Services: capiv1.NetworkRanges{
 				CIDRBlocks: []string{"172.30.0.0/16"},
 			},
 			ServiceDomain: "svc.clsuter.local",
-			Pods: clusterapiv1.NetworkRanges{
+			Pods: capiv1.NetworkRanges{
 				CIDRBlocks: []string{"10.128.0.0/14"},
 			},
 		},

--- a/pkg/controller/route53hostedzone/route53hostedzone_controller_test.go
+++ b/pkg/controller/route53hostedzone/route53hostedzone_controller_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golang/mock/gomock"
 	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clustopaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+	coaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -135,7 +135,7 @@ func TestSyncHandler(t *testing.T) {
 
 			if tc.dnsZone != nil {
 				setFakeDNSZoneInKube(ctx.mocks, tc.dnsZone)
-				ctx.controller.awsClientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (clustopaws.Client, error) {
+				ctx.controller.awsClientBuilder = func(kubeClient kubernetes.Interface, secretName, namespace, region string) (coaws.Client, error) {
 					return ctx.mocks.mockAWSClient, tc.awsClientBuilderError
 				}
 

--- a/pkg/controller/route53hostedzone/test_helpers.go
+++ b/pkg/controller/route53hostedzone/test_helpers.go
@@ -24,11 +24,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golang/mock/gomock"
 	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clusteroperatorclient "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	coclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
 	clusteropclientfake "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset/fake"
 	clusteroperatorinformerfactories "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions"
 	clusteropinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions"
-	v1alpha1clusteroperatorinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions/clusteroperator/v1alpha1"
+	coinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions/clusteroperator/v1alpha1"
 	mockaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws/mock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -111,9 +111,9 @@ var (
 
 type mocks struct {
 	fakeKubeClient         kubeclientset.Interface
-	fakeClusteropClient    clusteroperatorclient.Interface
+	fakeClusteropClient    coclientset.Interface
 	fakeClusteropInformers clusteroperatorinformerfactories.SharedInformerFactory
-	fakeDNSZonesInformer   v1alpha1clusteroperatorinformers.DNSZoneInformer
+	fakeDNSZonesInformer   coinformers.DNSZoneInformer
 	mockCtrl               *gomock.Controller
 	mockAWSClient          *mockaws.MockClient
 }

--- a/pkg/controller/route53hostedzone/zonereconciler.go
+++ b/pkg/controller/route53hostedzone/zonereconciler.go
@@ -23,15 +23,15 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/route53"
 	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clustopaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
+	coaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 
 	"github.com/aws/aws-sdk-go/aws"
-	controller "github.com/openshift/cluster-operator/pkg/controller"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
 
-	coclient "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	coclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
 )
 
 // ZoneReconciler manages getting the desired state, getting the current state and reconciling the two.
@@ -45,19 +45,19 @@ type ZoneReconciler struct {
 	kubeClient kubeclientset.Interface
 
 	// clusteroperatorClient is a kubernetes client to access cluster operator related objects.
-	clusteroperatorClient coclient.Interface
+	clusteroperatorClient coclientset.Interface
 
 	// clusterOperatorAwsClient is a utility for making it easy for cluster operator controllers to interface with AWS
-	clusterOperatorAwsClient clustopaws.Client
+	clusterOperatorAwsClient coaws.Client
 }
 
 // NewZoneReconciler creates a new ZoneReconciler object. A new ZoneReconciler is expected to be created for each controller sync.
 func NewZoneReconciler(
 	desiredState *cov1.DNSZone,
 	kubeClient kubeclientset.Interface,
-	clusteroperatorClient coclient.Interface,
+	clusteroperatorClient coclientset.Interface,
 	logger log.FieldLogger,
-	clusterOperatorAwsClient clustopaws.Client,
+	clusterOperatorAwsClient coaws.Client,
 ) (*ZoneReconciler, error) {
 	if desiredState == nil {
 		return nil, fmt.Errorf("ZoneReconciler requires desiredState to be set")
@@ -140,7 +140,7 @@ func (zr *ZoneReconciler) createRoute53HostedZone() error {
 	}
 
 	// Only add a finalizer after a route53 hostedzone was successfully created (nothing to clean up otherwise).
-	controller.AddFinalizer(zr.desiredState, cov1.FinalizerRoute53HostedZone)
+	cocontroller.AddFinalizer(zr.desiredState, cov1.FinalizerRoute53HostedZone)
 
 	zr.addRateLimitingStatusEntries()
 
@@ -163,7 +163,7 @@ func (zr *ZoneReconciler) deleteRoute53HostedZone(currentState *route53.HostedZo
 	}
 
 	// Only reomve the finalizer after the route53 hostedzone was successfully deleted (still need to clean up otherwise).
-	controller.DeleteFinalizer(zr.desiredState, cov1.FinalizerRoute53HostedZone)
+	cocontroller.DeleteFinalizer(zr.desiredState, cov1.FinalizerRoute53HostedZone)
 
 	zr.addRateLimitingStatusEntries()
 

--- a/pkg/hyperkube/hyperkube.go
+++ b/pkg/hyperkube/hyperkube.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/spf13/pflag"
 
-	utiltemplate "github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/template"
+	cotemplateutil "github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/template"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
@@ -228,7 +228,7 @@ Servers
 Call '{{.Name}} --make-symlinks' to create symlinks for each server in the local directory.
 Call '{{.Name}} <server> --help' for help on a specific server.
 `
-	utiltemplate.ExecuteTemplate(hk.Out(), tt, hk)
+	cotemplateutil.ExecuteTemplate(hk.Out(), tt, hk)
 }
 
 // MakeSymlinks will create a symlink for each registered hyperkube server in the local directory.

--- a/pkg/hyperkube/server.go
+++ b/pkg/hyperkube/server.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	utiltemplate "github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/template"
+	cotemplateutil "github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/template"
 	"k8s.io/apiserver/pkg/util/flag"
 
 	"github.com/spf13/pflag"
@@ -50,7 +50,7 @@ func (s *Server) Usage() error {
 Available Flags:
 {{.Flags.FlagUsages}}`
 
-	return utiltemplate.ExecuteTemplate(s.hk.Out(), tt, s)
+	return cotemplateutil.ExecuteTemplate(s.hk.Out(), tt, s)
 }
 
 // Name returns the name of the command as derived from the usage line.

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -21,31 +21,29 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	log "github.com/sirupsen/logrus"
 )
 
 // WithMachineSet expands a logger's context to include info about the given machineset.
-func WithMachineSet(logger log.FieldLogger, machineSet *clusterapi.MachineSet) log.FieldLogger {
+func WithMachineSet(logger log.FieldLogger, machineSet *capiv1.MachineSet) log.FieldLogger {
 	return WithGenericObject(logger, "machineset", machineSet)
 }
 
 // WithClusterDeployment expands a logger's context to include info about the given cluster deployment.
-func WithClusterDeployment(logger log.FieldLogger, clusterDeployment *clusteroperator.ClusterDeployment) log.FieldLogger {
+func WithClusterDeployment(logger log.FieldLogger, clusterDeployment *cov1.ClusterDeployment) log.FieldLogger {
 	return WithGenericObject(logger, "clusterdeployment", clusterDeployment)
 }
 
 // WithCluster expands a logger's context to include info about the given cluster.
-func WithCluster(logger log.FieldLogger, cluster *clusterapi.Cluster) log.FieldLogger {
+func WithCluster(logger log.FieldLogger, cluster *capiv1.Cluster) log.FieldLogger {
 	return WithGenericObject(logger, "cluster", cluster)
 }
 
 // WithCombinedCluster expands a logger's context to include info about the given cluster.
-func WithCombinedCluster(logger log.FieldLogger, cluster *clusteroperator.CombinedCluster) log.FieldLogger {
+func WithCombinedCluster(logger log.FieldLogger, cluster *cov1.CombinedCluster) log.FieldLogger {
 	return WithGenericObject(logger, "cluster", cluster)
 }
 
@@ -55,6 +53,6 @@ func WithGenericObject(logger log.FieldLogger, objectType string, obj metav1.Obj
 }
 
 // WithMachine expands a logger's context to include info about the given machine.
-func WithMachine(logger log.FieldLogger, machine *clusterv1.Machine) log.FieldLogger {
+func WithMachine(logger log.FieldLogger, machine *capiv1.Machine) log.FieldLogger {
 	return WithGenericObject(logger, "machine", machine)
 }

--- a/pkg/registry/clusteroperator/clusterdeployment/storage.go
+++ b/pkg/registry/clusteroperator/clusterdeployment/storage.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clusterdeployment
 
 import (
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,9 +31,9 @@ import (
 // Cluster resources
 func NewStorage(opts generic.RESTOptions) (clusters *registry.Store, clustersStatus *StatusREST) {
 	store := registry.Store{
-		NewFunc:                  func() runtime.Object { return &clusteroperator.ClusterDeployment{} },
-		NewListFunc:              func() runtime.Object { return &clusteroperator.ClusterDeploymentList{} },
-		DefaultQualifiedResource: clusteroperator.Resource("clusterdeployments"),
+		NewFunc:                  func() runtime.Object { return &coapi.ClusterDeployment{} },
+		NewListFunc:              func() runtime.Object { return &coapi.ClusterDeploymentList{} },
+		DefaultQualifiedResource: coapi.Resource("clusterdeployments"),
 
 		CreateStrategy:          clusterDeploymentRESTStrategies,
 		UpdateStrategy:          clusterDeploymentRESTStrategies,
@@ -61,7 +61,7 @@ type StatusREST struct {
 
 // New returns a new ClusterDeployment.
 func (r *StatusREST) New() runtime.Object {
-	return &clusteroperator.ClusterDeployment{}
+	return &coapi.ClusterDeployment{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch

--- a/pkg/registry/clusteroperator/clusterdeployment/storage_test.go
+++ b/pkg/registry/clusteroperator/clusterdeployment/storage_test.go
@@ -26,7 +26,7 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 
-	clusteroperatorapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	"github.com/openshift/cluster-operator/pkg/registry/registrytest"
 
 	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -44,26 +44,26 @@ func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServ
 	return clusterStorage, server
 }
 
-func validNewClusterDeployment(name string) *clusteroperatorapi.ClusterDeployment {
-	return &clusteroperatorapi.ClusterDeployment{
+func validNewClusterDeployment(name string) *coapi.ClusterDeployment {
+	return &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: clusteroperatorapi.ClusterDeploymentSpec{
-			MachineSets: []clusteroperatorapi.ClusterMachineSet{
+		Spec: coapi.ClusterDeploymentSpec{
+			MachineSets: []coapi.ClusterMachineSet{
 				{
-					MachineSetConfig: clusteroperatorapi.MachineSetConfig{
-						NodeType: clusteroperatorapi.NodeTypeMaster,
+					MachineSetConfig: coapi.MachineSetConfig{
+						NodeType: coapi.NodeTypeMaster,
 						Infra:    true,
 						Size:     1,
 					},
 				},
 			},
-			ClusterVersionRef: clusteroperatorapi.ClusterVersionReference{
+			ClusterVersionRef: coapi.ClusterVersionReference{
 				Namespace: "openshift-cluster-operator",
 				Name:      "v3-9",
 			},
-			Config: clusteroperatorapi.ClusterConfigSpec{
+			Config: coapi.ClusterConfigSpec{
 				SDNPluginName: "redhat/openshift-ovs-multitenant",
 			},
 			NetworkConfig: capiv1.ClusterNetworkingConfig{
@@ -71,14 +71,14 @@ func validNewClusterDeployment(name string) *clusteroperatorapi.ClusterDeploymen
 				Pods:          capiv1.NetworkRanges{CIDRBlocks: []string{"10.128.0.0/14"}},
 				ServiceDomain: "svc.cluster.local",
 			},
-			Hardware: clusteroperatorapi.ClusterHardwareSpec{
-				AWS: &clusteroperatorapi.AWSClusterSpec{},
+			Hardware: coapi.ClusterHardwareSpec{
+				AWS: &coapi.AWSClusterSpec{},
 			},
 		},
 	}
 }
 
-func validChangedClusterDeployment() *clusteroperatorapi.ClusterDeployment {
+func validChangedClusterDeployment() *coapi.ClusterDeployment {
 	return validNewClusterDeployment("foo")
 }
 
@@ -93,11 +93,11 @@ func TestCreate(t *testing.T) {
 		// valid
 		clusterDeployment,
 		// invalid
-		&clusteroperatorapi.ClusterDeployment{
+		&coapi.ClusterDeployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "*BadName!"},
-			Spec: clusteroperatorapi.ClusterDeploymentSpec{
-				Hardware: clusteroperatorapi.ClusterHardwareSpec{
-					AWS: &clusteroperatorapi.AWSClusterSpec{},
+			Spec: coapi.ClusterDeploymentSpec{
+				Hardware: coapi.ClusterHardwareSpec{
+					AWS: &coapi.AWSClusterSpec{},
 				},
 			},
 		},
@@ -118,12 +118,12 @@ func TestUpdate(t *testing.T) {
 		}(),
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*clusteroperatorapi.ClusterDeployment)
+			object := obj.(*coapi.ClusterDeployment)
 			return object
 		},
 		//invalid update
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*clusteroperatorapi.ClusterDeployment)
+			object := obj.(*coapi.ClusterDeployment)
 			return object
 		},
 	)

--- a/pkg/registry/clusteroperator/clusterdeployment/strategy.go
+++ b/pkg/registry/clusteroperator/clusterdeployment/strategy.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"github.com/golang/glog"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	covalidation "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
 )
 
 // NewScopeStrategy returns a new NamespaceScopedStrategy for clusterdeployments
@@ -70,7 +70,7 @@ var (
 
 // Canonicalize does not transform a clusterdeployment.
 func (clusterDeploymentRESTStrategy) Canonicalize(obj runtime.Object) {
-	_, ok := obj.(*clusteroperator.ClusterDeployment)
+	_, ok := obj.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to create")
 	}
@@ -84,7 +84,7 @@ func (clusterDeploymentRESTStrategy) NamespaceScoped() bool {
 // PrepareForCreate receives a the incoming ClusterDeployment and clears it's
 // Status. Status is not a user settable field.
 func (clusterDeploymentRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
-	clusterDeployment, ok := obj.(*clusteroperator.ClusterDeployment)
+	clusterDeployment, ok := obj.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-cluster object to create")
 	}
@@ -99,13 +99,13 @@ func (clusterDeploymentRESTStrategy) PrepareForCreate(ctx genericapirequest.Cont
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
-	clusterDeployment.Status = clusteroperator.ClusterDeploymentStatus{}
+	clusterDeployment.Status = coapi.ClusterDeploymentStatus{}
 
 	clusterDeployment.Generation = 1
 }
 
 func (clusterDeploymentRESTStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateClusterDeployment(obj.(*clusteroperator.ClusterDeployment))
+	return covalidation.ValidateClusterDeployment(obj.(*coapi.ClusterDeployment))
 }
 
 func (clusterDeploymentRESTStrategy) AllowCreateOnUpdate() bool {
@@ -117,11 +117,11 @@ func (clusterDeploymentRESTStrategy) AllowUnconditionalUpdate() bool {
 }
 
 func (clusterDeploymentRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, old runtime.Object) {
-	newClusterDeployment, ok := new.(*clusteroperator.ClusterDeployment)
+	newClusterDeployment, ok := new.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to update to")
 	}
-	oldClusterDeployment, ok := old.(*clusteroperator.ClusterDeployment)
+	oldClusterDeployment, ok := old.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to update from")
 	}
@@ -137,24 +137,24 @@ func (clusterDeploymentRESTStrategy) PrepareForUpdate(ctx genericapirequest.Cont
 }
 
 func (clusterDeploymentRESTStrategy) ValidateUpdate(ctx genericapirequest.Context, new, old runtime.Object) field.ErrorList {
-	newClusterDeployment, ok := new.(*clusteroperator.ClusterDeployment)
+	newClusterDeployment, ok := new.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to validate to")
 	}
-	oldCluster, ok := old.(*clusteroperator.ClusterDeployment)
+	oldCluster, ok := old.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to validate from")
 	}
 
-	return validation.ValidateClusterDeploymentUpdate(newClusterDeployment, oldCluster)
+	return covalidation.ValidateClusterDeploymentUpdate(newClusterDeployment, oldCluster)
 }
 
 func (clusterDeploymentStatusRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, old runtime.Object) {
-	newClusterDeployment, ok := new.(*clusteroperator.ClusterDeployment)
+	newClusterDeployment, ok := new.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to update to")
 	}
-	oldClusterDeployment, ok := old.(*clusteroperator.ClusterDeployment)
+	oldClusterDeployment, ok := old.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to update from")
 	}
@@ -163,14 +163,14 @@ func (clusterDeploymentStatusRESTStrategy) PrepareForUpdate(ctx genericapireques
 }
 
 func (clusterDeploymentStatusRESTStrategy) ValidateUpdate(ctx genericapirequest.Context, new, old runtime.Object) field.ErrorList {
-	newClusterDeployment, ok := new.(*clusteroperator.ClusterDeployment)
+	newClusterDeployment, ok := new.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to validate to")
 	}
-	oldClusterDeployment, ok := old.(*clusteroperator.ClusterDeployment)
+	oldClusterDeployment, ok := old.(*coapi.ClusterDeployment)
 	if !ok {
 		glog.Fatal("received a non-clusterdeployment object to validate from")
 	}
 
-	return validation.ValidateClusterDeploymentStatusUpdate(newClusterDeployment, oldClusterDeployment)
+	return covalidation.ValidateClusterDeploymentStatusUpdate(newClusterDeployment, oldClusterDeployment)
 }

--- a/pkg/registry/clusteroperator/clusterdeployment/strategy_test.go
+++ b/pkg/registry/clusteroperator/clusterdeployment/strategy_test.go
@@ -21,19 +21,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func clusterDeploymentWithOldSpec() *clusteroperator.ClusterDeployment {
-	return &clusteroperator.ClusterDeployment{
+func clusterDeploymentWithOldSpec() *coapi.ClusterDeployment {
+	return &coapi.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 1,
 		},
 	}
 }
 
-func clusterDeploymentWithNewSpec() *clusteroperator.ClusterDeployment {
+func clusterDeploymentWithNewSpec() *coapi.ClusterDeployment {
 	b := clusterDeploymentWithOldSpec()
 	return b
 }
@@ -77,13 +77,13 @@ func TestClusterDeploymentCreateWithSshKeyName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
 			// Create a clusterdeployment or clusterdeployments
-			clusterDeployment := &clusteroperator.ClusterDeployment{
+			clusterDeployment := &coapi.ClusterDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tc.clusterDeploymentName,
 				},
-				Spec: clusteroperator.ClusterDeploymentSpec{
-					Hardware: clusteroperator.ClusterHardwareSpec{
-						AWS: &clusteroperator.AWSClusterSpec{
+				Spec: coapi.ClusterDeploymentSpec{
+					Hardware: coapi.ClusterHardwareSpec{
+						AWS: &coapi.AWSClusterSpec{
 							KeyPairName: tc.keyPairName,
 						},
 					},

--- a/pkg/registry/clusteroperator/clusterversion/storage.go
+++ b/pkg/registry/clusteroperator/clusterversion/storage.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clusterversion
 
 import (
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,9 +31,9 @@ import (
 // ClusterVersion resources
 func NewStorage(opts generic.RESTOptions) (clusterVersions *registry.Store, clusterStorageVersion *StatusREST) {
 	store := registry.Store{
-		NewFunc:                  func() runtime.Object { return &clusteroperator.ClusterVersion{} },
-		NewListFunc:              func() runtime.Object { return &clusteroperator.ClusterVersionList{} },
-		DefaultQualifiedResource: clusteroperator.Resource("clusterversions"),
+		NewFunc:                  func() runtime.Object { return &coapi.ClusterVersion{} },
+		NewListFunc:              func() runtime.Object { return &coapi.ClusterVersionList{} },
+		DefaultQualifiedResource: coapi.Resource("clusterversions"),
 
 		CreateStrategy:          clusterVersionRESTStrategies,
 		UpdateStrategy:          clusterVersionRESTStrategies,
@@ -61,7 +61,7 @@ type StatusREST struct {
 
 // New returns a new ClusterVersion.
 func (r *StatusREST) New() runtime.Object {
-	return &clusteroperator.ClusterVersion{}
+	return &coapi.ClusterVersion{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch

--- a/pkg/registry/clusteroperator/clusterversion/storage_test.go
+++ b/pkg/registry/clusteroperator/clusterversion/storage_test.go
@@ -26,7 +26,7 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 
-	clusteroperatorapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	"github.com/openshift/cluster-operator/pkg/registry/registrytest"
 )
 
@@ -42,18 +42,18 @@ func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServ
 	return clusterVersionStorage, server
 }
 
-func validClusterVersion(name string) *clusteroperatorapi.ClusterVersion {
-	return &clusteroperatorapi.ClusterVersion{
+func validClusterVersion(name string) *coapi.ClusterVersion {
+	return &coapi.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: clusteroperatorapi.ClusterVersionSpec{
-			Images: clusteroperatorapi.ClusterVersionImages{
+		Spec: coapi.ClusterVersionSpec{
+			Images: coapi.ClusterVersionImages{
 				ImageFormat: "openshift/origin-${component}:v3.7.9",
 			},
-			VMImages: clusteroperatorapi.VMImages{
-				AWSImages: &clusteroperatorapi.AWSVMImages{
-					RegionAMIs: []clusteroperatorapi.AWSRegionAMIs{
+			VMImages: coapi.VMImages{
+				AWSImages: &coapi.AWSVMImages{
+					RegionAMIs: []coapi.AWSRegionAMIs{
 						{
 							Region: "us-east-1",
 							AMI:    "computeAMI_ID",
@@ -61,7 +61,7 @@ func validClusterVersion(name string) *clusteroperatorapi.ClusterVersion {
 					},
 				},
 			},
-			DeploymentType: clusteroperatorapi.ClusterDeploymentTypeOrigin,
+			DeploymentType: coapi.ClusterDeploymentTypeOrigin,
 			Version:        "v3.9.0",
 		},
 	}
@@ -78,7 +78,7 @@ func TestCreate(t *testing.T) {
 		// valid
 		cv,
 		// invalid
-		&clusteroperatorapi.ClusterVersion{
+		&coapi.ClusterVersion{
 			ObjectMeta: metav1.ObjectMeta{Name: "*BadName!"},
 		},
 	)
@@ -94,12 +94,12 @@ func TestUpdate(t *testing.T) {
 		validClusterVersion("v3.9"),
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*clusteroperatorapi.ClusterVersion)
+			object := obj.(*coapi.ClusterVersion)
 			return object
 		},
 		//invalid update
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*clusteroperatorapi.ClusterVersion)
+			object := obj.(*coapi.ClusterVersion)
 			return object
 		},
 	)

--- a/pkg/registry/clusteroperator/clusterversion/strategy.go
+++ b/pkg/registry/clusteroperator/clusterversion/strategy.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"github.com/golang/glog"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	covalidation "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
 )
 
 // NewScopeStrategy returns a new NamespaceScopedStrategy for clusterversions
@@ -68,7 +68,7 @@ var (
 
 // Canonicalize does not transform a cluster.
 func (clusterVersionRESTStrategy) Canonicalize(obj runtime.Object) {
-	_, ok := obj.(*clusteroperator.ClusterVersion)
+	_, ok := obj.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-cluster version object to create")
 	}
@@ -80,7 +80,7 @@ func (clusterVersionRESTStrategy) NamespaceScoped() bool {
 }
 
 func (clusterVersionRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
-	cv, ok := obj.(*clusteroperator.ClusterVersion)
+	cv, ok := obj.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-cluster version object to create")
 	}
@@ -88,11 +88,11 @@ func (clusterVersionRESTStrategy) PrepareForCreate(ctx genericapirequest.Context
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
-	cv.Status = clusteroperator.ClusterVersionStatus{}
+	cv.Status = coapi.ClusterVersionStatus{}
 }
 
 func (clusterVersionRESTStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateClusterVersion(obj.(*clusteroperator.ClusterVersion))
+	return covalidation.ValidateClusterVersion(obj.(*coapi.ClusterVersion))
 }
 
 func (clusterVersionRESTStrategy) AllowCreateOnUpdate() bool {
@@ -104,11 +104,11 @@ func (clusterVersionRESTStrategy) AllowUnconditionalUpdate() bool {
 }
 
 func (clusterVersionRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, old runtime.Object) {
-	newCV, ok := new.(*clusteroperator.ClusterVersion)
+	newCV, ok := new.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-cluster version object to update to")
 	}
-	oldCV, ok := old.(*clusteroperator.ClusterVersion)
+	oldCV, ok := old.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-cluster version object to update from")
 	}
@@ -116,26 +116,26 @@ func (clusterVersionRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context
 }
 
 func (clusterVersionRESTStrategy) ValidateUpdate(ctx genericapirequest.Context, new, old runtime.Object) field.ErrorList {
-	newCV, ok := new.(*clusteroperator.ClusterVersion)
+	newCV, ok := new.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-cluster version object to validate to")
 	}
-	oldCV, ok := old.(*clusteroperator.ClusterVersion)
+	oldCV, ok := old.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-cluster version object to validate from")
 	}
 
 	// Cluster versions are not actually mutable yet today, this will always return an error
 	// if the spec changed.
-	return validation.ValidateClusterVersionUpdate(newCV, oldCV)
+	return covalidation.ValidateClusterVersionUpdate(newCV, oldCV)
 }
 
 func (clusterVersionStatusRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, old runtime.Object) {
-	newCV, ok := new.(*clusteroperator.ClusterVersion)
+	newCV, ok := new.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-clusterversion object to update to")
 	}
-	oldCV, ok := old.(*clusteroperator.ClusterVersion)
+	oldCV, ok := old.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-clusterversion object to update from")
 	}
@@ -144,14 +144,14 @@ func (clusterVersionStatusRESTStrategy) PrepareForUpdate(ctx genericapirequest.C
 }
 
 func (clusterVersionStatusRESTStrategy) ValidateUpdate(ctx genericapirequest.Context, new, old runtime.Object) field.ErrorList {
-	newCV, ok := new.(*clusteroperator.ClusterVersion)
+	newCV, ok := new.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-clusterversion object to validate to")
 	}
-	oldCV, ok := old.(*clusteroperator.ClusterVersion)
+	oldCV, ok := old.(*coapi.ClusterVersion)
 	if !ok {
 		glog.Fatal("received a non-clusterversion object to validate from")
 	}
 
-	return validation.ValidateClusterVersionStatusUpdate(newCV, oldCV)
+	return covalidation.ValidateClusterVersionStatusUpdate(newCV, oldCV)
 }

--- a/pkg/registry/clusteroperator/clusterversion/strategy_test.go
+++ b/pkg/registry/clusteroperator/clusterversion/strategy_test.go
@@ -19,12 +19,12 @@ package clusterversion
 import (
 	"testing"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func clusterVersion() *clusteroperator.ClusterVersion {
-	return &clusteroperator.ClusterVersion{
+func clusterVersion() *coapi.ClusterVersion {
+	return &coapi.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{},
 	}
 }
@@ -45,7 +45,7 @@ func TestClusterVersionStrategyTrivial(t *testing.T) {
 
 func TestClusterVersionCreate(t *testing.T) {
 	// Create a cluster version
-	cv := &clusteroperator.ClusterVersion{}
+	cv := &coapi.ClusterVersion{}
 
 	// Canonicalize the cluster
 	clusterVersionRESTStrategies.PrepareForCreate(nil, cv)

--- a/pkg/registry/clusteroperator/dnszone/storage.go
+++ b/pkg/registry/clusteroperator/dnszone/storage.go
@@ -17,7 +17,7 @@ limitations under the License.
 package dnszone
 
 import (
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,9 +31,9 @@ import (
 // DNSZone resources
 func NewStorage(opts generic.RESTOptions) (dnsZones *registry.Store, clusterStorageVersion *StatusREST) {
 	store := registry.Store{
-		NewFunc:                  func() runtime.Object { return &clusteroperator.DNSZone{} },
-		NewListFunc:              func() runtime.Object { return &clusteroperator.DNSZoneList{} },
-		DefaultQualifiedResource: clusteroperator.Resource("dnszone"),
+		NewFunc:                  func() runtime.Object { return &coapi.DNSZone{} },
+		NewListFunc:              func() runtime.Object { return &coapi.DNSZoneList{} },
+		DefaultQualifiedResource: coapi.Resource("dnszone"),
 
 		CreateStrategy:          dnsZoneRESTStrategies,
 		UpdateStrategy:          dnsZoneRESTStrategies,
@@ -61,7 +61,7 @@ type StatusREST struct {
 
 // New returns a new DNSZone.
 func (r *StatusREST) New() runtime.Object {
-	return &clusteroperator.DNSZone{}
+	return &coapi.DNSZone{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch

--- a/pkg/registry/clusteroperator/dnszone/storage_test.go
+++ b/pkg/registry/clusteroperator/dnszone/storage_test.go
@@ -26,7 +26,7 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 
-	clusteroperatorapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	"github.com/openshift/cluster-operator/pkg/registry/registrytest"
 )
 
@@ -42,12 +42,12 @@ func newStorage(t *testing.T) (*genericregistry.Store, *etcdtesting.EtcdTestServ
 	return dnsZoneStorage, server
 }
 
-func validDNSZone(name string) *clusteroperatorapi.DNSZone {
-	return &clusteroperatorapi.DNSZone{
+func validDNSZone(name string) *coapi.DNSZone {
+	return &coapi.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: clusteroperatorapi.DNSZoneSpec{
+		Spec: coapi.DNSZoneSpec{
 			Zone: "aws.example.com",
 		},
 	}
@@ -64,7 +64,7 @@ func TestCreate(t *testing.T) {
 		// valid
 		hz,
 		// invalid
-		&clusteroperatorapi.DNSZone{
+		&coapi.DNSZone{
 			ObjectMeta: metav1.ObjectMeta{Name: "*BadName!"},
 		},
 	)
@@ -80,12 +80,12 @@ func TestUpdate(t *testing.T) {
 		validDNSZone("hz1"),
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*clusteroperatorapi.DNSZone)
+			object := obj.(*coapi.DNSZone)
 			return object
 		},
 		//invalid update
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*clusteroperatorapi.DNSZone)
+			object := obj.(*coapi.DNSZone)
 			return object
 		},
 	)

--- a/pkg/registry/clusteroperator/dnszone/strategy.go
+++ b/pkg/registry/clusteroperator/dnszone/strategy.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"github.com/golang/glog"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	covalidation "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
 )
 
 // NewScopeStrategy returns a new NamespaceScopedStrategy for dnszones
@@ -68,7 +68,7 @@ var (
 
 // Canonicalize does not transform a dnszone.
 func (dnsZoneRESTStrategy) Canonicalize(obj runtime.Object) {
-	_, ok := obj.(*clusteroperator.DNSZone)
+	_, ok := obj.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to create")
 	}
@@ -80,7 +80,7 @@ func (dnsZoneRESTStrategy) NamespaceScoped() bool {
 }
 
 func (dnsZoneRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
-	cv, ok := obj.(*clusteroperator.DNSZone)
+	cv, ok := obj.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone version object to create")
 	}
@@ -88,11 +88,11 @@ func (dnsZoneRESTStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 	// Creating a brand new object, thus it must have no
 	// status. We can't fail here if they passed a status in, so
 	// we just wipe it clean.
-	cv.Status = clusteroperator.DNSZoneStatus{}
+	cv.Status = coapi.DNSZoneStatus{}
 }
 
 func (dnsZoneRESTStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateDNSZone(obj.(*clusteroperator.DNSZone))
+	return covalidation.ValidateDNSZone(obj.(*coapi.DNSZone))
 }
 
 func (dnsZoneRESTStrategy) AllowCreateOnUpdate() bool {
@@ -104,11 +104,11 @@ func (dnsZoneRESTStrategy) AllowUnconditionalUpdate() bool {
 }
 
 func (dnsZoneRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, old runtime.Object) {
-	newCV, ok := new.(*clusteroperator.DNSZone)
+	newCV, ok := new.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to update to")
 	}
-	oldCV, ok := old.(*clusteroperator.DNSZone)
+	oldCV, ok := old.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to update from")
 	}
@@ -116,26 +116,26 @@ func (dnsZoneRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, 
 }
 
 func (dnsZoneRESTStrategy) ValidateUpdate(ctx genericapirequest.Context, new, old runtime.Object) field.ErrorList {
-	newCV, ok := new.(*clusteroperator.DNSZone)
+	newCV, ok := new.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to validate to")
 	}
-	oldCV, ok := old.(*clusteroperator.DNSZone)
+	oldCV, ok := old.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to validate from")
 	}
 
 	// DNSZones are not actually mutable today, this will always return an error
 	// if the spec changed.
-	return validation.ValidateDNSZoneUpdate(newCV, oldCV)
+	return covalidation.ValidateDNSZoneUpdate(newCV, oldCV)
 }
 
 func (dnsZoneStatusRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context, new, old runtime.Object) {
-	newCV, ok := new.(*clusteroperator.DNSZone)
+	newCV, ok := new.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to update to")
 	}
-	oldCV, ok := old.(*clusteroperator.DNSZone)
+	oldCV, ok := old.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to update from")
 	}
@@ -144,14 +144,14 @@ func (dnsZoneStatusRESTStrategy) PrepareForUpdate(ctx genericapirequest.Context,
 }
 
 func (dnsZoneStatusRESTStrategy) ValidateUpdate(ctx genericapirequest.Context, new, old runtime.Object) field.ErrorList {
-	newCV, ok := new.(*clusteroperator.DNSZone)
+	newCV, ok := new.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to validate to")
 	}
-	oldCV, ok := old.(*clusteroperator.DNSZone)
+	oldCV, ok := old.(*coapi.DNSZone)
 	if !ok {
 		glog.Fatal("received a non-dnszone object to validate from")
 	}
 
-	return validation.ValidateDNSZoneStatusUpdate(newCV, oldCV)
+	return covalidation.ValidateDNSZoneStatusUpdate(newCV, oldCV)
 }

--- a/pkg/registry/clusteroperator/dnszone/strategy_test.go
+++ b/pkg/registry/clusteroperator/dnszone/strategy_test.go
@@ -19,12 +19,12 @@ package dnszone
 import (
 	"testing"
 
-	clusteroperator "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func dnsZone() *clusteroperator.DNSZone {
-	return &clusteroperator.DNSZone{
+func dnsZone() *coapi.DNSZone {
+	return &coapi.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{},
 	}
 }
@@ -45,7 +45,7 @@ func TestDNSZoneStrategyTrivial(t *testing.T) {
 
 func TestDNSZoneCreate(t *testing.T) {
 	// Create a cluster version
-	hz := &clusteroperator.DNSZone{}
+	hz := &coapi.DNSZone{}
 
 	// Canonicalize the cluster
 	dnsZoneRESTStrategies.PrepareForCreate(nil, hz)

--- a/pkg/registry/clusteroperator/rest/storage_cluster_operator.go
+++ b/pkg/registry/clusteroperator/rest/storage_cluster_operator.go
@@ -18,8 +18,8 @@ package rest
 
 import (
 	"github.com/openshift/cluster-operator/pkg/api"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
-	clusteroperatorv1alpha1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	"github.com/openshift/cluster-operator/pkg/registry/clusteroperator/clusterdeployment"
 	"github.com/openshift/cluster-operator/pkg/registry/clusteroperator/clusterversion"
 	"github.com/openshift/cluster-operator/pkg/registry/clusteroperator/dnszone"
@@ -49,11 +49,11 @@ func (p StorageProvider) NewRESTStorage(
 		return nil, err
 	}
 
-	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(clusteroperator.GroupName, api.Registry, api.Scheme, api.ParameterCodec, api.Codecs)
-	apiGroupInfo.GroupMeta.GroupVersion = clusteroperatorv1alpha1.SchemeGroupVersion
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(coapi.GroupName, api.Registry, api.Scheme, api.ParameterCodec, api.Codecs)
+	apiGroupInfo.GroupMeta.GroupVersion = cov1.SchemeGroupVersion
 
 	apiGroupInfo.VersionedResourcesStorageMap = map[string]map[string]rest.Storage{
-		clusteroperatorv1alpha1.SchemeGroupVersion.Version: storage,
+		cov1.SchemeGroupVersion.Version: storage,
 	}
 
 	return &apiGroupInfo, nil
@@ -63,19 +63,19 @@ func (p StorageProvider) v1alpha1Storage(
 	apiResourceConfigSource serverstorage.APIResourceConfigSource,
 	restOptionsGetter generic.RESTOptionsGetter,
 ) (map[string]rest.Storage, error) {
-	clusterDeploymentRESTOptions, err := restOptionsGetter.GetRESTOptions(clusteroperator.Resource("clusterdeployments"))
+	clusterDeploymentRESTOptions, err := restOptionsGetter.GetRESTOptions(coapi.Resource("clusterdeployments"))
 	if err != nil {
 		return nil, err
 	}
 	clusterDeploymentStorage, clusterDeploymentStatusStorage := clusterdeployment.NewStorage(clusterDeploymentRESTOptions)
 
-	clusterVerRESTOptions, err := restOptionsGetter.GetRESTOptions(clusteroperator.Resource("clusterversions"))
+	clusterVerRESTOptions, err := restOptionsGetter.GetRESTOptions(coapi.Resource("clusterversions"))
 	if err != nil {
 		return nil, err
 	}
 	clusterVersionStorage, clusterVersionStatusStorage := clusterversion.NewStorage(clusterVerRESTOptions)
 
-	dnsZoneRESTOptions, err := restOptionsGetter.GetRESTOptions(clusteroperator.Resource("dnszones"))
+	dnsZoneRESTOptions, err := restOptionsGetter.GetRESTOptions(coapi.Resource("dnszones"))
 	if err != nil {
 		return nil, err
 	}
@@ -93,5 +93,5 @@ func (p StorageProvider) v1alpha1Storage(
 
 // GroupName returns the API group name.
 func (p StorageProvider) GroupName() string {
-	return clusteroperator.GroupName
+	return coapi.GroupName
 }

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 
 	"github.com/openshift/cluster-operator/pkg/api"
-	"github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
+	coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
 )
 
 // NewEtcdStorage creates a new etcd storage for the clusteroperator schema.
@@ -43,6 +43,6 @@ func NewEtcdStorage(t *testing.T) (*storagebackend.Config, *etcdtesting.EtcdTest
 	}
 	s := storageSerializer.Serializer
 	ds := recognizer.NewDecoder(s, api.Codecs.UniversalDeserializer())
-	config.Codec = api.Codecs.CodecForVersions(s, ds, schema.GroupVersions{clusteroperator.SchemeGroupVersion}, nil)
+	config.Codec = api.Codecs.CodecForVersions(s, ds, schema.GroupVersions{coapi.SchemeGroupVersion}, nil)
 	return config, server
 }

--- a/test/integration/waitutils.go
+++ b/test/integration/waitutils.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/openshift/cluster-operator/pkg/controller"
-	capiv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	cocontroller "github.com/openshift/cluster-operator/pkg/controller"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	capiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
@@ -76,25 +76,25 @@ func waitForObjectToNotExistOrNotHaveFinalizer(namespace, name string, finalizer
 	)
 }
 
-func waitForClusterStatus(capiClient capiclientset.Interface, namespace, name string, checkStatus func(*capiv1alpha1.Cluster) bool) error {
+func waitForClusterStatus(capiClient capiclientset.Interface, namespace, name string, checkStatus func(*capiv1.Cluster) bool) error {
 	return waitForObjectStatus(
 		namespace,
 		name,
 		func(namespace, name string) (metav1.Object, error) {
 			return getCluster(capiClient, namespace, name)
 		},
-		func(obj metav1.Object) bool { return checkStatus(obj.(*capiv1alpha1.Cluster)) },
+		func(obj metav1.Object) bool { return checkStatus(obj.(*capiv1.Cluster)) },
 	)
 }
 
-func waitForMachineSetStatus(capiClient capiclientset.Interface, namespace, name string, checkStatus func(*capiv1alpha1.MachineSet) bool) error {
+func waitForMachineSetStatus(capiClient capiclientset.Interface, namespace, name string, checkStatus func(*capiv1.MachineSet) bool) error {
 	return waitForObjectStatus(
 		namespace,
 		name,
 		func(namespace, name string) (metav1.Object, error) {
 			return getMachineSet(capiClient, namespace, name)
 		},
-		func(obj metav1.Object) bool { return checkStatus(obj.(*capiv1alpha1.MachineSet)) },
+		func(obj metav1.Object) bool { return checkStatus(obj.(*capiv1.MachineSet)) },
 	)
 }
 
@@ -104,7 +104,7 @@ func waitForClusterToExist(capiClient capiclientset.Interface, namespace, name s
 	return waitForClusterStatus(
 		capiClient,
 		namespace, name,
-		func(cluster *capiv1alpha1.Cluster) bool { return cluster != nil },
+		func(cluster *capiv1.Cluster) bool { return cluster != nil },
 	)
 }
 
@@ -125,7 +125,7 @@ func waitForMachineSetToExist(capiClient capiclientset.Interface, namespace, nam
 	return waitForMachineSetStatus(
 		capiClient,
 		namespace, name,
-		func(machineSet *capiv1alpha1.MachineSet) bool { return machineSet != nil },
+		func(machineSet *capiv1.MachineSet) bool { return machineSet != nil },
 	)
 }
 
@@ -145,8 +145,8 @@ func waitForClusterProvisioned(capiClient capiclientset.Interface, namespace, na
 	return waitForClusterStatus(
 		capiClient,
 		namespace, name,
-		func(cluster *capiv1alpha1.Cluster) bool {
-			status, err := controller.ClusterProviderStatusFromCluster(cluster)
+		func(cluster *capiv1.Cluster) bool {
+			status, err := cocontroller.ClusterProviderStatusFromCluster(cluster)
 			if err != nil {
 				return false
 			}
@@ -160,8 +160,8 @@ func waitForClusterReady(capiClient capiclientset.Interface, namespace, name str
 	return waitForClusterStatus(
 		capiClient,
 		namespace, name,
-		func(cluster *capiv1alpha1.Cluster) bool {
-			status, err := controller.ClusterProviderStatusFromCluster(cluster)
+		func(cluster *capiv1.Cluster) bool {
+			status, err := cocontroller.ClusterProviderStatusFromCluster(cluster)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
- [x] Standardize: coclientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
- [x] Standardize: coinformers "github.com/openshift/cluster-operator/pkg/client/informers_generated/externalversions/clusteroperator/v1alpha1"
- [x] Standardize: colisters "github.com/openshift/cluster-operator/pkg/client/listers_generated/clusteroperator/v1alpha1"
- [x] Standardize: cometrics "github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/metrics"
- [x] Standardize: cov1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
- [x] Standardize: coaws "github.com/openshift/cluster-operator/pkg/clusterapi/aws"
- [x] Standardize: covalidation "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/validation"
- [x] Standardize: cologging "github.com/openshift/cluster-operator/pkg/logging"
- [x] Standardize: cocontroller "github.com/openshift/cluster-operator/pkg/controller"
- [x] Standardize: coapi "github.com/openshift/cluster-operator/pkg/apis/clusteroperator"
- [x] Standardize: coansible "github.com/openshift/cluster-operator/pkg/ansible"
- [x] Standardize: cotemplateutil "github.com/openshift/cluster-operator/pkg/kubernetes/pkg/util/template"
- [x] Standardize: capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
- [x] Standardize: capicluster "sigs.k8s.io/cluster-api/pkg/apis/cluster"
- [x] Verify tests were changed and still pass
- [x] Verify vendored code wasn't changed
- [x] Verify generated code wasn't changed